### PR TITLE
Add passName attr and getName() function to MLIR passes

### DIFF
--- a/include/Conversion/QUIRToPulse/LoadPulseCals.h
+++ b/include/Conversion/QUIRToPulse/LoadPulseCals.h
@@ -58,8 +58,7 @@ struct LoadPulseCalsPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-      "Load Pulse Cals Pass (" + getArgument().str() + ")";
+  std::string passName = "Load Pulse Cals Pass (" + getArgument().str() + ")";
 
   // optionally, one can override the path to default pulse calibrations with
   // this option; e.g., to write a LIT test one can invoke this pass with

--- a/include/Conversion/QUIRToPulse/LoadPulseCals.h
+++ b/include/Conversion/QUIRToPulse/LoadPulseCals.h
@@ -57,6 +57,9 @@ struct LoadPulseCalsPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Load Pulse Cals Pass (" + getArgument().str() + ")";
 
   // optionally, one can override the path to default pulse calibrations with
   // this option; e.g., to write a LIT test one can invoke this pass with

--- a/include/Conversion/QUIRToPulse/QUIRToPulse.h
+++ b/include/Conversion/QUIRToPulse/QUIRToPulse.h
@@ -49,6 +49,9 @@ struct QUIRToPulsePass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "QUIR To Pulse Pass (" + getArgument().str() + ")";
 
   // optionally, one can override the path to pulse waveform container file with
   // this option; e.g., to write a LIT test one can invoke this pass with

--- a/include/Conversion/QUIRToPulse/QUIRToPulse.h
+++ b/include/Conversion/QUIRToPulse/QUIRToPulse.h
@@ -50,8 +50,7 @@ struct QUIRToPulsePass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-      "QUIR To Pulse Pass (" + getArgument().str() + ")";
+  std::string passName = "QUIR To Pulse Pass (" + getArgument().str() + ")";
 
   // optionally, one can override the path to pulse waveform container file with
   // this option; e.g., to write a LIT test one can invoke this pass with

--- a/include/Dialect/OQ3/Transforms/LimitCBitWidth.h
+++ b/include/Dialect/OQ3/Transforms/LimitCBitWidth.h
@@ -39,8 +39,7 @@ public:
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-      "Limit CBit Width Pass (" + getArgument().str() + ")";
+  std::string passName = "Limit CBit Width Pass (" + getArgument().str() + ")";
 
   Option<uint> maxCBitWidthOption{
       *this, "max-cbit-width",

--- a/include/Dialect/OQ3/Transforms/LimitCBitWidth.h
+++ b/include/Dialect/OQ3/Transforms/LimitCBitWidth.h
@@ -38,6 +38,9 @@ public:
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Limit CBit Width Pass (" + getArgument().str() + ")";
 
   Option<uint> maxCBitWidthOption{
       *this, "max-cbit-width",

--- a/include/Dialect/Pulse/Transforms/ClassicalOnlyDetection.h
+++ b/include/Dialect/Pulse/Transforms/ClassicalOnlyDetection.h
@@ -37,6 +37,9 @@ struct ClassicalOnlyDetectionPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Classical Only Detection Pass (" + getArgument().str() + ")";
 }; // end struct ClassicalOnlyDetectionPass
 
 } // namespace mlir::pulse

--- a/include/Dialect/Pulse/Transforms/ClassicalOnlyDetection.h
+++ b/include/Dialect/Pulse/Transforms/ClassicalOnlyDetection.h
@@ -38,7 +38,7 @@ struct ClassicalOnlyDetectionPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Classical Only Detection Pass (" + getArgument().str() + ")";
 }; // end struct ClassicalOnlyDetectionPass
 

--- a/include/Dialect/Pulse/Transforms/InlineRegion.h
+++ b/include/Dialect/Pulse/Transforms/InlineRegion.h
@@ -32,6 +32,9 @@ public:
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Inline Region Pass (" + getArgument().str() + ")";
 };
 
 } // namespace mlir::pulse

--- a/include/Dialect/Pulse/Transforms/InlineRegion.h
+++ b/include/Dialect/Pulse/Transforms/InlineRegion.h
@@ -33,8 +33,7 @@ public:
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-      "Inline Region Pass (" + getArgument().str() + ")";
+  std::string passName = "Inline Region Pass (" + getArgument().str() + ")";
 };
 
 } // namespace mlir::pulse

--- a/include/Dialect/Pulse/Transforms/MergeDelays.h
+++ b/include/Dialect/Pulse/Transforms/MergeDelays.h
@@ -36,6 +36,9 @@ public:
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Merge Delay Pass (" + getArgument().str() + ")";
 };
 } // namespace mlir::pulse
 

--- a/include/Dialect/Pulse/Transforms/MergeDelays.h
+++ b/include/Dialect/Pulse/Transforms/MergeDelays.h
@@ -37,8 +37,7 @@ public:
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-      "Merge Delay Pass (" + getArgument().str() + ")";
+  std::string passName = "Merge Delay Pass (" + getArgument().str() + ")";
 };
 } // namespace mlir::pulse
 

--- a/include/Dialect/Pulse/Transforms/RemoveUnusedArguments.h
+++ b/include/Dialect/Pulse/Transforms/RemoveUnusedArguments.h
@@ -37,6 +37,9 @@ public:
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Remove Unused Arguments Pass (" + getArgument().str() + ")";
 };
 } // namespace mlir::pulse
 

