### PR TITLE
Fix for clang-tidy in internal CI not caught by open CI

### DIFF
--- a/include/HAL/TargetOperationPass.h
+++ b/include/HAL/TargetOperationPass.h
@@ -65,7 +65,7 @@ protected:
         &mlir::OperationPass<OpT>::getContext());
     if (!target) {
       // look for a child target that matches
-      for (auto childName : TargetT::childNames)
+      for (const auto &childName : TargetT::childNames)
         if ((targetInfo =
                  registry::TargetSystemRegistry::lookupPluginInfo(childName)) &&
             (target = targetInfo.getValue()->getTarget(


### PR DESCRIPTION
This PR adds a fix for clang-tidy that wasn't caught by the  open CI but that is causing problems on the internal CI.