### PR TITLE
Enable --mlir-timing and --mlir-timing-display command line options

### DIFF
--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -48,7 +48,6 @@
 
 #include <filesystem>
 
-
 using namespace mlir;
 
 // The space below at the front of the string causes this category to be printed


### PR DESCRIPTION
Enables the `--mlir-timing` options from the command line for printing pass related timing. 