--- a/include/Dialect/Pulse/Transforms/RemoveUnusedArguments.h
+++ b/include/Dialect/Pulse/Transforms/RemoveUnusedArguments.h
@@ -38,7 +38,7 @@ public:
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Remove Unused Arguments Pass (" + getArgument().str() + ")";
 };
 } // namespace mlir::pulse

--- a/include/Dialect/Pulse/Transforms/SchedulePort.h
+++ b/include/Dialect/Pulse/Transforms/SchedulePort.h
@@ -46,8 +46,7 @@ public:
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-      "Schedule Port Pass (" + getArgument().str() + ")";
+  std::string passName = "Schedule Port Pass (" + getArgument().str() + ")";
 
 private:
   using mixedFrameMap_t = std::map<uint32_t, std::vector<Operation *>>;

--- a/include/Dialect/Pulse/Transforms/SchedulePort.h
+++ b/include/Dialect/Pulse/Transforms/SchedulePort.h
@@ -45,6 +45,9 @@ public:
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Schedule Port Pass (" + getArgument().str() + ")";
 
 private:
   using mixedFrameMap_t = std::map<uint32_t, std::vector<Operation *>>;

--- a/include/Dialect/Pulse/Transforms/SystemCreation.h
+++ b/include/Dialect/Pulse/Transforms/SystemCreation.h
@@ -52,8 +52,7 @@ struct SystemCreationPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-      "System Creation Pass (" + getArgument().str() + ")";
+  std::string passName = "System Creation Pass (" + getArgument().str() + ")";
 };
 
 struct SystemPlotPass : public PassWrapper<SystemPlotPass, OperationPass<>> {
@@ -71,8 +70,7 @@ struct SystemPlotPass : public PassWrapper<SystemPlotPass, OperationPass<>> {
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-      "System Plot Pass (" + getArgument().str() + ")";
+  std::string passName = "System Plot Pass (" + getArgument().str() + ")";
 };
 
 } // namespace mlir::pulse

--- a/include/Dialect/Pulse/Transforms/SystemCreation.h
+++ b/include/Dialect/Pulse/Transforms/SystemCreation.h
@@ -51,6 +51,9 @@ struct SystemCreationPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "System Creation Pass (" + getArgument().str() + ")";
 };
 
 struct SystemPlotPass : public PassWrapper<SystemPlotPass, OperationPass<>> {
@@ -67,6 +70,9 @@ struct SystemPlotPass : public PassWrapper<SystemPlotPass, OperationPass<>> {
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "System Plot Pass (" + getArgument().str() + ")";
 };
 
 } // namespace mlir::pulse

--- a/include/Dialect/QCS/Utils/ParameterInitialValueAnalysis.h
+++ b/include/Dialect/QCS/Utils/ParameterInitialValueAnalysis.h
@@ -59,6 +59,9 @@ struct ParameterInitialValueAnalysisPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Parameter Initial Value Analysis Pass (" + getArgument().str() + ")";
 }; // struct ParameterInitialValueAnalysisPass
 
 // TODO: move registerQCSPasses to separate header if additional passes

--- a/include/Dialect/QCS/Utils/ParameterInitialValueAnalysis.h
+++ b/include/Dialect/QCS/Utils/ParameterInitialValueAnalysis.h
@@ -60,7 +60,7 @@ struct ParameterInitialValueAnalysisPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Parameter Initial Value Analysis Pass (" + getArgument().str() + ")";
 }; // struct ParameterInitialValueAnalysisPass
 

--- a/include/Dialect/QUIR/IR/QUIRTestInterfaces.h
+++ b/include/Dialect/QUIR/IR/QUIRTestInterfaces.h
@@ -35,6 +35,9 @@ struct TestQubitOpInterfacePass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Test Qubit Op Interface Pass (" + getArgument().str() + ")";
 };
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/IR/QUIRTestInterfaces.h
+++ b/include/Dialect/QUIR/IR/QUIRTestInterfaces.h
@@ -36,7 +36,7 @@ struct TestQubitOpInterfacePass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Test Qubit Op Interface Pass (" + getArgument().str() + ")";
 };
 

--- a/include/Dialect/QUIR/Transforms/AddShotLoop.h
+++ b/include/Dialect/QUIR/Transforms/AddShotLoop.h
@@ -54,8 +54,7 @@ struct AddShotLoopPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-      "Add Shot Loop Pass (" + getArgument().str() + ")";
+  std::string passName = "Add Shot Loop Pass (" + getArgument().str() + ")";
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<mlir::quir::QUIRDialect>();

--- a/include/Dialect/QUIR/Transforms/AddShotLoop.h
+++ b/include/Dialect/QUIR/Transforms/AddShotLoop.h
@@ -53,6 +53,9 @@ struct AddShotLoopPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Add Shot Loop Pass (" + getArgument().str() + ")";
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<mlir::quir::QUIRDialect>();

--- a/include/Dialect/QUIR/Transforms/AngleConversion.h
+++ b/include/Dialect/QUIR/Transforms/AngleConversion.h
@@ -35,6 +35,9 @@ struct QUIRAngleConversionPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "QUIR Angle Conversion Pass (" + getArgument().str() + ")";
 
 private:
   std::unordered_map<std::string, FuncOp> functionOps;

--- a/include/Dialect/QUIR/Transforms/AngleConversion.h
+++ b/include/Dialect/QUIR/Transforms/AngleConversion.h
@@ -36,7 +36,7 @@ struct QUIRAngleConversionPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "QUIR Angle Conversion Pass (" + getArgument().str() + ")";
 
 private:

