### PR TITLE
Fix conversion QUIR/STD -> LLVM

### DIFF
--- a/include/Conversion/QUIRToLLVM/QUIRToLLVM.h
+++ b/include/Conversion/QUIRToLLVM/QUIRToLLVM.h
@@ -1,0 +1,87 @@
+//===- QUIRToLLVM.h - Convert QUIR to LLVM Dialect --------------*- C++ -*-===//
+//
+// (C) Copyright IBM 2023.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file declares the pass for converting QUIR to LLVM dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CONVERSION_QUIRTOLLVM_QUIRTOLLVM_H_
+#define CONVERSION_QUIRTOLLVM_QUIRTOLLVM_H_
+
+#include "Conversion/QUIRToStandard/SwitchOpLowering.h"
+#include "Dialect/QUIR/IR/QUIRDialect.h"
+
+#include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
+#include "mlir/Conversion/ArithmeticToLLVM/ArithmeticToLLVM.h"
+#include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
+#include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
+#include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "llvm/Support/Error.h"
+
+namespace mlir::quir {
+static auto translateModuleToLLVMDialect(mlir::ModuleOp op,
+                                         llvm::DataLayout &dataLayout)
+    -> llvm::Error {
+
+  // The MLIR documentation on lowering to LLVM IR recommends to use the
+  // conversion patterns for all used dialects collected together, instead of
+  // using the existing passes that treat only individual dialects.
+  // https://mlir.llvm.org/docs/TargetLLVMIR/
+  //
+  // The Toy tutorial is the best documentation resource for the overall flow
+  // https://mlir.llvm.org/docs/Tutorials/Toy/Ch-6/
+  auto *context = op.getContext();
+  assert(context);
+
+  // Register LLVM dialect and all infrastructure required for translation to
+  // LLVM IR
+  mlir::registerLLVMDialectTranslation(*context);
+
+  mlir::LLVMConversionTarget target(*context);
+  target.addLegalDialect<mlir::LLVM::LLVMDialect>();
+  target.addIllegalDialect<mlir::quir::QUIRDialect>();
+  target.addLegalOp<mlir::ModuleOp>();
+
+  mlir::LowerToLLVMOptions options(context);
+
+  options.overrideIndexBitwidth(64);
+  options.dataLayout = dataLayout;
+
+  mlir::LLVMTypeConverter typeConverter(context, options);
+
+  mlir::RewritePatternSet patterns(context);
+  mlir::populateLoopToStdConversionPatterns(patterns);
+  mlir::quir::populateSwitchOpLoweringPatterns(patterns);
+  mlir::arith::populateArithmeticToLLVMConversionPatterns(typeConverter,
+                                                          patterns);
+  mlir::populateAffineToStdConversionPatterns(patterns);
+  mlir::populateMemRefToLLVMConversionPatterns(typeConverter, patterns);
+  mlir::populateStdToLLVMFuncOpConversionPattern(typeConverter, patterns);
+  mlir::populateStdToLLVMConversionPatterns(typeConverter, patterns);
+
+  if (mlir::applyFullConversion(op, target, std::move(patterns)).failed())
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "Failed to convert module to LLVM Dialect.");
+
+  op->setAttr(
+      mlir::LLVM::LLVMDialect::getDataLayoutAttrName(),
+      mlir::StringAttr::get(context, dataLayout.getStringRepresentation()));
+
+  return llvm::Error::success();
+}
+} // namespace mlir::quir
+
+#endif // CONVERSION_QUIRTOLLVM_QUIRTOLLVM_H_

--- a/mock_target/CMakeLists.txt
+++ b/mock_target/CMakeLists.txt
@@ -1,4 +1,4 @@
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
@@ -25,6 +25,7 @@ MLIROptLib
 MLIRLLVMIR
 MLIRLLVMToLLVMIRTranslation
 MLIRStandardOpsTransforms
+LLVMAArch64CodeGen
 LLVMPowerPCCodeGen
 LLVMX86CodeGen
 

