### PR TITLE
enable `--verify-each` option

### DIFF
--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -561,6 +561,9 @@ compile_(int argc, char const **argv, std::string *outputString,
   mlir::applyPassManagerCLOptions(pm);
   mlir::applyDefaultTimingPassManagerCLOptions(pm);
 
+  // Enable verifier (default: true)
+  pm.enableVerifier(verifyPasses);
+
   // Build the configuration for this compilation event.
   auto configResult = buildConfig_(&context);
   if (auto err = configResult.takeError())


### PR DESCRIPTION
`qss-opt` uses `verify-each` option to dis/enable verifier of `PassManager`. As `qss-opt` does, `qss-compiler` should use this to configure verifier for performance.