--- a/include/Dialect/QUIR/Transforms/BreakReset.h
+++ b/include/Dialect/QUIR/Transforms/BreakReset.h
@@ -51,8 +51,7 @@ struct BreakResetPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-      "Break Reset Pass (" + getArgument().str() + ")";
+  std::string passName = "Break Reset Pass (" + getArgument().str() + ")";
 }; // struct BreakResetPass
 } // namespace mlir::quir
 

--- a/include/Dialect/QUIR/Transforms/BreakReset.h
+++ b/include/Dialect/QUIR/Transforms/BreakReset.h
@@ -50,6 +50,9 @@ struct BreakResetPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Break Reset Pass (" + getArgument().str() + ")";
 }; // struct BreakResetPass
 } // namespace mlir::quir
 

--- a/include/Dialect/QUIR/Transforms/ConvertDurationUnits.h
+++ b/include/Dialect/QUIR/Transforms/ConvertDurationUnits.h
@@ -74,7 +74,7 @@ struct ConvertDurationUnitsPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Convert Duration Units Pass (" + getArgument().str() + ")";
 
 }; // struct ConvertDurationUnitsPass

--- a/include/Dialect/QUIR/Transforms/ConvertDurationUnits.h
+++ b/include/Dialect/QUIR/Transforms/ConvertDurationUnits.h
@@ -73,6 +73,9 @@ struct ConvertDurationUnitsPass
   virtual double getDtTimestep();
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Convert Duration Units Pass (" + getArgument().str() + ")";
 
 }; // struct ConvertDurationUnitsPass
 

--- a/include/Dialect/QUIR/Transforms/FunctionArgumentSpecialization.h
+++ b/include/Dialect/QUIR/Transforms/FunctionArgumentSpecialization.h
@@ -48,6 +48,9 @@ struct FunctionArgumentSpecializationPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Function Argument Specialization Pass (" + getArgument().str() + ")";
 }; // struct FunctionArgumentSpecializationPass
 } // namespace mlir::quir
 

--- a/include/Dialect/QUIR/Transforms/FunctionArgumentSpecialization.h
+++ b/include/Dialect/QUIR/Transforms/FunctionArgumentSpecialization.h
@@ -49,7 +49,7 @@ struct FunctionArgumentSpecializationPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Function Argument Specialization Pass (" + getArgument().str() + ")";
 }; // struct FunctionArgumentSpecializationPass
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/LoadElimination.h
+++ b/include/Dialect/QUIR/Transforms/LoadElimination.h
@@ -32,8 +32,7 @@ struct LoadEliminationPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-      "Load Elimination Pass (" + getArgument().str() + ")";
+  std::string passName = "Load Elimination Pass (" + getArgument().str() + ")";
 }; // struct LoadEliminationPass
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/LoadElimination.h
+++ b/include/Dialect/QUIR/Transforms/LoadElimination.h
@@ -31,6 +31,9 @@ struct LoadEliminationPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Load Elimination Pass (" + getArgument().str() + ")";
 }; // struct LoadEliminationPass
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/MergeCircuits.h
+++ b/include/Dialect/QUIR/Transforms/MergeCircuits.h
@@ -43,6 +43,9 @@ struct MergeCircuitsPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Merge Circuits Pass (" + getArgument().str() + ")";
 }; // struct MergeCircuitsPass
 } // namespace mlir::quir
 #endif // QUIR_MERGE_CIRCUITS_H

--- a/include/Dialect/QUIR/Transforms/MergeCircuits.h
+++ b/include/Dialect/QUIR/Transforms/MergeCircuits.h
@@ -44,8 +44,7 @@ struct MergeCircuitsPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-      "Merge Circuits Pass (" + getArgument().str() + ")";
+  std::string passName = "Merge Circuits Pass (" + getArgument().str() + ")";
 }; // struct MergeCircuitsPass
 } // namespace mlir::quir
 #endif // QUIR_MERGE_CIRCUITS_H

--- a/include/Dialect/QUIR/Transforms/MergeMeasures.h
+++ b/include/Dialect/QUIR/Transforms/MergeMeasures.h
@@ -35,7 +35,7 @@ struct MergeMeasuresLexographicalPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Merge Measures Lexographical Pass (" + getArgument().str() + ")";
 }; // struct MergeMeasuresLexographicalPass
 
@@ -48,7 +48,7 @@ struct MergeMeasuresTopologicalPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Merge Measures Topological Pass (" + getArgument().str() + ")";
 }; // struct MergeMeasuresTopologicalPass
 

--- a/include/Dialect/QUIR/Transforms/MergeMeasures.h
+++ b/include/Dialect/QUIR/Transforms/MergeMeasures.h
@@ -34,6 +34,9 @@ struct MergeMeasuresLexographicalPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Merge Measures Lexographical Pass (" + getArgument().str() + ")";
 }; // struct MergeMeasuresLexographicalPass
 
 /// @brief Merge together measures in a circuit that are topologically
@@ -44,6 +47,9 @@ struct MergeMeasuresTopologicalPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Merge Measures Topological Pass (" + getArgument().str() + ")";
 }; // struct MergeMeasuresTopologicalPass
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/MergeParallelResets.h
+++ b/include/Dialect/QUIR/Transforms/MergeParallelResets.h
@@ -38,7 +38,7 @@ struct MergeResetsLexicographicPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Merge Resets Lexicographic Pass (" + getArgument().str() + ")";
 }; // struct MergeResetsLexicographicPass
 
@@ -55,7 +55,7 @@ struct MergeResetsTopologicalPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Merge Resets Topological Pass (" + getArgument().str() + ")";
 }; // struct MergeResetsTopologicalPass
 

