### PR TITLE
Fix M1 CI Failure in VariableEliminationPass 

### DIFF
--- a/lib/Dialect/QUIR/Transforms/VariableElimination.cpp
+++ b/lib/Dialect/QUIR/Transforms/VariableElimination.cpp
@@ -285,9 +285,11 @@ LogicalResult RemoveAllocaWithIsolatedStoresPattern::matchAndRewrite(
       return failure();
   }
 
+  // Drop all users
   for (auto *user : usersToErase)
     rewriter.eraseOp(user);
 
+  // and remove the alloca
   rewriter.eraseOp(op);
   return success();
 }


### PR DESCRIPTION
This PR makes a small change to the VariableEliminationPass to fix CI failures on Apple M1s. See issue #102.

The code in question iterates over the users of a the result of the operation to delete the users. On M1 it is necessary to copy the users to a SmallVector and then iterate as erasing a user appears to change the iteration over getUsers().