--- a/mock_target/Conversion/QUIRToStandard/QUIRToStandard.cpp
+++ b/mock_target/Conversion/QUIRToStandard/QUIRToStandard.cpp
@@ -16,13 +16,19 @@
 
 #include "MockUtils.h"
 
+#include "Conversion/QUIRToStandard/CBitOperations.h"
+#include "Conversion/QUIRToStandard/QUIRCast.h"
 #include "Conversion/QUIRToStandard/TypeConversion.h"
+#include "Conversion/QUIRToStandard/VariablesToGlobalMemRefConversion.h"
+#include "Dialect/Pulse/IR/PulseDialect.h"
 #include "Dialect/QCS/IR/QCSOps.h"
 #include "Dialect/QUIR/IR/QUIRDialect.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Dialect/StandardOps/Transforms/FuncConversions.h"
@@ -41,8 +47,7 @@ struct ReturnConversionPat : public OpConversionPattern<mlir::ReturnOp> {
   LogicalResult
   matchAndRewrite(mlir::ReturnOp retOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto operands = adaptor.getOperands();
-    rewriter.create<mlir::ReturnOp>(retOp->getLoc(), operands);
+    rewriter.create<mlir::ReturnOp>(retOp->getLoc(), adaptor.getOperands());
     rewriter.replaceOp(retOp, {});
     return success();
   } // matchAndRewrite
@@ -60,8 +65,7 @@ struct ConstantOpConversionPat : public OpConversionPattern<quir::ConstantOp> {
   matchAndRewrite(quir::ConstantOp constOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (auto angleAttr = constOp.value().dyn_cast<quir::AngleAttr>()) {
-      auto angleWidth =
-          constOp.getType().dyn_cast<quir::AngleType>().getWidth();
+      auto angleWidth = constOp.getType().cast<quir::AngleType>().getWidth();
 
       // cannot handle non-parameterized angle types
       if (!angleWidth.hasValue())
@@ -159,19 +163,34 @@ struct CommOpConversionPat : public OpConversionPattern<CommOp> {
   } // matchAndRewrite
 };  // struct CommOpConversionPat
 
-void MockQUIRToStdPass::runOnOperation() {
+void conversion::MockQUIRToStdPass::getDependentDialects(
+    DialectRegistry &registry) const {
+  registry.insert<LLVM::LLVMDialect, mlir::memref::MemRefDialect,
+                  mlir::AffineDialect, arith::ArithmeticDialect>();
+}
+
+void MockQUIRToStdPass::runOnOperation(MockSystem &system) {
   ModuleOp moduleOp = getOperation();
-  // attempt to apply the conversion only to the controller module
+
+  // Attempt to apply the conversion only to the controller module
   ModuleOp controllerModuleOp = getControllerModule(moduleOp);
   if (!controllerModuleOp)
     controllerModuleOp = moduleOp;
 
-  QuirTypeConverter typeConverter;
-  ConversionTarget target(getContext());
+  // First remove all arguments from synchronization ops
+  controllerModuleOp->walk([](qcs::SynchronizeOp synchOp) {
+    synchOp.qubitsMutable().assign(ValueRange({}));
+  });
 
-  target.addLegalDialect<StandardOpsDialect, scf::SCFDialect,
-                         arith::ArithmeticDialect, LLVM::LLVMDialect,
-                         quir::QUIRDialect>();
+  QuirTypeConverter typeConverter;
+  auto *context = &getContext();
+  ConversionTarget target(*context);
+
+  target.addLegalDialect<arith::ArithmeticDialect, LLVM::LLVMDialect,
+                         mlir::AffineDialect, memref::MemRefDialect,
+                         scf::SCFDialect, StandardOpsDialect,
+                         mlir::pulse::PulseDialect, mlir::qcs::QCSDialect>();
+  target.addIllegalDialect<quir::QUIRDialect>();
   target.addIllegalOp<qcs::RecvOp, qcs::BroadcastOp>();
   target.addDynamicallyLegalOp<FuncOp>(
       [&](FuncOp op) { return typeConverter.isSignatureLegal(op.getType()); });
@@ -181,8 +200,9 @@ void MockQUIRToStdPass::runOnOperation() {
   target.addDynamicallyLegalOp<mlir::ReturnOp>([&](mlir::ReturnOp op) {
     return typeConverter.isLegal(op.getOperandTypes());
   });
+  target.addLegalOp<quir::SwitchOp>();
+  target.addLegalOp<quir::YieldOp>();
 
-  auto *context = &getContext();
   RewritePatternSet patterns(context);
   populateFunctionOpInterfaceTypeConversionPattern<FuncOp>(patterns,
                                                            typeConverter);
@@ -207,22 +227,27 @@ void MockQUIRToStdPass::runOnOperation() {
       .insert<AngleBinOpConversionPat<quir::Angle_DivOp, mlir::arith::DivSIOp>>(
           context, typeConverter);
 
+  quir::populateQUIRCastPatterns(patterns, typeConverter);
+  quir::populateCBitOperationsPatterns(patterns, typeConverter);
+  quir::populateVariableToGlobalMemRefConversionPatterns(
+      patterns, typeConverter, externalizeOutputVariables);
+
   // With the target and rewrite patterns defined, we can now attempt the
   // conversion. The conversion will signal failure if any of our `illegal`
   // operations were not converted successfully.
   if (failed(applyPartialConversion(controllerModuleOp, target,
                                     std::move(patterns)))) {
+    // If we fail conversion remove remaining ops for the Mock target.
+    controllerModuleOp.walk([&](Operation *op) {
+      if (llvm::isa<quir::QUIRDialect>(op->getDialect()) ||
+          llvm::isa<qcs::QCSDialect>(op->getDialect())) {
+        llvm::outs() << "Removing unsupported " << op->getName() << " \n";
+        op->dropAllReferences();
+        op->dropAllDefinedValueUses();
+        op->erase();
+      }
+    });
   }
-  // If we fail conversion remove remaining ops for the Mock target.
-  controllerModuleOp.walk([&](Operation *op) {
-    if (llvm::isa<quir::QUIRDialect>(op->getDialect())) {
-      llvm::outs() << "Removing unsupported " << op->getName() << " \n";
-      op->dropAllReferences();
-      op->dropAllDefinedValueUses();
-      op->erase();
-    }
-  });
-
 } // QUIRToStdPass::runOnOperation()
 
 llvm::StringRef MockQUIRToStdPass::getArgument() const {

--- a/mock_target/Conversion/QUIRToStandard/QUIRToStandard.h
+++ b/mock_target/Conversion/QUIRToStandard/QUIRToStandard.h
@@ -1,6 +1,6 @@
 //===- QUIRToStd.h - Convert QUIR to Std Dialect ----------------*- C++ -*-===//
 //
-// (C) Copyright IBM 2021, 2022.
+// (C) Copyright IBM 2021, 2023.
 //
 // Any modifications or derivative works of this code must retain this
 // copyright notice, and modified files need to carry a notice indicating
@@ -15,14 +15,25 @@
 #ifndef MOCK_CONVERSION_QUIRTOSTD_H
 #define MOCK_CONVERSION_QUIRTOSTD_H
 
+#include "MockTarget.h"
+
+#include "HAL/TargetOperationPass.h"
+
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace qssc::targets::mock::conversion {
 struct MockQUIRToStdPass
-    : public mlir::PassWrapper<MockQUIRToStdPass,
-                               mlir::OperationPass<mlir::ModuleOp>> {
-  void runOnOperation() override;
+    : public mlir::PassWrapper<
+          MockQUIRToStdPass,
+          hal::TargetOperationPass<MockSystem, mlir::ModuleOp>> {
+  void runOnOperation(MockSystem &system) override;
+  void getDependentDialects(mlir::DialectRegistry &registry) const override;
+
+  bool externalizeOutputVariables;
+
+  MockQUIRToStdPass(bool externalizeOutputVariables)
+      : PassWrapper(), externalizeOutputVariables(externalizeOutputVariables) {}
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;

--- a/mock_target/Transforms/QubitLocalization.cpp
+++ b/mock_target/Transforms/QubitLocalization.cpp
@@ -778,6 +778,7 @@ void mock::MockQubitLocalizationPass::runOnOperation(MockSystem &target) {
       newBuilders->emplace(config->driveNode(qubitId),
                            new OpBuilder(mockMainOp.getBody()));
     }
+
     if (!mockModules.count(config->acquireNode(qubitId))) {
       llvm::outs() << "Creating module for acquire Mocks " << qubitId << "\n";
       auto acquireMod = b.create<ModuleOp>(

--- a/mock_target/test/static/integration/openqasm3/bell-v0.qasm
+++ b/mock_target/test/static/integration/openqasm3/bell-v0.qasm
@@ -2,6 +2,12 @@ OPENQASM 3.0;
 // RUN: qss-compiler %s --target mock --config %TEST_CFG --emit=qem --plaintext-payload | FileCheck %s
 
 // CHECK: Manifest
+// CHECK: MockAcquire_0.mlir
+// CHECK: MockController.mlir
+// CHECK: MockDrive_0.mlir
+// CHECK: MockDrive_1.mlir
+// CHECK: controller.bin
+// CHECK: llvmModule.ll
 qubit $0;
 qubit $1;
 


### PR DESCRIPTION
To translate operations from a dialect to LLVMIR, the dialect must have a registered implementation of
`LLVMTranslationDialectInterface`. Due to changes during the migration to LLVM-14, the `mock_target` implementation of `QUIRToStandard` was not updated to accommodate the new interface. When testing the generation of a QuantumExecutionModule (QEM) from a QASM 3.0 input, the following error was observed:

```
error: cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface` registration for dialect
for op: builtin.unrealized_conversion_cast
```

ultimately, producing no controller binary for the target. Due to the lack of test coverage for `mock_target`, the functionality for emitting a QEM output from QASM 3 input was broken for some time.

This PR fixes the above issue, adding the necessary pieces for QUIR to have a registered implementation of
`LLVMTranslationDialectInterface`, as well as additional testing to check for correct output when emitting a QEM from QASM.

All tests passing:
```
[$] ninja check-tests && ninja check-mock
[0/3] Running the Mock Static regression tests

Testing Time: 0.91s
  Passed: 7
[1/3] cd /Users/vrpascuzzi/devel/ibm-q-restricted-system/qic-rta-driver/compiler/qss-compiler/build/test/unittest && /opt/homebrew/Cellar/cmake/3.25.1/bin/ctest
Test project /Users/vrpascuzzi/devel/ibm-q-restricted-system/qic-rta-driver/compiler/qss-compiler/build/test/unittest
    Start 1: QUIRDialect.CPTPOpTrait
1/4 Test #1: QUIRDialect.CPTPOpTrait ...........   Passed    0.13 sec
    Start 2: QUIRDialect.UnitaryOpTrait
2/4 Test #2: QUIRDialect.UnitaryOpTrait ........   Passed    0.15 sec
    Start 3: QUIRDialect.MeasureSideEffects
3/4 Test #3: QUIRDialect.MeasureSideEffects ....   Passed    0.13 sec
    Start 4: TargetRegistry.LookupMockTarget
4/4 Test #4: TargetRegistry.LookupMockTarget ...   Passed    0.51 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =   0.92 sec
[2/3] Running the QSS Compiler Core regression tests

Testing Time: 15.58s
  Passed           : 119
  Expectedly Failed:   3
[0/1] Running the Mock Static regression tests

Testing Time: 0.85s
  Passed: 7
```

Closes https://github.com/Qiskit/qss-compiler/issues/41.