### PR TITLE
Enable pulse.sequence ops to use the getDuration interface

### DIFF
--- a/include/Dialect/Pulse/IR/PulseOps.td
+++ b/include/Dialect/Pulse/IR/PulseOps.td
@@ -712,7 +712,8 @@ def Pulse_CallSequenceOp : Pulse_Op<"call_sequence", [CallOpInterface, MemRefsNo
 
 def Pulse_SequenceOp : Pulse_Op<"sequence", [
   AutomaticAllocationScope, CallableOpInterface,
-  FunctionOpInterface, IsolatedFromAbove, Symbol, SequenceAllowed
+  FunctionOpInterface, IsolatedFromAbove, Symbol, SequenceAllowed,
+  DeclareOpInterfaceMethods<PulseOpSchedulingInterface, ["getDuration"]>
 ]> {
   let summary = "An operation with a name containing a single `SSACFG` region corresponding to a pulse sequence execution";
   let description = [{

--- a/lib/Dialect/Pulse/IR/PulseOps.cpp
+++ b/lib/Dialect/Pulse/IR/PulseOps.cpp
@@ -305,6 +305,11 @@ SequenceOp SequenceOp::clone() {
   return clone(mapper);
 }
 
+llvm::Expected<uint64_t>
+SequenceOp::getDuration(mlir::Operation *callSequenceOp = nullptr) {
+  return interfaces_impl::getDuration(*this, callSequenceOp);
+}
+
 //===----------------------------------------------------------------------===//
 //
 // end SequenceOp


### PR DESCRIPTION
This PR updates the pulse.sequence op to have the getDuration pulse interface. Going forward we expect the pulse.sequence duration to be stored here instead of relying on the timepoint of it's terminating pulse.return.