### PR TITLE
Bump Boost 1.80.0 -> 1.81.0

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,5 +1,5 @@
 requirements:
-  - boost/1.80.0
+  - boost/1.81.0
   - gtest/1.11.0
   - libzip/1.8.0
   - zlib/1.2.13


### PR DESCRIPTION
Drops `iconv` dependency, and harmonizes version with other internal projects.