### PR TITLE
Add a payload to output a binary file

### DIFF
--- a/lib/Payload/BinaryPayload/BinaryPayload.cpp
+++ b/lib/Payload/BinaryPayload/BinaryPayload.cpp
@@ -1,0 +1,94 @@
+//===- BinaryPayload.cpp ----------------------------------------*- C++ -*-===//
+//
+// (C) Copyright IBM 2023.
+//
+// This code is part of Qiskit.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+///
+/// Implements the BinaryPayload class
+///
+//===----------------------------------------------------------------------===//
+
+#include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <ostream>
+#include <unordered_set>
+
+#include "BinaryPayload.h"
+#include "Config.h"
+
+#include "Payload/PayloadRegistry.h"
+
+using namespace qssc::payload;
+namespace fs = std::filesystem;
+
+int qssc::payload::init_binary_payload() {
+  const char *name = "BINARY";
+  bool registered = registry::PayloadRegistry::registerPlugin(
+      name, name, "Payload that generates a single binary",
+      [](llvm::Optional<PayloadConfig> config)
+          -> llvm::Expected<std::unique_ptr<payload::Payload>> {
+        if (config.hasValue())
+          return std::make_unique<BinaryPayload>(config.getValue());
+        return std::make_unique<BinaryPayload>();
+      });
+  return registered ? 0 : -1;
+}
+
+void BinaryPayload::writePlain(llvm::raw_ostream &stream) {
+  std::vector<fs::path> orderedNames = orderedFileNames();
+  stream << "------------------------------------------\n";
+  stream << "Plaintext payload: " << prefix << "\n";
+  stream << "------------------------------------------\n";
+  stream << "Manifest:\n";
+  for (auto &fName : orderedNames)
+    stream << fName << "\n";
+  stream << "------------------------------------------\n";
+  for (auto &fName : orderedNames) {
+    stream << "File: " << fName << "\n";
+    stream << files[fName];
+    if (*(files[fName].rbegin()) != '\n')
+      stream << "\n";
+    stream << "------------------------------------------\n";
+  }
+}
+
+void BinaryPayload::writePlain(std::ostream &stream) {
+  llvm::raw_os_ostream llstream(stream);
+  writePlain(llstream);
+}
+
+void BinaryPayload::write(llvm::raw_ostream &stream) {
+  // single binary data is supported
+  assert(orderedFileNames().size() == 1);
+
+  for (auto &&filename : orderedFileNames()) {
+    // write binary data to stream
+    stream << files[filename];
+  }
+}
+
+void BinaryPayload::write(std::ostream &stream) {
+  // single binary data is supported
+  assert(orderedFileNames().size() == 1);
+
+  for (auto &&filename : orderedFileNames()) {
+    // write binary data to stream
+    stream << files[filename];
+  }
+}
+
+void BinaryPayload::addFile(llvm::StringRef filename, llvm::StringRef str) {
+  std::lock_guard<std::mutex> lock(_mtx);
+  files[filename.str()] = str;
+}

--- a/lib/Payload/BinaryPayload/BinaryPayload.h
+++ b/lib/Payload/BinaryPayload/BinaryPayload.h
@@ -1,0 +1,49 @@
+//===- BinaryPayload.h ------------------------------------------*- C++ -*-===//
+//
+// (C) Copyright IBM 2023.
+//
+// This code is part of Qiskit.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+///
+/// Declares the BinaryPayload class
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef PAYLOAD_BINARYPAYLOAD_H
+#define PAYLOAD_BINARYPAYLOAD_H
+
+#include "Payload/Payload.h"
+
+namespace qssc::payload {
+
+// Register the binary payload.
+int init_binary_payload();
+
+class BinaryPayload : public Payload {
+public:
+  BinaryPayload() = default;
+  BinaryPayload(PayloadConfig config) : Payload(std::move(config)) {}
+  virtual ~BinaryPayload() = default;
+
+  // write all files to the stream
+  virtual void write(llvm::raw_ostream &stream) override;
+  // write all files to the stream
+  virtual void write(std::ostream &stream) override;
+  // write all files in plaintext to the stream
+  virtual void writePlain(std::ostream &stream) override;
+  virtual void writePlain(llvm::raw_ostream &stream) override;
+  virtual void addFile(llvm::StringRef filename, llvm::StringRef str) override;
+}; // class BinaryPayload
+
+} // namespace qssc::payload
+
+#endif // PAYLOAD_BINARYPAYLOAD_H

--- a/lib/Payload/BinaryPayload/CMakeLists.txt
+++ b/lib/Payload/BinaryPayload/CMakeLists.txt
@@ -1,0 +1,30 @@
+# (C) Copyright IBM 2023.
+#
+# This code is part of Qiskit.
+#
+# This code is licensed under the Apache License, Version 2.0 with LLVM
+# Exceptions. You may obtain a copy of this license in the LICENSE.txt
+# file in the root directory of this source tree.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+set(QSSC_PAYLOAD_PATHS
+        ${QSSC_PAYLOAD_PATHS}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+
+qssc_add_plugin(QSSCPayloadBinary QSSC_PAYLOAD_PLUGIN
+        BinaryPayload.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${QSSC_INCLUDE_DIR}/Payload
+
+        LINK_LIBS
+        QSSCPayload
+
+        PLUGIN_REGISTRATION_HEADERS
+        ${CMAKE_CURRENT_SOURCE_DIR}/Payload.inc
+        )

--- a/lib/Payload/BinaryPayload/Payload.inc
+++ b/lib/Payload/BinaryPayload/Payload.inc
@@ -1,0 +1,33 @@
+//===- Payload.inc - BinaryPayload registration -----------------*- C++ -*-===//
+//
+// (C) Copyright IBM 2023.
+//
+// This code is part of Qiskit.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+///
+/// This file defines static objects that register payloads
+/// with the QSS compiler core.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef PAYLOAD_PAYLOAD_BINARYPAYLOAD_H
+#define PAYLOAD_PAYLOAD_BINARYPAYLOAD_H
+
+#include "BinaryPayload.h"
+
+namespace qssc::payload {
+
+[[maybe_unused]] int bin_registrar = init_binary_payload();
+
+} // namespace qssc::payload
+
+#endif // PAYLOAD_PAYLOAD_BINARYPAYLOAD_H

--- a/lib/Payload/CMakeLists.txt
+++ b/lib/Payload/CMakeLists.txt
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 add_subdirectory(ZipPayload)
+add_subdirectory(BinaryPayload)
 
 # Register payloads with build system
 foreach(payload_path ${QSSC_PAYLOAD_PATHS})


### PR DESCRIPTION
Add a new payload to output a single executable file that will be used by simulator targets.

This payload is mainly used to run executable binary files targeting simulators on the user's local PC.