### PR TITLE
python_lib: also export QSSCompilerError

### DIFF
--- a/python_lib/qss_compiler/__init__.py
+++ b/python_lib/qss_compiler/__init__.py
@@ -15,6 +15,7 @@ from .compile import (  # noqa: F401
     OutputType,
     CompileOptions,
     QSSCompilationFailure,
+    QSSCompilerError,
 )
 
 from .py_qssc import (  # noqa: F401


### PR DESCRIPTION
... to enable users of the qss-compiler's python interface to catch and handle these.