### PR TITLE
Enable standalone build on Mac/Clang

### DIFF
--- a/include/Dialect/QCS/IR/QCSOps.h
+++ b/include/Dialect/QCS/IR/QCSOps.h
@@ -21,6 +21,8 @@
 #ifndef DIALECT_QCS_QCSOPS_H_
 #define DIALECT_QCS_QCSOPS_H_
 
+#include <unordered_map>
+
 // TODO: move necessary components to `QCS`
 #include "Dialect/QUIR/IR/QUIRInterfaces.h"
 #include "Dialect/QUIR/IR/QUIRTraits.h"


### PR DESCRIPTION
8fd1178 added [`std::unordered_map` into `QCSOps.td`](https://github.com/Qiskit/qss-compiler/blob/8fd117830c8e8348a7d6fa2f2212459eca9d173d/include/Dialect/QCS/IR/QCSOps.td#L292), which fails build on Mac (Apple M1 Pro, Apple clang version 14.0.0 (clang-1400.0.29.202)) though build succeeds on Linux.

This PR just adds `#include <unordered_map>` into `QCSOps.h`. 

