### PR TITLE
Use find_program to locate llvm-config

### DIFF
--- a/cmake/apple-clang.cmake
+++ b/cmake/apple-clang.cmake
@@ -20,11 +20,18 @@ set (CXX_FLAGS
 
 option(DETECT_TARGET_TRIPLE "Automatically detect the target triple for clang" ON)
 if (DETECT_TARGET_TRIPLE)
-execute_process (
-    COMMAND bash -c "llvm-config --host-target | tr -d '\n'"
-    OUTPUT_VARIABLE LLVM_TARGET_TRIPLE
-)
-list(APPEND CXX_FLAGS "-target ${LLVM_TARGET_TRIPLE}")
+
+    find_program(LLVM_CONFIG_BIN llvm-config)
+    if (NOT LLVM_CONFIG_BIN)
+        message(FATAL_ERROR "llvm-config not found!")
+    endif()
+    message(STATUS "Using llvm-config: " ${LLVM_CONFIG_BIN})
+
+    execute_process (
+        COMMAND bash -c "${LLVM_CONFIG_BIN} --host-target | tr -d '\n'"
+        OUTPUT_VARIABLE LLVM_TARGET_TRIPLE
+    )
+    list(APPEND CXX_FLAGS "-target ${LLVM_TARGET_TRIPLE}")
 endif()
 
 list (JOIN CXX_FLAGS " " CXX_FLAGS_STR)

--- a/cmake/apple-clang.cmake
+++ b/cmake/apple-clang.cmake
@@ -20,7 +20,6 @@ set (CXX_FLAGS
 
 option(DETECT_TARGET_TRIPLE "Automatically detect the target triple for clang" ON)
 if (DETECT_TARGET_TRIPLE)
-
     find_program(LLVM_CONFIG_BIN llvm-config)
     if (NOT LLVM_CONFIG_BIN)
         message(FATAL_ERROR "llvm-config not found!")


### PR DESCRIPTION
The build may fail on Apple Silicon if the `llvm-config` program is not available on the path. This results in an empty `LLVM_TARGET_TRIPLE` variable and the error:
```
clang: error: argument unused during compilation: '-arch arm64' [-Werror,-Wunused-command-line-argument]
```

This PR uses `find_program` to locate the llvm-config binary. cmake will raise an error if the binary is not located. 