### PR TITLE
Generate payload in `--emit=qe-qem`

### DIFF
--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -746,7 +746,7 @@ compile_(int argc, char const **argv, std::string *outputString,
     dumpMLIR_(ostream, moduleOp);
   }
 
-  if (emitAction == Action::GenQEM) {
+  if (emitAction == Action::GenQEM || emitAction == Action::GenQEQEM) {
 
     if (includeSourceInPayload) {
       if (directInput) {


### PR DESCRIPTION
This PR adds missing implementation to generate target-specific payload introduced in #146.

In #146, `--emit=qe-qem` option was introduced. However, when this option is enabled, registered payload is not generate and this PR fixes this issue.