### PR TITLE
WIP: Support for virtual qubits in QUIR

### DIFF
--- a/include/Dialect/QUIR/IR/QUIROps.td
+++ b/include/Dialect/QUIR/IR/QUIROps.td
@@ -374,6 +374,25 @@ def QUIR_DeclareQubitOp : QUIR_Op<"declare_qubit", [NonInterferingNonDeadSideEff
     }];
 }
 
+def QUIR_DeclareVirtualQubitOp : QUIR_Op<"declare_virtual_qubit", [NonInterferingNonDeadSideEffect]> {
+    let summary = "Declare a new virtual qubit.";
+    let description = [{
+        The `quir.declare_virtual_qubit` operation creates a new virtual qubit.
+        Example:
+
+        ```mlir
+        %1 = quir.declare_virtual_qubit "qVar"
+        ```
+    }];
+
+    let arguments = (ins SymbolNameAttr:$sym_name);
+    let results = (outs AnyType:$res);
+
+    let assemblyFormat = [{
+        attr-dict $sym_name `:` type($res)
+    }];
+}
+
 def QUIR_DeclareDurationOp : QUIR_Op<"declare_duration", [NoSideEffect]> {
     let summary = "Declare a new duration.";
     let description = [{

--- a/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
@@ -913,14 +913,27 @@ Type QUIRGenQASM3Visitor::getQUIRTypeFromDeclaration(
 ExpressionValueType
 QUIRGenQASM3Visitor::visit_(const ASTQubitContainerNode *node) {
   const std::string &qId = node->GetName();
-  int id = stoi(node->GetIdentifier()->GetQubitMnemonic());
-
   const unsigned size = node->Size();
-  Value qubitRef = builder
-                       .create<DeclareQubitOp>(
-                           getLocation(node), builder.getType<QubitType>(size),
-                           builder.getIntegerAttr(builder.getI32Type(), id))
-                       .res();
+
+  const ASTIdentifierNode *idnode = node->GetIdentifier();
+  Value qubitRef;
+
+  if (idnode->IsBoundQubit()) {
+    int id = stoi(idnode->GetQubitMnemonic());
+
+    qubitRef = builder
+                   .create<DeclareQubitOp>(
+                       getLocation(node), builder.getType<QubitType>(size),
+                       builder.getIntegerAttr(builder.getI32Type(), id))
+                   .res();
+  } else {
+    auto id_name = idnode->GetName();
+    qubitRef = builder
+                   .create<DeclareVirtualQubitOp>(
+                       getLocation(node), builder.getType<QubitType>(size),
+                       builder.getStringAttr(id_name))
+                   .res();
+  }
   ssaValues[qId] = qubitRef;
   return qubitRef;
 }


### PR DESCRIPTION
Support virtual qubits in QUIR.  For example
```
qubit[8] q;
```
results in something like
```mlir
%0 = quir.declare_virtual_qubit @q : !quir.qubit<8>
```

#### Tasks

- [x] Allow virtual qubits to be represented in QUIR
- [ ] Decide whether virtual and physical qubits should be different types
- [ ] Unit tests
- [ ] Reno note
- [ ] Documentation