### PR TITLE
Fix CMake config to build on Ubuntu 22.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     endif()
 endif()
 
-project(qss-compiler)
+project(qss-compiler CXX)
 project(qss-opt LANGUAGES CXX C)
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Closes https://github.com/Qiskit/qss-compiler/issues/104 and https://github.com/Qiskit/qss-compiler/issues/105

Testing was done on a fresh Ubuntu 22.04 VM running on a Ubuntu 22.04 host.
To reproduce, install VirtualBox on the host with:
`sudo apt install virtualbox-qt`
Then download the Ubuntu ISO from:
`https://releases.ubuntu.com/22.04.2/ubuntu-22.04.2-desktop-amd64.iso`
Launch the VirtualBox GUI, install the image, inside the VM install the common build tools with:
```bash
sudo apt install build-essential git ninja-build python3-pip python3-setuptools-scm
sudo pip install --upgrade pip
sudo pip install cmake  # newer version than repo
sudo pip install --upgrade conan==1.59.0
conan profile new default --detect
conan profile update settings.compiler.libcxx=libstdc++11 default
```
Copy the repo into the VM (either by `git clone` with valid credentials or a passthrough directory to the host) and `cd` into it.
```bash
mkdir build && cd build
conan install .. --build=missing
conan build ..
```