### PR TITLE
Extend quir::SwitchOp lowering to correctly lower results. 

### DIFF
--- a/lib/Conversion/QUIRToStandard/SwitchOpLowering.cpp
+++ b/lib/Conversion/QUIRToStandard/SwitchOpLowering.cpp
@@ -60,24 +60,12 @@ SwitchOpLowering::matchAndRewrite(SwitchOp switchOp,
   // continuation point.
   auto *condBlock = rewriter.getInsertionBlock();
   auto opPosition = rewriter.getInsertionPoint();
-  // auto *remainingOpsBlock = rewriter.splitBlock(condBlock, opPosition);
-  // FIXME: opPosition vs Block::iterator(switchOp)??
   Block *continueBlock = rewriter.splitBlock(condBlock, opPosition);
-#if 0  
-  if (switchOp.getNumResults() == 0) {
-    continueBlock = remainingOpsBlock;
-  } else {
-    continueBlock =
-        rewriter.createBlock(remainingOpsBlock, switchOp.getResultTypes());
-    rewriter.create<BranchOp>(loc, remainingOpsBlock);
-  }
-#else
   SmallVector<Value> results;
   results.reserve(switchOp.getNumResults());
   for (Type resultType : switchOp.getResultTypes())
     results.push_back(
         continueBlock->addArgument(resultType, switchOp.getLoc()));
-#endif
   // Move blocks from the "default" region to the region containing
   // 'quir.switch', place it before the continuation block, and branch to it.
   auto &defaultRegion = switchOp.defaultRegion();


### PR DESCRIPTION
This patch extends the quir::SwitchOp lowering to LLVM IR to correctly handle results. These changes are based on the support added to scf::IndexSwitchOp operation, which also supports switch ops with results.
Support for lowering the scf::IndexSwitchOp was added to MLIR in commit 91effec85 (https://github.com/llvm/llvm-project/commit/91effec85). 