--- a/include/Dialect/QUIR/Transforms/MergeParallelResets.h
+++ b/include/Dialect/QUIR/Transforms/MergeParallelResets.h
@@ -37,6 +37,9 @@ struct MergeResetsLexicographicPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Merge Resets Lexicographic Pass (" + getArgument().str() + ")";
 }; // struct MergeResetsLexicographicPass
 
 /// This pass merges qubit reset operations that can be parallelized into a
@@ -51,6 +54,9 @@ struct MergeResetsTopologicalPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Merge Resets Topological Pass (" + getArgument().str() + ")";
 }; // struct MergeResetsTopologicalPass
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/Passes.h
+++ b/include/Dialect/QUIR/Transforms/Passes.h
@@ -54,7 +54,7 @@ struct ClassicalOnlyDetectionPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Classical Only Detection Pass (" + getArgument().str() + ")";
 }; // end struct ClassicalOnlyDetectionPass
 

--- a/include/Dialect/QUIR/Transforms/Passes.h
+++ b/include/Dialect/QUIR/Transforms/Passes.h
@@ -53,6 +53,9 @@ struct ClassicalOnlyDetectionPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Classical Only Detection Pass (" + getArgument().str() + ")";
 }; // end struct ClassicalOnlyDetectionPass
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.h
+++ b/include/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.h
@@ -71,7 +71,7 @@ struct QUIRCircuitAnalysisPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "QUIR Circuit Analysis Pass (" + getArgument().str() + ")";
 }; // QUIRCircuitAnalysisPass
 

--- a/include/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.h
+++ b/include/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.h
@@ -70,6 +70,9 @@ struct QUIRCircuitAnalysisPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "QUIR Circuit Analysis Pass (" + getArgument().str() + ")";
 }; // QUIRCircuitAnalysisPass
 
 llvm::Expected<double>

--- a/include/Dialect/QUIR/Transforms/QuantumDecoration.h
+++ b/include/Dialect/QUIR/Transforms/QuantumDecoration.h
@@ -51,6 +51,9 @@ struct QuantumDecorationPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Quantum Decoration Pass (" + getArgument().str() + ")";
 }; // QuantumDecorationPass
 } // namespace mlir::quir
 

--- a/include/Dialect/QUIR/Transforms/QuantumDecoration.h
+++ b/include/Dialect/QUIR/Transforms/QuantumDecoration.h
@@ -52,7 +52,7 @@ struct QuantumDecorationPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Quantum Decoration Pass (" + getArgument().str() + ")";
 }; // QuantumDecorationPass
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/RemoveQubitOperands.h
+++ b/include/Dialect/QUIR/Transforms/RemoveQubitOperands.h
@@ -49,6 +49,9 @@ struct RemoveQubitOperandsPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Remove Qubit Operands Pass (" + getArgument().str() + ")";
 }; // struct SubroutineCloningPass
 } // namespace mlir::quir
 

--- a/include/Dialect/QUIR/Transforms/RemoveQubitOperands.h
+++ b/include/Dialect/QUIR/Transforms/RemoveQubitOperands.h
@@ -50,7 +50,7 @@ struct RemoveQubitOperandsPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Remove Qubit Operands Pass (" + getArgument().str() + ")";
 }; // struct SubroutineCloningPass
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/ReorderCircuits.h
+++ b/include/Dialect/QUIR/Transforms/ReorderCircuits.h
@@ -32,6 +32,9 @@ struct ReorderCircuitsPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Reorder Circuits Pass (" + getArgument().str() + ")";
 }; // struct ReorderCircuitsPass
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/ReorderCircuits.h
+++ b/include/Dialect/QUIR/Transforms/ReorderCircuits.h
@@ -33,8 +33,7 @@ struct ReorderCircuitsPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-      "Reorder Circuits Pass (" + getArgument().str() + ")";
+  std::string passName = "Reorder Circuits Pass (" + getArgument().str() + ")";
 }; // struct ReorderCircuitsPass
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/ReorderMeasurements.h
+++ b/include/Dialect/QUIR/Transforms/ReorderMeasurements.h
@@ -33,7 +33,7 @@ struct ReorderMeasurementsPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Reorder Measurements Pass (" + getArgument().str() + ")";
 }; // struct ReorderMeasurementsPass
 

--- a/include/Dialect/QUIR/Transforms/ReorderMeasurements.h
+++ b/include/Dialect/QUIR/Transforms/ReorderMeasurements.h
@@ -32,6 +32,9 @@ struct ReorderMeasurementsPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Reorder Measurements Pass (" + getArgument().str() + ")";
 }; // struct ReorderMeasurementsPass
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/SubroutineCloning.h
+++ b/include/Dialect/QUIR/Transforms/SubroutineCloning.h
@@ -56,7 +56,7 @@ struct SubroutineCloningPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Subroutine Cloning Pass (" + getArgument().str() + ")";
 }; // struct SubroutineCloningPass
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/SubroutineCloning.h
+++ b/include/Dialect/QUIR/Transforms/SubroutineCloning.h
@@ -55,6 +55,9 @@ struct SubroutineCloningPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Subroutine Cloning Pass (" + getArgument().str() + ")";
 }; // struct SubroutineCloningPass
 } // namespace mlir::quir
 

