### PR TITLE
python API: when child process fails to send data, kill process

### DIFF
--- a/python_lib/qss_compiler/compile.py
+++ b/python_lib/qss_compiler/compile.py
@@ -248,6 +248,9 @@ def _do_compile(execution: _CompilerExecution) -> Union[bytes, str, None]:
             else:
                 output = None
         except EOFError:
+            # make sure that child process terminates
+            childproc.kill()
+            childproc.join()
             raise QSSCompilerError("compile process exited before delivering output.")
 
         childproc.join()


### PR DESCRIPTION
When the child process fails to send a status and/or data back via the pipe, kill() and join() the child process to avoid half-terminated (still consuming resources) or zombie processes lingering around.