### PR TITLE
Revise folding for CBitExtractBitOp

### DIFF
--- a/include/Dialect/OQ3/IR/OQ3CBitOps.td
+++ b/include/Dialect/OQ3/IR/OQ3CBitOps.td
@@ -204,6 +204,9 @@ def OQ3_CBitExtractBitOp : OQ3_Op<"cbit_extractbit", [NoSideEffect]> {
     }];
 
     let hasFolder = 1;
+
+    // TODO in LLVM 15 + this can become just let hasVerifier = 1;
+    let verifier = [{ return ::verify(*this);}];
 }
 
 // -----

--- a/test/Dialect/OQ3/IR/fold-cbit-extractbit.mlir
+++ b/test/Dialect/OQ3/IR/fold-cbit-extractbit.mlir
@@ -1,0 +1,19 @@
+// RUN: qss-opt %s --canonicalize | qss-opt | FileCheck %s --implicit-check-not cbit_extractbit
+// Verify that all oq3.cbit_extractbit operations are eliminated
+
+// CHECK: func @single_bit(%[[ARG0:.*]]: i1) -> i1 {
+func @single_bit(%bit: i1) -> i1 {
+    %2 = oq3.cbit_extractbit(%bit : i1) [0] : i1
+    // CHECK: return %[[ARG0]] : i1
+    return %2 : i1
+}
+
+// CHECK: func @two_bits(%[[ARG0:.*]]: !quir.cbit<2>, %[[ARG1:.*]]: i1, %[[ARG2:.*]]: i1)
+func @two_bits(%cbit: !quir.cbit<2>, %bit1: i1, %bit2: i1) -> i1 {
+   %0 = oq3.cbit_insertbit(%cbit : !quir.cbit<2>)[0] = %bit1 : !quir.cbit<2>
+   %1 = oq3.cbit_insertbit(%cbit : !quir.cbit<2>)[1] = %bit2 : !quir.cbit<2>
+
+   %2 = oq3.cbit_extractbit(%1 : !quir.cbit<2>) [1] : i1
+   // CHECK: return %[[ARG2]] : i1
+   return %2 : i1
+}


### PR DESCRIPTION
Simplify and add support for the base case of single-bit registers. While at it, add a verifier for CBitExtractBitOp.