### PR TITLE
Use SymbolUserMap instead of call of getSymbolUses()

### DIFF
--- a/lib/Dialect/QUIR/Transforms/LoadElimination.cpp
+++ b/lib/Dialect/QUIR/Transforms/LoadElimination.cpp
@@ -19,8 +19,6 @@
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/SymbolTable.h"
 
-#include <iostream>
-
 namespace mlir::quir {
 
 void LoadEliminationPass::runOnOperation() {

--- a/lib/Dialect/QUIR/Transforms/UnusedVariable.cpp
+++ b/lib/Dialect/QUIR/Transforms/UnusedVariable.cpp
@@ -45,7 +45,7 @@ struct UnusedVariablePat : public OpRewritePattern<DeclareVariableOp> {
     // iterate through uses
     for (auto *useOp : symbolUses.getUsers(declOp)) {
       if (auto useVariable = dyn_cast<UseVariableOp>(useOp)) {
-        if (!useVariable.use_empty())
+        if (!useVariable || !useVariable.use_empty())
           return failure();
       }
     }


### PR DESCRIPTION
Compilation of QASM3 with logs of `input` variables takes long time. This is because `LoadEliminationPass` and `UnusedVariablePass` frequently call `getSymbolUsesImpl`, which searches all the IRs in a specified scope to find use of a symbol. This PR uses `SymbolUserMap` instead of call of `getSymbolUsesImpl()` to reduce its overheads. 