### PR TITLE
Don't recompile regex for every delay.  52.76->48.47 on 101x51 delay/…

### DIFF
--- a/lib/Dialect/QUIR/Utils/Utils.cpp
+++ b/lib/Dialect/QUIR/Utils/Utils.cpp
@@ -350,7 +350,7 @@ Duration::parseDuration(mlir::quir::ConstantOp &duration) {
 
 llvm::Expected<Duration>
 Duration::parseDuration(const std::string &durationStr) {
-  std::regex re("^([0-9]*[.]?[0-9]+)([a-zA-Z]*)");
+  static std::regex re("^([0-9]*[.]?[0-9]+)([a-zA-Z]*)");
   std::smatch m;
   std::regex_match(durationStr, m, re);
   if (m.size() != 3)


### PR DESCRIPTION
On circuits that are about 50% delays, this is worth about 5% in CPU time.   Not a huge win, but hey, it's one line :)