### PR TITLE
Add LLVM AArch64 libraries to llvm_code_gen_libraries if present.

### DIFF
--- a/mock_target/CMakeLists.txt
+++ b/mock_target/CMakeLists.txt
@@ -26,7 +26,7 @@ if ("LLVMAArch64CodeGen" IN_LIST LLVM_AVAILABLE_LIBS)
         LLVMAArch64AsmParser
         LLVMAArch64Desc
     )
-    message(STATUS, "Adding AArch64 libraries to llvm_code_gen_libraries")
+    message(STATUS "Adding AArch64 libraries to llvm_code_gen_libraries")
 endif ()
 
 qssc_add_plugin(QSSCTargetMock QSSC_TARGET_PLUGIN


### PR DESCRIPTION
This fix adds the LLVMAArch64 libraries if they are present in the LLVM_AVAILABLE_LIBS list. This is a way to check whether the AArch64 target was included as part of the LLVM build. If it was, the corresponding AArch64 libs may be needed by the qss-compiler as well.