### PR TITLE
Add back existing python exception in `__init__.py` for backward compatibility

### DIFF
--- a/python_lib/qss_compiler/__init__.py
+++ b/python_lib/qss_compiler/__init__.py
@@ -22,6 +22,11 @@ from .compile import (  # noqa: F401
     CompileOptions,
 )
 
+from .exceptions import (  # noqa: F401
+    QSSCompilationFailure,
+    QSSCompilerError,
+)
+
 from .py_qssc import (  # noqa: F401
     Diagnostic,
     ErrorCategory,


### PR DESCRIPTION
This was removed in PR https://github.com/Qiskit/qss-compiler/pull/124