### PR TITLE
update libzip to 1.10.1

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,6 +1,6 @@
 requirements:
   - gtest/1.11.0
-  - libzip/1.8.0
+  - libzip/1.10.1
   - zlib/1.2.13
   - nlohmann_json/3.9.1
   - pybind11/2.10.1


### PR DESCRIPTION
Updates libzip to the 1.10.1 to avoid some zip related memory free issues. 