### PR TITLE
Add support for classical bit arrays > 64 bits

### DIFF
--- a/include/Dialect/OQ3/CMakeLists.txt
+++ b/include/Dialect/OQ3/CMakeLists.txt
@@ -5,3 +5,4 @@
 # that they have been altered from the originals.
 
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/include/Dialect/OQ3/Transforms/CMakeLists.txt
+++ b/include/Dialect/OQ3/Transforms/CMakeLists.txt
@@ -1,0 +1,11 @@
+# (C) Copyright IBM 2023.
+#
+# This code is part of Qiskit.
+#
+# This code is licensed under the Apache License, Version 2.0 with LLVM
+# Exceptions. You may obtain a copy of this license in the LICENSE.txt
+# file in the root directory of this source tree.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.

--- a/include/Dialect/OQ3/Transforms/LimitCBitWidth.h
+++ b/include/Dialect/OQ3/Transforms/LimitCBitWidth.h
@@ -1,0 +1,68 @@
+//===- LimitCBitWidth.h - limit width of cbit registers --------*- C++ -*--===//
+//
+// (C) Copyright IBM 2023.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+///
+///  This file declares the pass limiting the width of classical bit registers.
+///  Registers that are larger than the limit are broken into multiple registers
+///  of the maximum size.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LIMIT_CBIT_WIDTH_H
+#define LIMIT_CBIT_WIDTH_H
+
+#include "Dialect/OQ3/IR/OQ3Ops.h"
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::oq3 {
+
+using namespace mlir;
+
+class LimitCBitWidthPass
+    : public PassWrapper<LimitCBitWidthPass, OperationPass<ModuleOp>> {
+public:
+  uint MAX_CBIT_WIDTH{32};
+
+  LimitCBitWidthPass() = default;
+  LimitCBitWidthPass(uint maxCBitWidth) : MAX_CBIT_WIDTH(maxCBitWidth) {}
+  LimitCBitWidthPass(const LimitCBitWidthPass &pass) : PassWrapper(pass) {}
+
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const override;
+  llvm::StringRef getDescription() const override;
+
+  Option<uint> maxCBitWidthOption{
+      *this, "max-cbit-width",
+      llvm::cl::desc("Maximum width of classical bit arrays")};
+
+private:
+  void addNewDeclareVariableOps(
+      mlir::Operation *module, mlir::oq3::DeclareVariableOp op,
+      uint numRegistersRequired, uint numRemainingBits,
+      llvm::SmallVector<mlir::oq3::DeclareVariableOp> &newRegisters,
+      mlir::SymbolTableCollection &symbolTableCol);
+  void processOp(mlir::oq3::CBitAssignBitOp cbitAssignOp,
+                 uint numRegistersRequired, uint numRemainingBits,
+                 llvm::SmallVector<mlir::oq3::DeclareVariableOp> &newRegisters);
+  void processOp(mlir::oq3::VariableAssignOp variableAssignOp, uint orgWidth,
+                 uint numRegistersRequired, uint numRemainingBits,
+                 llvm::SmallVector<mlir::oq3::DeclareVariableOp> &newRegisters);
+  void processOp(mlir::oq3::VariableLoadOp variableLoadOp,
+                 uint numRegistersRequired, uint numRemainingBits,
+                 llvm::SmallVector<mlir::oq3::DeclareVariableOp> &newRegisters);
+  std::pair<uint64_t, uint64_t> remapBit(const llvm::APInt &indexInt);
+  uint getNewRegisterWidth(uint regNum, uint numRegistersRequired,
+                           uint numRemainingBits);
+  std::vector<Operation *> eraseList_;
+};
+} // namespace mlir::oq3
+
+#endif // LIMIT_CBIT_WIDTH_H

