### PR TITLE
Add required header for `libQSSC` (follow-up on #98)

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -62,4 +62,13 @@ target_link_libraries(QSSCLib INTERFACE ${qssc_api_libs})
 # Expose (i.e., write to disk) static library with same contents as `QSSCLib`,
 # including interface to `compile()` in `api.h`.
 qssc_add_library(QSSC "API/api.cpp" ADDITIONAL_HEADER_DIRS ${QSSC_INCLUDE_DIR}/API)
+set_target_properties(QSSC PROPERTIES PUBLIC_HEADER ${QSSC_INCLUDE_DIR}/API/api.h)
 target_link_libraries(QSSC ${qssc_api_libs})
+install(
+        TARGETS
+        QSSC
+        PUBLIC_HEADER DESTINATION
+        "${CMAKE_INSTALL_INCLUDEDIR}/API"
+        LIBRARY DESTINATION
+        "${CMAKE_INSTALL_LIBDIR}"
+)


### PR DESCRIPTION
Needed for calling into `libQSSC.a`.