### PR TITLE
Treating pulse duration as uint64_t

### DIFF
--- a/lib/Conversion/QUIRToPulse/LoadPulseCals.cpp
+++ b/lib/Conversion/QUIRToPulse/LoadPulseCals.cpp
@@ -533,8 +533,8 @@ bool LoadPulseCalsPass::doAllSequenceOpsHaveSameDuration(
     if (!sequenceOp->hasAttrOfType<IntegerAttr>("pulse.duration"))
       return false;
 
-    uint sequenceDuration =
-        sequenceOp->getAttrOfType<IntegerAttr>("pulse.duration").getUInt();
+    uint sequenceDuration = static_cast<uint64_t>(
+        sequenceOp->getAttrOfType<IntegerAttr>("pulse.duration").getInt());
     if (!prevSequenceEncountered) {
       prevSequenceEncountered = true;
       prevSequencePulseDuration = sequenceDuration;


### PR DESCRIPTION
MLIR does does not have a `UI64IntegerAttr` so duration is stored as `I64IntegerAttr` but should be treated as a `uint64_t` (which is done throughout the codebase). The change of this PR is so that it's done in loadPulseCals pass as well.