### PR TITLE
Update required version of cmake

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 breathe
-cmake>=3.15
+cmake>=3.23
 conan==1.59.0
 Jinja2==3.0.3 # https://github.com/sphinx-doc/sphinx/issues/10291
 lit>=12.0.0


### PR DESCRIPTION
A feature used since #123 has only been available since cmake 3.23. Update `requirements-dev.txt` accordingly.

Note that most environments use a sufficiently recent version of cmake (as of this writing, version 3.27 is current), so that we did not notice this missing update (including in the CI run in this repository). Another use case exposed the problem, since it used an older cmake (<3.20) and failed to handle the keyword FILE_SET properly (introduced in 3.23)

Fixes #123