--- a/include/Dialect/OQ3/Transforms/Passes.h
+++ b/include/Dialect/OQ3/Transforms/Passes.h
@@ -1,0 +1,28 @@
+//===- Passes.h - OQ3 Passes  -----------------------------------*- C++ -*-===//
+//
+// (C) Copyright IBM 2023.
+//
+// This code is part of Qiskit.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OQ3_OQ3PASSES_H
+#define OQ3_OQ3PASSES_H
+
+#include "LimitCBitWidth.h"
+
+namespace mlir::oq3 {
+void registerOQ3Passes();
+void registerOQ3PassPipeline();
+
+} // namespace mlir::oq3
+
+#endif // OQ3_OQ3PASSES_H

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -46,6 +46,7 @@
 #include "HAL/TargetSystem.h"
 #include "HAL/TargetSystemRegistry.h"
 
+#include "Dialect/OQ3/Transforms/Passes.h"
 #include "Dialect/Pulse/IR/PulseDialect.h"
 #include "Dialect/Pulse/Transforms/Passes.h"
 #include "Dialect/QCS/Utils/ParameterInitialValueAnalysis.h"
@@ -238,6 +239,8 @@ auto getExtension(const std::string &inStr) -> qss::FileExtension {
 llvm::Error registerPasses() {
   // TODO: Register standalone passes here.
   llvm::Error err = llvm::Error::success();
+  mlir::oq3::registerOQ3Passes();
+  mlir::oq3::registerOQ3PassPipeline();
   mlir::qcs::registerQCSPasses();
   mlir::quir::registerQuirPasses();
   mlir::quir::registerQuirPassPipeline();

--- a/lib/Dialect/OQ3/CMakeLists.txt
+++ b/lib/Dialect/OQ3/CMakeLists.txt
@@ -5,3 +5,4 @@
 # that they have been altered from the originals.
 
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/lib/Dialect/OQ3/Transforms/CMakeLists.txt
+++ b/lib/Dialect/OQ3/Transforms/CMakeLists.txt
@@ -1,0 +1,25 @@
+# (C) Copyright IBM 2023.
+#
+# This code is part of Qiskit.
+#
+# This code is licensed under the Apache License, Version 2.0 with LLVM
+# Exceptions. You may obtain a copy of this license in the LICENSE.txt
+# file in the root directory of this source tree.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+add_mlir_dialect_library(MLIROQ3Transforms
+    LimitCBitWidth.cpp
+    Passes.cpp
+
+    ADDITIONAL_HEADER_DIRS
+    ${PROJECT_SOURCE_DIR}/include/OQ3
+
+    DEPENDS
+    MLIROQ3OpsIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRIR
+    )

--- a/lib/Dialect/OQ3/Transforms/LimitCBitWidth.cpp
+++ b/lib/Dialect/OQ3/Transforms/LimitCBitWidth.cpp
@@ -1,0 +1,251 @@
+//===- LimitCBitWidth.cpp - limit width of cbit registers -------*- C++ -*-===//
+//
+// (C) Copyright IBM 2023.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+///
+///  This file implements the pass limiting the width of classical bit
+///  registers. Registers that are larger than the limit are broken into
+///  multiple registers of the maximum size.
+///
+//===----------------------------------------------------------------------===//
+
+#include "Dialect/OQ3/Transforms/LimitCBitWidth.h"
+
+#include "Dialect/OQ3/IR/OQ3Ops.h"
+
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/SymbolTable.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Casting.h"
+
+#include <string>
+
+#define DEBUG_TYPE "LimitCBitWidth"
+
+using namespace mlir::oq3;
+
+void LimitCBitWidthPass::addNewDeclareVariableOps(
+    Operation *module, DeclareVariableOp op, uint numRegistersRequired,
+    uint numRemainingBits,
+    llvm::SmallVector<mlir::oq3::DeclareVariableOp> &newRegisters,
+    mlir::SymbolTableCollection &symbolTableCol) {
+  auto variableName = op.sym_name();
+
+  // create new registers with _# added to end
+  // add additional "_" if symbol name is found
+  OpBuilder builder(op);
+  newRegisters.clear();
+  for (uint regNum = 0; regNum < numRegistersRequired; regNum++) {
+    std::string newVariableName =
+        variableName.str() + "_" + std::to_string(regNum);
+    auto *findOp =
+        symbolTableCol.getSymbolTable(module).lookup(newVariableName);
+    if (findOp) {
+      uint extraInt = 0;
+      std::string baseVariableName = newVariableName;
+      while (findOp) {
+        newVariableName = baseVariableName + std::to_string(extraInt++);
+        findOp = symbolTableCol.getSymbolTable(module).lookup(newVariableName);
+      }
+    }
+
+    uint bitWidth =
+        getNewRegisterWidth(regNum, numRegistersRequired, numRemainingBits);
+    auto newCbitType = builder.getType<mlir::quir::CBitType>(bitWidth);
+    newRegisters.push_back(builder.create<DeclareVariableOp>(
+        op->getLoc(), newVariableName, mlir::TypeAttr::get(newCbitType)));
+  }
+}
+
+void LimitCBitWidthPass::processOp(
+    CBitAssignBitOp cbitAssignOp, uint numRegistersRequired,
+    uint numRemainingBits,
+    llvm::SmallVector<mlir::oq3::DeclareVariableOp> &newRegisters) {
+  uint64_t index;
+  uint64_t reg;
+  std::tie(reg, index) = remapBit(cbitAssignOp.index());
+  auto width = newRegisters[reg].type().dyn_cast<quir::CBitType>().getWidth();
+  auto value = cbitAssignOp.assigned_bit();
+
+  OpBuilder builder(cbitAssignOp);
+  builder.create<CBitAssignBitOp>(
+      cbitAssignOp->getLoc(),
+      mlir::SymbolRefAttr::get(
+          builder.getStringAttr(newRegisters[reg].sym_name())),
+      builder.getIndexAttr(index), builder.getIndexAttr(width), value);
+
+  eraseList_.push_back(cbitAssignOp);
+}
+
+void LimitCBitWidthPass::processOp(
+    VariableAssignOp variableAssignOp, uint orgWidth, uint numRegistersRequired,
+    uint numRemainingBits,
+    llvm::SmallVector<mlir::oq3::DeclareVariableOp> &newRegisters) {
+  auto castOp =
+      dyn_cast<oq3::CastOp>(variableAssignOp.assigned_value().getDefiningOp());
+  if (!castOp) {
+    variableAssignOp.emitError(
+        "expect assigned_value() to be defined by a CastOp");
+    signalPassFailure();
+  }
+  auto constantOp = dyn_cast<arith::ConstantOp>(castOp.arg().getDefiningOp());
+  if (!constantOp) {
+    castOp.emitError("expect cast arg() to be a constant op");
+    signalPassFailure();
+  }
+  OpBuilder builder(variableAssignOp);
+  if (constantOp.getValue().getType() != builder.getIntegerType(orgWidth)) {
+    constantOp.emitError("constant type is in valid must have width " +
+                         std::to_string(orgWidth));
+    signalPassFailure();
+  }
+
+  auto intAttr = constantOp.getValue().dyn_cast_or_null<IntegerAttr>();
+  if (!intAttr) {
+    constantOp.emitError("constant must have a IntegerAttr value");
+    signalPassFailure();
+  }
+
+  APInt apInt = intAttr.getValue();
+
+  for (uint regNum = 0; regNum < numRegistersRequired; regNum++) {
+    uint bitWidth =
+        getNewRegisterWidth(regNum, numRegistersRequired, numRemainingBits);
+    auto subPart = apInt.extractBits(bitWidth, regNum * MAX_CBIT_WIDTH);
+    auto initializerVal = builder.create<mlir::arith::ConstantOp>(
+        constantOp->getLoc(),
+        builder.getIntegerAttr(builder.getIntegerType(bitWidth), subPart));
+
+    auto newCastOp = builder.create<mlir::oq3::CastOp>(
+        constantOp->getLoc(), builder.getType<mlir::quir::CBitType>(bitWidth),
+        initializerVal);
+
+    builder.create<VariableAssignOp>(
+        variableAssignOp->getLoc(), newRegisters[regNum].sym_name(), newCastOp);
+  }
+  eraseList_.push_back(variableAssignOp);
+}
+
+void LimitCBitWidthPass::processOp(
+    VariableLoadOp variableLoadOp, uint numRegistersRequired,
+    uint numRemainingBits,
+    llvm::SmallVector<mlir::oq3::DeclareVariableOp> &newRegisters) {
+  // load all of the registers
+  llvm::SmallVector<VariableLoadOp> newVariableLoads;
+  OpBuilder builder(variableLoadOp);
+  for (uint regNum = 0; regNum < numRegistersRequired; regNum++) {
+    uint bitWidth =
+        getNewRegisterWidth(regNum, numRegistersRequired, numRemainingBits);
+    newVariableLoads.push_back(builder.create<VariableLoadOp>(
+        variableLoadOp.getLoc(),
+        builder.getType<mlir::quir::CBitType>(bitWidth),
+        newRegisters[regNum].sym_name()));
+  }
+
+  for (auto *loadUse : variableLoadOp->getUsers()) {
+    auto extractBitOp = dyn_cast<CBitExtractBitOp>(loadUse);
+    if (extractBitOp) {
+      uint64_t reg;
+      uint64_t remain;
+      std::tie(reg, remain) = remapBit(extractBitOp.index());
+      auto newExtract = builder.create<CBitExtractBitOp>(
+          extractBitOp->getLoc(), builder.getI1Type(), newVariableLoads[reg],
+          builder.getIndexAttr(remain));
+      extractBitOp->replaceAllUsesWith(newExtract);
+      eraseList_.push_back(extractBitOp);
+    } else {
+      llvm::errs() << "Unhandled use type: ";
+      loadUse->dump();
+      assert(false);
+    }
+  }
+  eraseList_.push_back(variableLoadOp);
+}
+
+std::pair<uint64_t, uint64_t>
+LimitCBitWidthPass::remapBit(const llvm::APInt &indexInt) {
+  uint64_t index = indexInt.getZExtValue();
+  uint64_t reg = index / MAX_CBIT_WIDTH;
+  index = index - (reg * MAX_CBIT_WIDTH);
+  return std::make_pair(reg, index);
+}
+
+uint LimitCBitWidthPass::getNewRegisterWidth(uint regNum,
+                                             uint numRegistersRequired,
+                                             uint numRemainingBits) {
+  uint bitWidth =
+      regNum == (numRegistersRequired - 1) ? numRemainingBits : MAX_CBIT_WIDTH;
+  return bitWidth;
+}
+
+void LimitCBitWidthPass::runOnOperation() {
+
+  eraseList_.clear();
+
+  // check for command line override of MAX_CBIT_WIDTH
+  if (maxCBitWidthOption.hasValue())
+    MAX_CBIT_WIDTH = maxCBitWidthOption.getValue();
+
+  Operation *module = getOperation();
+
+  mlir::SymbolTableCollection symbolTableCol;
+
+  module->walk([&](DeclareVariableOp op) {
+    // look for declare variables of CBitType and Width > 64
+    auto cbitType = op.type().dyn_cast<quir::CBitType>();
+    if (!cbitType || cbitType.getWidth() <= MAX_CBIT_WIDTH)
+      return;
+
+    uint orgWidth = cbitType.getWidth();
+    uint numRegistersRequired = cbitType.getWidth() / MAX_CBIT_WIDTH + 1;
+    uint numRemainingBits = cbitType.getWidth() % MAX_CBIT_WIDTH;
+    llvm::SmallVector<mlir::oq3::DeclareVariableOp> newRegisters;
+
+    addNewDeclareVariableOps(module, op, numRegistersRequired, numRemainingBits,
+                             newRegisters, symbolTableCol);
+
+    if (auto rangeOrNone = SymbolTable::getSymbolUses(op, module))
+      for (auto &use : rangeOrNone.getValue()) {
+        auto *user = use.getUser();
+        if (auto variableAssignOp = dyn_cast<VariableAssignOp>(user))
+          processOp(variableAssignOp, orgWidth, numRegistersRequired,
+                    numRemainingBits, newRegisters);
+        else if (auto cbitAssignOp = dyn_cast<CBitAssignBitOp>(user))
+          processOp(cbitAssignOp, numRegistersRequired, numRemainingBits,
+                    newRegisters);
+        else if (auto variableLoadOp = dyn_cast<VariableLoadOp>(user))
+          processOp(variableLoadOp, numRegistersRequired, numRemainingBits,
+                    newRegisters);
+        else {
+          llvm::errs() << "Unhandled use type: ";
+          use.getUser()->dump();
+          assert(false);
+        }
+      }
+    eraseList_.push_back(op);
+  });
+
+  for (auto *op : eraseList_) {
+    assert(op->use_empty() && "operation usage expected to be empty");
+    op->erase();
+  }
+
+} // runOnOperation
+
+llvm::StringRef LimitCBitWidthPass::getArgument() const {
+  return "oq3-limit-cbit-width";
+}
+
+llvm::StringRef LimitCBitWidthPass::getDescription() const {
+  return "Limit classical bit register width";
+}

--- a/lib/Dialect/OQ3/Transforms/Passes.cpp
+++ b/lib/Dialect/OQ3/Transforms/Passes.cpp
@@ -1,0 +1,40 @@
+//===- Passes.cpp - OQ3 Passes ----------------------------------*- C++ -*-===//
+//
+// (C) Copyright IBM 2023.
+//
+// This code is part of Qiskit.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dialect/OQ3/Transforms/Passes.h"
+
+#include "Dialect/OQ3/Transforms/LimitCBitWidth.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+
+namespace mlir::oq3 {
+
+void oq3PassPipelineBuilder(OpPassManager &pm) {
+  pm.addPass(std::make_unique<LimitCBitWidthPass>());
+}
+
+void registerOQ3Passes() {
+  //===----------------------------------------------------------------------===//
+  // Transform Passes
+  //===----------------------------------------------------------------------===//
+  PassRegistration<LimitCBitWidthPass>();
+}
+
+void registerOQ3PassPipeline() {
+  PassPipelineRegistration<> pipeline(
+      "oq3Opt", "Enable OQ3-specific optimizations", oq3PassPipelineBuilder);
+}
+} // end namespace mlir::oq3

--- a/test/Dialect/OQ3/Transforms/limit-cbit-width.mlir
+++ b/test/Dialect/OQ3/Transforms/limit-cbit-width.mlir
@@ -1,0 +1,108 @@
+// RUN: qss-compiler -X=mlir -emit=mlir %s --oq3-limit-cbit-width | FileCheck %s
+//
+// Test that the we can successfully split cbit arrays larger than 32 bits wide
+
+module {
+  
+  %c34359738368_i36= arith.constant 34359738368 : i36
+  %c0_i2 = arith.constant 0 : i2
+  %c0_i48 = arith.constant 0 : i48
+  %c0_i4 = arith.constant 0 : i4
+
+  // test does not change cbit arrays < 32
+  oq3.declare_variable @meas : !quir.cbit<4>
+  // CHECK: oq3.declare_variable @meas : !quir.cbit<4>
+
+  // test breaking apart wide array
+  oq3.declare_variable @wide : !quir.cbit<48>
+  // CHECK-NOT: oq3.declare_variable @wide : !quir.cbit<48>
+  // CHECK: oq3.declare_variable @wide_00 : !quir.cbit<32>
+  // CHECK: oq3.declare_variable @wide_1 : !quir.cbit<16>
+  
+  // test does not overwrite existing symbols when breaking appart wide arrays
+  oq3.declare_variable @wide_0 : !quir.cbit<2>
+  // CHECK: oq3.declare_variable @wide_0 : !quir.cbit<2>
+
+  // test wide array assignment 
+  oq3.declare_variable @assignment1 : !quir.cbit<36>
+  // CHECK-NOT: oq3.declare_variable @assignment1 : !quir.cbit<36>
+  // CHECK: oq3.declare_variable @assignment1_0 : !quir.cbit<32>
+  // CHECK: oq3.declare_variable @assignment1_1 : !quir.cbit<4>
+  
+  // test initialization into original narrow array - no change
+  %0 = "oq3.cast"(%c0_i4) : (i4) -> !quir.cbit<4>
+  oq3.variable_assign @meas : !quir.cbit<4> = %0
+  // CHECK: %0 = "oq3.cast"(%c0_i4) : (i4) -> !quir.cbit<4>
+  // CHECK: oq3.variable_assign @meas : !quir.cbit<4> = %0
+
+  // test initialization of split array
+  %1 = "oq3.cast"(%c0_i48) : (i48) -> !quir.cbit<48>
+  oq3.variable_assign @wide : !quir.cbit<48> = %1
+  // CHECK: [[CAST1:%.*]] = "oq3.cast"(%c0_i32) : (i32) -> !quir.cbit<32>
+  // CHECK: oq3.variable_assign @wide_00 : !quir.cbit<32> = [[CAST1]]
+  // CHECK: %c0_i16 = arith.constant 0 : i16
+  // CHECK: [[CAST2:%.*]]  = "oq3.cast"(%c0_i16) : (i16) -> !quir.cbit<16>
+  // CHECK: oq3.variable_assign @wide_1 : !quir.cbit<16> = [[CAST2]]
+  
+
+  // test initialization into original narrow array symbol name that 
+  // would have been used to break apart wide wide array - no change
+  %2 = "oq3.cast"(%c0_i2) : (i2) -> !quir.cbit<2>
+  oq3.variable_assign @wide_0 : !quir.cbit<2> = %2
+  // CHECK: [[INIT1:%.*]] = "oq3.cast"(%c0_i2) : (i2) -> !quir.cbit<2>
+  // CHECK: oq3.variable_assign @wide_0 : !quir.cbit<2> = [[INIT1]]
+  
+  // declare qubits to make sure measurement mapping is correct
+  %3 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
+  %4 = quir.declare_qubit {id = 3 : i32} : !quir.qubit<1>
+  %5 = quir.declare_qubit {id = 47 : i32} : !quir.qubit<1>
+  // CHECK: [[Q0:%.*]] = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
+  // CHECK: [[Q3:%.*]] = quir.declare_qubit {id = 3 : i32} : !quir.qubit<1>
+  // CHECK: [[Q47:%.*]] = quir.declare_qubit {id = 47 : i32} : !quir.qubit<1>
+  
+  // assignment into narrow array - no change
+  %7 = quir.measure(%4) : (!quir.qubit<1>) -> i1
+  oq3.cbit_assign_bit @meas<4> [3] : i1 = %7
+  // CHECK: [[M1:%.*]] = quir.measure([[Q3]]) : (!quir.qubit<1>) -> i1
+  // CHECK: oq3.cbit_assign_bit @meas<4> [3] : i1 = [[M1]]
+  
+  // assignment into wide array LSB - assign into lowest split register
+  %8 = quir.measure(%3) : (!quir.qubit<1>) -> i1
+  oq3.cbit_assign_bit @wide<48> [0] : i1 = %8
+  // CHECK: [[M2:%.*]] = quir.measure([[Q0]]) : (!quir.qubit<1>) -> i1
+  // CHECK: oq3.cbit_assign_bit @wide_00<32> [0] : i1 = [[M2]]
+
+  // assignment into wide array MSB - 
+  // assign into calculated  split register
+  %10 = quir.measure(%5) : (!quir.qubit<1>) -> i1
+  oq3.cbit_assign_bit @wide<48> [47] : i1 = %10
+  // CHECK: [[M4:%.*]] = quir.measure([[Q47]]) : (!quir.qubit<1>) -> i1
+  // CHECK: oq3.cbit_assign_bit @wide_1<16> [15] : i1 = [[M4]]
+
+  // test intialization of wide array 
+  %11 = "oq3.cast"(%c34359738368_i36) : (i36) -> !quir.cbit<36>
+  oq3.variable_assign @assignment1 : !quir.cbit<36> = %11
+  %12 = oq3.variable_load @assignment1 : !quir.cbit<36>
+  // CHECK: [[CAST1:%.*]] = "oq3.cast"(%c0_i32_0) : (i32) -> !quir.cbit<32>
+  // CHECK: oq3.variable_assign @assignment1_0 : !quir.cbit<32> = [[CAST1:%.*]]
+  // CHECK: [[CAST2:%.*]] = "oq3.cast"(%c-8_i4) : (i4) -> !quir.cbit<4>
+  // CHECK: oq3.variable_assign @assignment1_1 : !quir.cbit<4> = [[CAST2:%.*]]
+
+  
+  // test remapped extract bit and if conditional
+  %13 = oq3.cbit_extractbit(%12 : !quir.cbit<36>) [35] : i1
+  scf.if %13 {
+    %14 = oq3.variable_load @assignment1 : !quir.cbit<36>
+    %15 = oq3.cbit_extractbit(%14 : !quir.cbit<36>) [0] : i1
+    oq3.cbit_assign_bit @assignment1<36> [35] : i1 = %15
+  }
+  // CHECK: {{%.*}} = oq3.variable_load @assignment1_0 : !quir.cbit<32>
+  // CHECK: {{%.*}} = oq3.variable_load @assignment1_1 : !quir.cbit<4>
+  // CHECK: [[COND:%.*]] = oq3.cbit_extractbit(%15 : !quir.cbit<4>) [3] : i1
+  // CHECK: scf.if [[COND]] {
+  // CHECK: [[LOADLOWER:%.*]] = oq3.variable_load @assignment1_0 : !quir.cbit<32>
+  // CHECK: [[LOADUPPER:%.*]] = oq3.variable_load @assignment1_1 : !quir.cbit<4>
+  // CHECK: [[EXTRACTLOWER:%.*]] = oq3.cbit_extractbit([[LOADLOWER]] : !quir.cbit<32>) [0] : i1
+  // CHECK: oq3.cbit_assign_bit @assignment1_1<4> [3] : i1 = [[EXTRACTLOWER]]
+  
+} 

--- a/test/Dialect/OQ3/integration/openqasm3/cbit-width.qasm
+++ b/test/Dialect/OQ3/integration/openqasm3/cbit-width.qasm
@@ -1,0 +1,72 @@
+OPENQASM 3.0;
+// RUN: qss-compiler %s --emit=mlir --oq3-limit-cbit-width --canonicalize | FileCheck %s
+//
+// Test that the we can successfully split cbit arrays larger than 32 bits wide
+
+cbit[4] meas;
+// CHECK: oq3.declare_variable @meas : !quir.cbit<4>
+cbit[48] wide;
+// CHECK-NOT: oq3.declare_variable @wide : !quir.cbit<48>
+// CHECK: oq3.declare_variable @wide_00 : !quir.cbit<32>
+// CHECK: oq3.declare_variable @wide_1 : !quir.cbit<16>
+// test for existing Symbol with new name
+cbit[2] wide_0;
+// CHECK: oq3.declare_variable @wide_0 : !quir.cbit<2>
+
+// CHECK: func @main() -> i32
+
+// CHECK-DAG: %c-8_i4 = arith.constant -8 : i4
+
+// CHECK-NOT: oq3.variable_assign @wide : !quir.cbit<48> = %1
+// CHECK-NOT: %2 = "oq3.cast"(%c0_i2) : (i2) -> !quir.cbit<2>
+
+// CHECK: [[CAST0:%.*]] = "oq3.cast"(%c0_i32) : (i32) -> !quir.cbit<32>
+// CHECK: oq3.variable_assign @wide_00 : !quir.cbit<32> = [[CAST0]]
+// CHECK: [[CAST1:%.*]] = "oq3.cast"(%c0_i16) : (i16) -> !quir.cbit<16>
+// CHECK: oq3.variable_assign @wide_1 : !quir.cbit<16> = [[CAST1]]
+
+
+qubit $0;
+// CHECK: [[QUBIT0:%.*]] = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
+qubit $3;
+// CHECK: [[QUBIT3:%.*]] = quir.declare_qubit {id = 3 : i32} : !quir.qubit<1>
+qubit $47;
+// CHECK: [[QUBIT432:%.*]] = quir.declare_qubit {id = 47 : i32} : !quir.qubit<1>
+
+
+meas[3] = measure $3;
+// CHECK: [[M3:%.*]] = quir.measure([[QUBIT3]]) : (!quir.qubit<1>) -> i1
+// CHECK: oq3.cbit_assign_bit @meas<4> [3] : i1 = [[M3]]
+
+wide[0] = measure $0;
+// CHECK: [[M0:%.*]] = quir.measure([[QUBIT0]]) : (!quir.qubit<1>) -> i1
+// CHECK: oq3.cbit_assign_bit @wide_00<32> [0] : i1 = [[M0]]
+
+wide[47] = measure $47;
+// CHECK: [[M47:%.*]] = quir.measure([[QUBIT432]]) : (!quir.qubit<1>) -> i1
+// CHECK: oq3.cbit_assign_bit @wide_1<16> [15] : i1 = [[M47]]
+
+// there is a bug with the following line - the initializer value is being
+// lost and set to 0
+// cbit[36] assignment0  = 34359738368; // 1 << 35
+
+cbit[36] assignment1 = "100000000000000000000000000000000000";
+
+// CHECK: [[LOWER:%.*]] = "oq3.cast"(%c0_i32) : (i32) -> !quir.cbit<32>
+// CHECK: oq3.variable_assign @assignment1_0 : !quir.cbit<32> = [[LOWER]]
+// CHECK: [[UPPER:%.*]] = "oq3.cast"(%c-8_i4) : (i4) -> !quir.cbit<4>
+// CHECK: oq3.variable_assign @assignment1_1 : !quir.cbit<4> = [[UPPER]]
+
+if (assignment1[35] == 1) {
+  assignment1[35] = assignment1[0];
+}
+
+// CHECK: [[LOAD:%.*]] = oq3.variable_load @assignment1_1 : !quir.cbit<4>
+// CHECK: [[COND:%.*]] = oq3.cbit_extractbit([[LOAD]] : !quir.cbit<4>) [3] : i1
+// CHECK: scf.if [[COND]] {
+// CHECK: [[LOADVAR:%.*]] = oq3.variable_load @assignment1_0 : !quir.cbit<32>
+// CHECK: [[LOADBIT:%.*]] = oq3.cbit_extractbit([[LOADVAR]] : !quir.cbit<32>) [0] : i1
+// CHECK: oq3.cbit_assign_bit @assignment1_1<4> [3] : i1 = [[LOADBIT]]
+
+
+

--- a/tools/qss-opt/qss-opt.cpp
+++ b/tools/qss-opt/qss-opt.cpp
@@ -41,6 +41,7 @@
 #include "Payload/PayloadRegistry.h"
 
 #include "Dialect/OQ3/IR/OQ3Dialect.h"
+#include "Dialect/OQ3/Transforms/Passes.h"
 #include "Dialect/Pulse/IR/PulseDialect.h"
 #include "Dialect/Pulse/Transforms/Passes.h"
 #include "Dialect/QCS/IR/QCSDialect.h"
@@ -100,6 +101,8 @@ static llvm::cl::opt<bool> allowUnregisteredDialects(
 auto main(int argc, char **argv) -> int {
   mlir::registerAllPasses();
   mlir::registerConversionPasses();
+  mlir::oq3::registerOQ3Passes();
+  mlir::oq3::registerOQ3PassPipeline();
   mlir::qcs::registerQCSPasses();
   mlir::quir::registerQuirPasses();
   mlir::quir::registerQuirPassPipeline();


### PR DESCRIPTION
This PR adds a test to validate that the truncation width is less than an APInt width before applying the truncation. 