### PR TITLE
Switch python context to forkserver

### DIFF
--- a/python_lib/qss_compiler/compile.py
+++ b/python_lib/qss_compiler/compile.py
@@ -292,7 +292,9 @@ def _do_compile(execution: _CompilerExecution) -> Union[bytes, str, None]:
             # make sure that child process terminates
             childproc.kill()
             childproc.join()
-            raise QSSCompilerError("compile process exited before delivering output.", diagnostics)
+            raise QSSCompilerError(
+                "compile process exited before delivering output.", diagnostics
+            )
 
         childproc.join()
         if childproc.exitcode != 0:


### PR DESCRIPTION
This PR switches the python multiprocess context from spawn to forkserver to minimize interactions with other python processes. 

The PR also applies `black` to the changed file. 