--- a/include/Dialect/QUIR/Transforms/UnusedVariable.h
+++ b/include/Dialect/QUIR/Transforms/UnusedVariable.h
@@ -38,8 +38,7 @@ struct UnusedVariablePass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-      "Unused Variable Pass (" + getArgument().str() + ")";
+  std::string passName = "Unused Variable Pass (" + getArgument().str() + ")";
 }; // struct UnusedVariablePass
 } // namespace mlir::quir
 

--- a/include/Dialect/QUIR/Transforms/UnusedVariable.h
+++ b/include/Dialect/QUIR/Transforms/UnusedVariable.h
@@ -37,6 +37,9 @@ struct UnusedVariablePass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Unused Variable Pass (" + getArgument().str() + ")";
 }; // struct UnusedVariablePass
 } // namespace mlir::quir
 

--- a/include/Dialect/QUIR/Transforms/VariableElimination.h
+++ b/include/Dialect/QUIR/Transforms/VariableElimination.h
@@ -40,7 +40,7 @@ struct VariableEliminationPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Variable Elimination Pass (" + getArgument().str() + ")";
 
   void getDependentDialects(DialectRegistry &registry) const override {

--- a/include/Dialect/QUIR/Transforms/VariableElimination.h
+++ b/include/Dialect/QUIR/Transforms/VariableElimination.h
@@ -39,6 +39,9 @@ struct VariableEliminationPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Variable Elimination Pass (" + getArgument().str() + ")";
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<mlir::memref::MemRefDialect>();

--- a/lib/Conversion/QUIRToPulse/LoadPulseCals.cpp
+++ b/lib/Conversion/QUIRToPulse/LoadPulseCals.cpp
@@ -621,3 +621,5 @@ llvm::StringRef LoadPulseCalsPass::getArgument() const {
 llvm::StringRef LoadPulseCalsPass::getDescription() const {
   return "Load the pulse calibrations, and add them to module";
 }
+
+llvm::StringRef LoadPulseCalsPass::getName() const { return passName; }

--- a/lib/Conversion/QUIRToPulse/QUIRToPulse.cpp
+++ b/lib/Conversion/QUIRToPulse/QUIRToPulse.cpp
@@ -621,3 +621,5 @@ llvm::StringRef QUIRToPulsePass::getArgument() const { return "quir-to-pulse"; }
 llvm::StringRef QUIRToPulsePass::getDescription() const {
   return "Convert quir circuit to pulse sequence.";
 }
+
+llvm::StringRef QUIRToPulsePass::getName() const { return passName; }

--- a/lib/Dialect/OQ3/Transforms/LimitCBitWidth.cpp
+++ b/lib/Dialect/OQ3/Transforms/LimitCBitWidth.cpp
@@ -249,3 +249,5 @@ llvm::StringRef LimitCBitWidthPass::getArgument() const {
 llvm::StringRef LimitCBitWidthPass::getDescription() const {
   return "Limit classical bit register width";
 }
+
+llvm::StringRef LimitCBitWidthPass::getName() const { return passName; }

--- a/lib/Dialect/Pulse/Transforms/ClassicalOnlyDetection.cpp
+++ b/lib/Dialect/Pulse/Transforms/ClassicalOnlyDetection.cpp
@@ -74,4 +74,6 @@ llvm::StringRef ClassicalOnlyDetectionPass::getDescription() const {
   return "Detect control flow blocks that contain only classical (non-quantum) "
          "operations, and decorate them with a classicalOnly bool attribute";
 }
+
+llvm::StringRef ClassicalOnlyDetectionPass::getName() const { return passName; }
 } // namespace mlir::pulse

--- a/lib/Dialect/Pulse/Transforms/InlineRegion.cpp
+++ b/lib/Dialect/Pulse/Transforms/InlineRegion.cpp
@@ -82,7 +82,10 @@ void InlineRegionPass::runOnOperation() {
 }
 
 llvm::StringRef InlineRegionPass::getArgument() const { return "pulse-inline"; }
+
 llvm::StringRef InlineRegionPass::getDescription() const {
   return "Inline all dialects.";
 }
+
+llvm::StringRef InlineRegionPass::getName() const { return passName; }
 } // namespace mlir::pulse

--- a/lib/Dialect/Pulse/Transforms/MergeDelays.cpp
+++ b/lib/Dialect/Pulse/Transforms/MergeDelays.cpp
@@ -116,3 +116,5 @@ llvm::StringRef MergeDelayPass::getArgument() const {
 llvm::StringRef MergeDelayPass::getDescription() const {
   return "Merge sequencial delays on the same physical channel";
 }
+
+llvm::StringRef MergeDelayPass::getName() const { return passName; }

--- a/lib/Dialect/Pulse/Transforms/RemoveUnusedArguments.cpp
+++ b/lib/Dialect/Pulse/Transforms/RemoveUnusedArguments.cpp
@@ -125,3 +125,5 @@ llvm::StringRef RemoveUnusedArgumentsPass::getArgument() const {
 llvm::StringRef RemoveUnusedArgumentsPass::getDescription() const {
   return "Remove sequence arguments that are unused by physical channel";
 }
+
+llvm::StringRef RemoveUnusedArgumentsPass::getName() const { return passName; }

--- a/lib/Dialect/Pulse/Transforms/SchedulePort.cpp
+++ b/lib/Dialect/Pulse/Transforms/SchedulePort.cpp
@@ -248,3 +248,5 @@ llvm::StringRef SchedulePortPass::getArgument() const {
 llvm::StringRef SchedulePortPass::getDescription() const {
   return "Schedule operations on the same port in a sequence";
 }
+
+llvm::StringRef SchedulePortPass::getName() const { return passName; }

--- a/lib/Dialect/QCS/Utils/ParameterInitialValueAnalysis.cpp
+++ b/lib/Dialect/QCS/Utils/ParameterInitialValueAnalysis.cpp
@@ -88,6 +88,8 @@ llvm::StringRef ParameterInitialValueAnalysisPass::getDescription() const {
   return "Run ParameterInitialValueAnalysis";
 }
 
+llvm::StringRef ParameterInitialValueAnalysisPass::getName() const { return passName; }
+
 // TODO: move registerQCSPasses to separate source file if additional passes
 // are added to the QCS Dialect
 void mlir::qcs::registerQCSPasses() {

--- a/lib/Dialect/QCS/Utils/ParameterInitialValueAnalysis.cpp
+++ b/lib/Dialect/QCS/Utils/ParameterInitialValueAnalysis.cpp
@@ -88,7 +88,9 @@ llvm::StringRef ParameterInitialValueAnalysisPass::getDescription() const {
   return "Run ParameterInitialValueAnalysis";
 }
 
-llvm::StringRef ParameterInitialValueAnalysisPass::getName() const { return passName; }
+llvm::StringRef ParameterInitialValueAnalysisPass::getName() const {
+  return passName;
+}
 
 // TODO: move registerQCSPasses to separate source file if additional passes
 // are added to the QCS Dialect

--- a/lib/Dialect/QUIR/IR/QUIRTestInterfaces.cpp
+++ b/lib/Dialect/QUIR/IR/QUIRTestInterfaces.cpp
@@ -56,3 +56,5 @@ llvm::StringRef TestQubitOpInterfacePass::getDescription() const {
   return "Test QubitOpInterface by attributing operations with operated "
          "qubits.";
 }
+
+llvm::StringRef TestQubitOpInterfacePass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/AddShotLoop.cpp
+++ b/lib/Dialect/QUIR/Transforms/AddShotLoop.cpp
@@ -103,7 +103,10 @@ void AddShotLoopPass::runOnOperation() {
 } // runOnOperation
 
 llvm::StringRef AddShotLoopPass::getArgument() const { return "add-shot-loop"; }
+
 llvm::StringRef AddShotLoopPass::getDescription() const {
   return "Add a for loop wrapping the main function body iterating over the "
          "number of shots";
 }
+
+llvm::StringRef AddShotLoopPass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/AngleConversion.cpp
+++ b/lib/Dialect/QUIR/Transforms/AngleConversion.cpp
@@ -102,3 +102,5 @@ llvm::StringRef QUIRAngleConversionPass::getDescription() const {
   return "Convert the angle types in CallGateOp "
          "based on the corresponding FuncOp args";
 }
+
+llvm::StringRef QUIRAngleConversionPass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/BreakReset.cpp
+++ b/lib/Dialect/QUIR/Transforms/BreakReset.cpp
@@ -126,6 +126,9 @@ void BreakResetPass::runOnOperation() {
 } // BreakResetPass::runOnOperation
 
 llvm::StringRef BreakResetPass::getArgument() const { return "break-reset"; }
+
 llvm::StringRef BreakResetPass::getDescription() const {
   return "Break reset ops into repeated measure and conditional x gate calls";
 }
+
+llvm::StringRef BreakResetPass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/ConvertDurationUnits.cpp
+++ b/lib/Dialect/QUIR/Transforms/ConvertDurationUnits.cpp
@@ -339,3 +339,5 @@ llvm::StringRef ConvertDurationUnitsPass::getDescription() const {
   return "Convert the units of all duration types within the module to the "
          "specified units.";
 }
+
+llvm::StringRef ConvertDurationUnitsPass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/FunctionArgumentSpecialization.cpp
+++ b/lib/Dialect/QUIR/Transforms/FunctionArgumentSpecialization.cpp
@@ -175,4 +175,6 @@ llvm::StringRef FunctionArgumentSpecializationPass::getDescription() const {
          "original function def is left unchanged";
 }
 
-llvm::StringRef FunctionArgumentSpecializationPass::getName() const { return passName; }
+llvm::StringRef FunctionArgumentSpecializationPass::getName() const {
+  return passName;
+}

--- a/lib/Dialect/QUIR/Transforms/FunctionArgumentSpecialization.cpp
+++ b/lib/Dialect/QUIR/Transforms/FunctionArgumentSpecialization.cpp
@@ -174,3 +174,5 @@ llvm::StringRef FunctionArgumentSpecializationPass::getDescription() const {
          "cloned, the call is updated to match the cloned def, and the "
          "original function def is left unchanged";
 }
+
+llvm::StringRef FunctionArgumentSpecializationPass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/LoadElimination.cpp
+++ b/lib/Dialect/QUIR/Transforms/LoadElimination.cpp
@@ -121,4 +121,6 @@ llvm::StringRef LoadEliminationPass::getDescription() const {
          "to a variable to subsequent uses of the variable.";
 }
 
+llvm::StringRef LoadEliminationPass::getName() const { return passName; }
+
 } // namespace mlir::quir

--- a/lib/Dialect/QUIR/Transforms/MergeCircuits.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuits.cpp
@@ -409,3 +409,5 @@ llvm::StringRef MergeCircuitsPass::getArgument() const {
 llvm::StringRef MergeCircuitsPass::getDescription() const {
   return "Merge back-to-back call_circuits ";
 }
+
+llvm::StringRef MergeCircuitsPass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/MergeMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeMeasures.cpp
@@ -126,7 +126,9 @@ llvm::StringRef MergeMeasuresLexographicalPass::getDescription() const {
          "single measurement operation with lexographicalal ordering";
 }
 
-llvm::StringRef MergeMeasuresLexographicalPass::getName() const { return passName; }
+llvm::StringRef MergeMeasuresLexographicalPass::getName() const {
+  return passName;
+}
 
 namespace {
 // This pattern matches on two MeasureOps that are only interspersed by
@@ -198,4 +200,6 @@ llvm::StringRef MergeMeasuresTopologicalPass::getDescription() const {
          "single measurement operation with topological ordering";
 }
 
-llvm::StringRef MergeMeasuresTopologicalPass::getName() const { return passName; }
+llvm::StringRef MergeMeasuresTopologicalPass::getName() const {
+  return passName;
+}

--- a/lib/Dialect/QUIR/Transforms/MergeMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeMeasures.cpp
@@ -126,6 +126,8 @@ llvm::StringRef MergeMeasuresLexographicalPass::getDescription() const {
          "single measurement operation with lexographicalal ordering";
 }
 
+llvm::StringRef MergeMeasuresLexographicalPass::getName() const { return passName; }
+
 namespace {
 // This pattern matches on two MeasureOps that are only interspersed by
 // classical non-control flow ops and merges them into one measure op
@@ -195,3 +197,5 @@ llvm::StringRef MergeMeasuresTopologicalPass::getDescription() const {
   return "Merge qubit-parallel measurement operations into a "
          "single measurement operation with topological ordering";
 }
+
+llvm::StringRef MergeMeasuresTopologicalPass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/MergeParallelResets.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeParallelResets.cpp
@@ -113,6 +113,8 @@ llvm::StringRef MergeResetsLexicographicPass::getDescription() const {
          "single operation lexicographically.";
 }
 
+llvm::StringRef MergeResetsLexicographicPass::getName() const { return passName; }
+
 namespace {
 // This pattern merges qubit reset operations that can be parallelized into a
 // single reset op topologically.
@@ -222,3 +224,5 @@ llvm::StringRef MergeResetsTopologicalPass::getDescription() const {
   return "Merge qubit reset ops that can be parallelized into a "
          "single operation topologically.";
 }
+
+llvm::StringRef MergeResetsTopologicalPass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/MergeParallelResets.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeParallelResets.cpp
@@ -113,7 +113,9 @@ llvm::StringRef MergeResetsLexicographicPass::getDescription() const {
          "single operation lexicographically.";
 }
 
-llvm::StringRef MergeResetsLexicographicPass::getName() const { return passName; }
+llvm::StringRef MergeResetsLexicographicPass::getName() const {
+  return passName;
+}
 
 namespace {
 // This pattern merges qubit reset operations that can be parallelized into a

--- a/lib/Dialect/QUIR/Transforms/Passes.cpp
+++ b/lib/Dialect/QUIR/Transforms/Passes.cpp
@@ -183,6 +183,8 @@ llvm::StringRef ClassicalOnlyDetectionPass::getDescription() const {
   return "Detect control flow blocks that contain only classical (non-quantum) "
          "operations, and decorate them with a classicalOnly bool attribute";
 }
+
+llvm::StringRef ClassicalOnlyDetectionPass::getName() const { return passName; }
 /////////////// End ClassicalOnlyDetectionPass functions ///////////////////
 
 struct DumpVariableDominanceInfoPass

--- a/lib/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.cpp
+++ b/lib/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.cpp
@@ -210,4 +210,6 @@ llvm::StringRef QUIRCircuitAnalysisPass::getDescription() const {
   return "Analyze Circuit Inputs";
 }
 
+llvm::StringRef QUIRCircuitAnalysisPass::getName() const { return passName; }
+
 } // namespace mlir::quir

--- a/lib/Dialect/QUIR/Transforms/QuantumDecoration.cpp
+++ b/lib/Dialect/QUIR/Transforms/QuantumDecoration.cpp
@@ -167,3 +167,5 @@ llvm::StringRef QuantumDecorationPass::getDescription() const {
   return "Detect and add attributes to ops describing which "
          "qubits are involved within those ops";
 }
+
+llvm::StringRef QuantumDecorationPass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/RemoveQubitOperands.cpp
+++ b/lib/Dialect/QUIR/Transforms/RemoveQubitOperands.cpp
@@ -143,3 +143,5 @@ llvm::StringRef RemoveQubitOperandsPass::getDescription() const {
   return "Remove qubit arguments from subroutine defs and calls, replacing "
          "them with qubit declarations inside the subroutine body";
 }
+
+llvm::StringRef RemoveQubitOperandsPass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/ReorderCircuits.cpp
+++ b/lib/Dialect/QUIR/Transforms/ReorderCircuits.cpp
@@ -105,3 +105,5 @@ llvm::StringRef ReorderCircuitsPass::getArgument() const {
 llvm::StringRef ReorderCircuitsPass::getDescription() const {
   return "Move call_circuits later if possible.";
 }
+
+llvm::StringRef ReorderCircuitsPass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/ReorderMeasurements.cpp
+++ b/lib/Dialect/QUIR/Transforms/ReorderMeasurements.cpp
@@ -230,3 +230,5 @@ llvm::StringRef ReorderMeasurementsPass::getDescription() const {
   return "Move qubits to be as lexicograpically as late as possible without "
          "affecting the topological ordering.";
 }
+
+llvm::StringRef ReorderMeasurementsPass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/SubroutineCloning.cpp
+++ b/lib/Dialect/QUIR/Transforms/SubroutineCloning.cpp
@@ -200,3 +200,5 @@ llvm::StringRef SubroutineCloningPass::getDescription() const {
          "the qubit arguments of the cloned def are decorated with attributes "
          "listing the id that the qubit should have";
 }
+
+llvm::StringRef SubroutineCloningPass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/UnusedVariable.cpp
+++ b/lib/Dialect/QUIR/Transforms/UnusedVariable.cpp
@@ -97,3 +97,5 @@ llvm::StringRef UnusedVariablePass::getArgument() const {
 llvm::StringRef UnusedVariablePass::getDescription() const {
   return "Remove variables that are not outputs and do not have any loads/uses";
 }
+
+llvm::StringRef UnusedVariablePass::getName() const { return passName; }

--- a/lib/Dialect/QUIR/Transforms/VariableElimination.cpp
+++ b/lib/Dialect/QUIR/Transforms/VariableElimination.cpp
@@ -347,4 +347,6 @@ llvm::StringRef VariableEliminationPass::getDescription() const {
   return "Replace QUIR variables by memref and simplify with store-forwarding.";
 }
 
+llvm::StringRef VariableEliminationPass::getName() const { return passName; }
+
 } // namespace mlir::quir

--- a/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.cpp
+++ b/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.cpp
@@ -269,4 +269,6 @@ llvm::StringRef MockQUIRToStdPass::getDescription() const {
   return "Convert QUIR ops to std dialect";
 }
 
+llvm::StringRef MockQUIRToStdPass::getName() const { return passName; }
+
 } // namespace qssc::targets::systems::mock::conversion

--- a/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.h
+++ b/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.h
@@ -43,6 +43,9 @@ struct MockQUIRToStdPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+        "Mock QUIR To Std Pass (" + getArgument().str() + ")";
 };
 } // namespace qssc::targets::systems::mock::conversion
 

--- a/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.h
+++ b/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.h
@@ -44,8 +44,7 @@ struct MockQUIRToStdPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-        "Mock QUIR To Std Pass (" + getArgument().str() + ")";
+  std::string passName = "Mock QUIR To Std Pass (" + getArgument().str() + ")";
 };
 } // namespace qssc::targets::systems::mock::conversion
 

--- a/targets/systems/mock/Transforms/FunctionLocalization.cpp
+++ b/targets/systems/mock/Transforms/FunctionLocalization.cpp
@@ -444,3 +444,5 @@ llvm::StringRef MockFunctionLocalizationPass::getArgument() const {
 llvm::StringRef MockFunctionLocalizationPass::getDescription() const {
   return "Copy and localize functions for Mock code blocks.";
 }
+
+llvm::StringRef MockFunctionLocalizationPass::getName() const { return passName; }

--- a/targets/systems/mock/Transforms/FunctionLocalization.cpp
+++ b/targets/systems/mock/Transforms/FunctionLocalization.cpp
@@ -445,4 +445,6 @@ llvm::StringRef MockFunctionLocalizationPass::getDescription() const {
   return "Copy and localize functions for Mock code blocks.";
 }
 
-llvm::StringRef MockFunctionLocalizationPass::getName() const { return passName; }
+llvm::StringRef MockFunctionLocalizationPass::getName() const {
+  return passName;
+}

--- a/targets/systems/mock/Transforms/FunctionLocalization.h
+++ b/targets/systems/mock/Transforms/FunctionLocalization.h
@@ -61,6 +61,9 @@ struct MockFunctionLocalizationPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+      "Mock Function Localization Pass (" + getArgument().str() + ")";
 
 private:
   mlir::Operation *moduleOperation;

--- a/targets/systems/mock/Transforms/FunctionLocalization.h
+++ b/targets/systems/mock/Transforms/FunctionLocalization.h
@@ -62,7 +62,7 @@ struct MockFunctionLocalizationPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
+  std::string passName =
       "Mock Function Localization Pass (" + getArgument().str() + ")";
 
 private:

--- a/targets/systems/mock/Transforms/QubitLocalization.cpp
+++ b/targets/systems/mock/Transforms/QubitLocalization.cpp
@@ -883,3 +883,5 @@ llvm::StringRef MockQubitLocalizationPass::getArgument() const {
 llvm::StringRef MockQubitLocalizationPass::getDescription() const {
   return "Create modules for Mock code blocks.";
 }
+
+llvm::StringRef MockQubitLocalizationPass::getName() const { return passName; }

--- a/targets/systems/mock/Transforms/QubitLocalization.h
+++ b/targets/systems/mock/Transforms/QubitLocalization.h
@@ -107,6 +107,9 @@ struct MockQubitLocalizationPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+  std::string passName = 
+        "Mock Qubit Localization Pass (" + getArgument().str() + ")";
 }; // struct MockQubitLocalizationPass
 
 } // namespace qssc::targets::systems::mock

--- a/targets/systems/mock/Transforms/QubitLocalization.h
+++ b/targets/systems/mock/Transforms/QubitLocalization.h
@@ -108,8 +108,8 @@ struct MockQubitLocalizationPass
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;
-  std::string passName = 
-        "Mock Qubit Localization Pass (" + getArgument().str() + ")";
+  std::string passName =
+      "Mock Qubit Localization Pass (" + getArgument().str() + ")";
 }; // struct MockQubitLocalizationPass
 
 } // namespace qssc::targets::systems::mock


### PR DESCRIPTION
- Added a `passName` attribute to each MLIR pass.
- Added a `getName()` function to each MLIR pass.

With this PR the output generated by `--print-ir-before-all` will show the transform name and 
short form for all passes.
