### PR TITLE
[Backport v3.7] Bug fix for comparison of large cbits and integer literals (#168)

### DIFF
--- a/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
@@ -1564,10 +1564,12 @@ ExpressionValueType QUIRGenQASM3Visitor::visit_(const ASTBinaryOpNode *node) {
     if (leftType.isa<quir::CBitType>()) {
       leftRef = builder.create<CastOp>(getLocation(left),
                                        builder.getIntegerType(bits), leftRef);
+      leftType = leftRef.getType();
     }
     if (rightType.isa<quir::CBitType>()) {
       rightRef = builder.create<CastOp>(getLocation(right),
                                         builder.getIntegerType(bits), rightRef);
+      rightType = rightRef.getType();
     }
     // integer types of different sizes
     if (leftType != rightType && leftType.isIntOrIndex() &&

--- a/test/Frontend/OpenQASM3/compare-bits.qasm
+++ b/test/Frontend/OpenQASM3/compare-bits.qasm
@@ -108,3 +108,12 @@ if (bit_two != bit_one){
 if (bit_one != bitstring[0]) {
     U(0, 0, 0) $0;
 }
+
+// MLIR-DAG: [[BIG_BITS:%.*]] = oq3.variable_load @big_bits : !quir.cbit<33>
+// MLIR-DAG: [[ZERO_32:%.*]] = arith.constant 0 : i32
+// MLIR-DAG: [[LHS:%.*]] = "oq3.cast"([[BIG_BITS]]) : (!quir.cbit<33>) -> i33
+// MLIR-DAG: [[RHS:%.*]] = "oq3.cast"([[ZERO_32]]) : (i32) -> i33
+// MLIR: [[CMP:%.*]] = arith.cmpi eq, [[LHS]], [[RHS]] : i33
+// MLIR: scf.if [[CMP]] {
+bit[33] big_bits;
+if (big_bits == 0) {}


### PR DESCRIPTION
This PR fixes a bug that caused verification failure on the generated QUIR when comparing large cbits (> 32 bits) with integer literals. This was caused by failing to cast to match bit width because we weren't updating the tracked type after casting the reference to convert from cbit to int.