### PR TITLE
Configure build mode for LIT tests.

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -55,3 +55,7 @@ llvm_config.with_environment("PATH", config.llvm_tools_dir, append_path=True)
 # Add substitutions for all files in QSS compiler tools directory.
 tools = os.listdir(config.qss_compiler_tools_dir)
 llvm_config.add_tool_substitutions(tools, [config.qss_compiler_tools_dir])
+
+llvm_config.feature_config(
+    [('--assertion-mode', {'ON': 'asserts'}),
+     ('--build-mode', {'[Dd][Ee][Bb][Uu][Gg]': 'debug'})])


### PR DESCRIPTION
This change allows us to query the build mode used to build the compiler in LIT tests. This will enable the REQUIRES constraint to disable tests when the compiler is not built with asserts or in debug mode. See https://llvm.org/docs/TestingGuide.html\#constraining-test-execution for more details on constraining test execution.