### PR TITLE
Support CMakeDeps generator for LLVM recipe.

### DIFF
--- a/conan/llvm/conanfile.py
+++ b/conan/llvm/conanfile.py
@@ -245,6 +245,12 @@ class LLVMConan(ConanFile):
         self.copy("llvm-lit", dst="bin", src="bin")
 
     def package_info(self):
+        # Don't generate any find modules. LLVM provides its own
+        # in lib/cmake, which will get picked up via builddirs.
+        self.cpp_info.set_property("cmake_find_mode", "none")
+        self.cpp_info.builddirs = ["lib/cmake"]
+
+        # TODO: remove once we've switched to Conan 2.0
         self.cpp_info.names["cmake_find_package"] = "LLVM"
         self.cpp_info.names["cmake_find_package_multi"] = "LLVM"
 

--- a/conan/qasm/conandata.yml
+++ b/conan/qasm/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   hash: "1a48cbd41705713b90820c9a989a368e96820f05"
 requirements:
-  - "bison/3.7.6"
+  - "bison/3.8.2"
   - "flex/2.6.4"
   - "gmp/6.2.1"
   - "mpfr/4.1.0"


### PR DESCRIPTION
Previously, the LLVM recipe would generate a `CMakeDeps` config module. However, LLVM contains its own config module which we use instead. Without this change, the generated module is always found and used first when using `CMakeDeps`.

This PR is required before #60.