### PR TITLE
Free up space from the CI build image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,14 @@ jobs:
     env:
       CONAN_USER_HOME: ${{ github.workspace }}
     steps:
+      - name: free-up-space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet   
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          df -h
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0


### PR DESCRIPTION
This PR adds a `free-up-space` stage to the ci pipeline to free up disk space from the build image in order to prevent errors of the form:


```
System.IO.IOException: No space left on device 
```