### PR TITLE
[CI] Review PRs using clang-tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: Continuous Integration
-on:
-  push:
-  pull_request:
+on: [push, pull_request]
 jobs:
   Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 * Adds CI for `pull_requests`. This will be needed when we start to use forks... and now it is useful as it's testing incoming changes merged with base branch.
 * On `pull_requests` it uses GH action [clang-tidy-review](https://github.com/ZedThree/clang-tidy-review) to run clang-tidy  **only on the files modified by the PR** and it submits a review with suggestions for tidy errors (see below one review without errors, and one with errors). These are just suggestions, the CI job doesn't fail.
 
   CI overhead is minimum (10s) as it uses already generated `compiler_commands.json` database file. 