### PR TITLE
Add support for TimingManager

### DIFF
--- a/include/Frontend/OpenQASM3/OpenQASM3Frontend.h
+++ b/include/Frontend/OpenQASM3/OpenQASM3Frontend.h
@@ -48,7 +48,8 @@ namespace qssc::frontend::openqasm3 {
 llvm::Error parse(std::string const &source, bool sourceIsFilename,
                   bool emitRawAST, bool emitPrettyAST, bool emitMLIR,
                   mlir::ModuleOp newModule,
-                  std::optional<DiagnosticCallback> diagnosticCb, mlir::TimingScope &timing);
+                  std::optional<DiagnosticCallback> diagnosticCb,
+                  mlir::TimingScope &timing);
 
 }; // namespace qssc::frontend::openqasm3
 

--- a/include/Frontend/OpenQASM3/OpenQASM3Frontend.h
+++ b/include/Frontend/OpenQASM3/OpenQASM3Frontend.h
@@ -25,6 +25,7 @@
 #include "API/errors.h"
 
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/Timing.h"
 
 #include "llvm/Support/Error.h"
 
@@ -47,7 +48,7 @@ namespace qssc::frontend::openqasm3 {
 llvm::Error parse(std::string const &source, bool sourceIsFilename,
                   bool emitRawAST, bool emitPrettyAST, bool emitMLIR,
                   mlir::ModuleOp newModule,
-                  std::optional<DiagnosticCallback> diagnosticCb);
+                  std::optional<DiagnosticCallback> diagnosticCb, mlir::TimingScope &timing);
 
 }; // namespace qssc::frontend::openqasm3
 

--- a/include/HAL/Compile/TargetCompilationManager.h
+++ b/include/HAL/Compile/TargetCompilationManager.h
@@ -69,8 +69,9 @@ public:
   /// @brief Compile only at the MLIR level for the full target
   /// system.
   /// @param moduleOp The root module operation to compile for.
+  /// @param timing Root timing scope for tracking timing of payload compilation.
   /// This must not be specialized to a system already.
-  virtual llvm::Error compileMLIR(mlir::ModuleOp moduleOp) = 0;
+  virtual llvm::Error compileMLIR(mlir::ModuleOp moduleOp, mlir::TimingScope &timing) = 0;
 
   /// @brief Generate the full configured compilation pipeline
   /// for all targets of the base target system. This will also
@@ -78,21 +79,18 @@ public:
   /// @param moduleOp The root module operation to compile for.
   /// This must not be specialized to a system already.
   /// @param payload The payload to populate.
+  /// @param timing Root timing scope for tracking timing of payload compilation.
   /// @param doCompileMLIR Whether to call compileMLIR prior to compiling the
   /// payload. Defaults to true.
   virtual llvm::Error compilePayload(mlir::ModuleOp moduleOp,
                                      qssc::payload::Payload &payload,
+                                     mlir::TimingScope &timing,
                                      bool doCompileMLIR = true) = 0;
 
   void enableIRPrinting(bool printBeforeAllTargetPasses,
                         bool printAfterAllTargetPasses,
                         bool printBeforeAllTargetPayload,
                         bool printAfterTargetCompileFailure);
-
-  /// @brief Add an instrumentation to time the execution of target compilation.
-  /// Will be automatically propagated to child pass managers.
-  void setTimingScope(mlir::TimingScope &timingScope);
-  mlir::TimingScope getNestedTimingScope(llvm::StringRef name);
 
 protected:
   bool getPrintBeforeAllTargetPasses() { return printBeforeAllTargetPasses; }
@@ -114,11 +112,6 @@ private:
   bool printAfterAllTargetPasses = false;
   bool printBeforeAllTargetPayload = false;
   bool printAfterTargetCompileFailure = false;
-
-  /// Non-owning pointer of the timing scope.
-  /// TODO: This should be replaced with a PassManager
-  /// like instrumentation.
-  mlir::TimingScope* timingScope;
 
 }; // class TargetCompilationManager
 

--- a/include/HAL/Compile/TargetCompilationManager.h
+++ b/include/HAL/Compile/TargetCompilationManager.h
@@ -71,7 +71,7 @@ public:
   /// @param moduleOp The root module operation to compile for.
   /// @param timing Root timing scope for tracking timing of payload compilation.
   /// This must not be specialized to a system already.
-  virtual llvm::Error compileMLIR(mlir::ModuleOp moduleOp, mlir::TimingScope &timing) = 0;
+  virtual llvm::Error compileMLIR(mlir::ModuleOp moduleOp) = 0;
 
   /// @brief Generate the full configured compilation pipeline
   /// for all targets of the base target system. This will also
@@ -84,13 +84,15 @@ public:
   /// payload. Defaults to true.
   virtual llvm::Error compilePayload(mlir::ModuleOp moduleOp,
                                      qssc::payload::Payload &payload,
-                                     mlir::TimingScope &timing,
                                      bool doCompileMLIR = true) = 0;
 
   void enableIRPrinting(bool printBeforeAllTargetPasses,
                         bool printAfterAllTargetPasses,
                         bool printBeforeAllTargetPayload,
                         bool printAfterTargetCompileFailure);
+
+  void enableTiming(mlir::TimingScope &timingScope);
+
 
 protected:
   bool getPrintBeforeAllTargetPasses() { return printBeforeAllTargetPasses; }
@@ -104,6 +106,9 @@ protected:
   virtual void printIR(llvm::StringRef msg, mlir::Operation *op,
                        llvm::raw_ostream &out);
 
+  /// @brief Get a nested timer instance from the root timer
+  mlir::TimingScope getTimer(llvm::StringRef name);
+
 private:
   hal::TargetSystem &target;
   mlir::MLIRContext *context;
@@ -112,6 +117,11 @@ private:
   bool printAfterAllTargetPasses = false;
   bool printBeforeAllTargetPayload = false;
   bool printAfterTargetCompileFailure = false;
+
+  mlir::TimingScope rootTimer;
+
+
+
 
 }; // class TargetCompilationManager
 

--- a/include/HAL/Compile/TargetCompilationManager.h
+++ b/include/HAL/Compile/TargetCompilationManager.h
@@ -43,12 +43,14 @@ protected:
   TargetCompilationManager(hal::TargetSystem &target,
                            mlir::MLIRContext *context);
 
-  using WalkTargetModulesFunction =
-      std::function<llvm::Error(hal::Target *, mlir::ModuleOp, mlir::TimingScope &timing)>;
-  using WalkTargetFunction = std::function<llvm::Error(hal::Target *, mlir::TimingScope &timing)>;
+  using WalkTargetModulesFunction = std::function<llvm::Error(
+      hal::Target *, mlir::ModuleOp, mlir::TimingScope &timing)>;
+  using WalkTargetFunction =
+      std::function<llvm::Error(hal::Target *, mlir::TimingScope &timing)>;
 
   // Depth first walker for a target system
-  llvm::Error walkTarget(Target *target, mlir::TimingScope &timing, const WalkTargetFunction &walkFunc);
+  llvm::Error walkTarget(Target *target, mlir::TimingScope &timing,
+                         const WalkTargetFunction &walkFunc);
   // Depth first walker for a target system modules
   llvm::Error
   walkTargetModules(Target *target, mlir::ModuleOp targetModuleOp,
@@ -69,8 +71,8 @@ public:
   /// @brief Compile only at the MLIR level for the full target
   /// system.
   /// @param moduleOp The root module operation to compile for.
-  /// @param timing Root timing scope for tracking timing of payload compilation.
-  /// This must not be specialized to a system already.
+  /// @param timing Root timing scope for tracking timing of payload
+  /// compilation. This must not be specialized to a system already.
   virtual llvm::Error compileMLIR(mlir::ModuleOp moduleOp) = 0;
 
   /// @brief Generate the full configured compilation pipeline
@@ -79,7 +81,8 @@ public:
   /// @param moduleOp The root module operation to compile for.
   /// This must not be specialized to a system already.
   /// @param payload The payload to populate.
-  /// @param timing Root timing scope for tracking timing of payload compilation.
+  /// @param timing Root timing scope for tracking timing of payload
+  /// compilation.
   /// @param doCompileMLIR Whether to call compileMLIR prior to compiling the
   /// payload. Defaults to true.
   virtual llvm::Error compilePayload(mlir::ModuleOp moduleOp,
@@ -92,7 +95,7 @@ public:
                         bool printAfterTargetCompileFailure);
 
   void enableTiming(mlir::TimingScope &timingScope);
-
+  void disableTiming();
 
 protected:
   bool getPrintBeforeAllTargetPasses() { return printBeforeAllTargetPasses; }
@@ -119,9 +122,6 @@ private:
   bool printAfterTargetCompileFailure = false;
 
   mlir::TimingScope rootTimer;
-
-
-
 
 }; // class TargetCompilationManager
 

--- a/include/HAL/Compile/TargetCompilationManager.h
+++ b/include/HAL/Compile/TargetCompilationManager.h
@@ -106,7 +106,7 @@ protected:
   }
 
   /// Thread-safe implementation
-  virtual void printIR(llvm::StringRef msg, mlir::Operation *op,
+  virtual void printIR(llvm::Twine msg, mlir::Operation *op,
                        llvm::raw_ostream &out);
 
   /// @brief Get a nested timer instance from the root timer

--- a/include/HAL/Compile/TargetCompilationManager.h
+++ b/include/HAL/Compile/TargetCompilationManager.h
@@ -110,6 +110,7 @@ protected:
                        llvm::raw_ostream &out);
 
   /// @brief Get a nested timer instance from the root timer
+  /// @param name The name of the timing span
   mlir::TimingScope getTimer(llvm::StringRef name);
 
 private:

--- a/include/HAL/Compile/ThreadedCompilationManager.h
+++ b/include/HAL/Compile/ThreadedCompilationManager.h
@@ -107,11 +107,12 @@ private:
   mlir::PassManager &createTargetPassManager_(Target *target);
 
   /// Compiles the input module for a single target.
-  llvm::Error compileMLIRTarget_(Target &target, mlir::ModuleOp targetModuleOp);
+  llvm::Error compileMLIRTarget_(Target &target, mlir::ModuleOp targetModuleOp, mlir::TimingScope &timing);
   /// Compiles the input payload for a single target.
   llvm::Error compilePayloadTarget_(Target &target,
                                     mlir::ModuleOp targetModuleOp,
                                     qssc::payload::Payload &payload,
+                                    mlir::TimingScope &timing,
                                     bool doCompileMLIR);
 
   PMBuilder pmBuilder;

--- a/include/HAL/Compile/ThreadedCompilationManager.h
+++ b/include/HAL/Compile/ThreadedCompilationManager.h
@@ -46,12 +46,12 @@ protected:
   /// Threaded depth first walker for a target system using the current
   /// MLIRContext's threadpool.
   llvm::Error walkTargetThreaded(
-      Target *target,
+      Target *target, mlir::TimingScope &timing,
       const TargetCompilationManager::WalkTargetFunction &walkFunc);
   /// Threaded depth first walker for a target system modules using the current
   /// MLIRContext's threadpool.
   llvm::Error walkTargetModulesThreaded(
-      Target *target, mlir::ModuleOp targetModuleOp,
+      Target *target, mlir::ModuleOp targetModuleOp, mlir::TimingScope &timing,
       const TargetCompilationManager::WalkTargetModulesFunction &walkFunc,
       const TargetCompilationManager::WalkTargetModulesFunction
           &postChildrenCallbackFunc);

--- a/include/HAL/Compile/ThreadedCompilationManager.h
+++ b/include/HAL/Compile/ThreadedCompilationManager.h
@@ -56,7 +56,7 @@ protected:
       const TargetCompilationManager::WalkTargetModulesFunction
           &postChildrenCallbackFunc);
 
-  virtual void printIR(llvm::StringRef msg, mlir::Operation *op,
+  virtual void printIR(llvm::Twine msg, mlir::Operation *op,
                        llvm::raw_ostream &out) override;
 
 public:

--- a/include/HAL/Compile/ThreadedCompilationManager.h
+++ b/include/HAL/Compile/ThreadedCompilationManager.h
@@ -67,10 +67,9 @@ public:
   virtual ~ThreadedCompilationManager() = default;
   virtual const std::string getName() const override;
 
-  virtual llvm::Error compileMLIR(mlir::ModuleOp moduleOp, mlir::TimingScope &timing) override;
+  virtual llvm::Error compileMLIR(mlir::ModuleOp moduleOp) override;
   virtual llvm::Error compilePayload(mlir::ModuleOp moduleOp,
                                      qssc::payload::Payload &payload,
-                                     mlir::TimingScope &timing,
                                      bool doCompileMLIR = true) override;
 
   bool isMultithreadingEnabled() {
@@ -94,7 +93,7 @@ private:
 
   /// Prepare pass managers in a threaded way
   /// initializing them with the mlir context safely.
-  llvm::Error buildTargetPassManagers_(Target &target, mlir::TimingScope &timing);
+  llvm::Error buildTargetPassManagers_(Target &target);
   /// Threadsafe initialization of PM to work around
   /// non-threadsafe registration of dependent dialects.
   /// I (Thomas) believe this is related to the conversation here

--- a/include/HAL/Compile/ThreadedCompilationManager.h
+++ b/include/HAL/Compile/ThreadedCompilationManager.h
@@ -93,7 +93,8 @@ private:
 
   /// Prepare pass managers in a threaded way
   /// initializing them with the mlir context safely.
-  llvm::Error buildTargetPassManagers_(Target &target);
+  llvm::Error buildTargetPassManagers_(Target &target,
+                                       mlir::TimingScope &timing);
   /// Threadsafe initialization of PM to work around
   /// non-threadsafe registration of dependent dialects.
   /// I (Thomas) believe this is related to the conversation here
@@ -106,7 +107,8 @@ private:
   mlir::PassManager &createTargetPassManager_(Target *target);
 
   /// Compiles the input module for a single target.
-  llvm::Error compileMLIRTarget_(Target &target, mlir::ModuleOp targetModuleOp, mlir::TimingScope &timing);
+  llvm::Error compileMLIRTarget_(Target &target, mlir::ModuleOp targetModuleOp,
+                                 mlir::TimingScope &timing);
   /// Compiles the input payload for a single target.
   llvm::Error compilePayloadTarget_(Target &target,
                                     mlir::ModuleOp targetModuleOp,

--- a/include/HAL/Compile/ThreadedCompilationManager.h
+++ b/include/HAL/Compile/ThreadedCompilationManager.h
@@ -67,9 +67,10 @@ public:
   virtual ~ThreadedCompilationManager() = default;
   virtual const std::string getName() const override;
 
-  virtual llvm::Error compileMLIR(mlir::ModuleOp moduleOp) override;
+  virtual llvm::Error compileMLIR(mlir::ModuleOp moduleOp, mlir::TimingScope &timing) override;
   virtual llvm::Error compilePayload(mlir::ModuleOp moduleOp,
                                      qssc::payload::Payload &payload,
+                                     mlir::TimingScope &timing,
                                      bool doCompileMLIR = true) override;
 
   bool isMultithreadingEnabled() {
@@ -93,7 +94,7 @@ private:
 
   /// Prepare pass managers in a threaded way
   /// initializing them with the mlir context safely.
-  llvm::Error buildTargetPassManagers_(Target &target);
+  llvm::Error buildTargetPassManagers_(Target &target, mlir::TimingScope &timing);
   /// Threadsafe initialization of PM to work around
   /// non-threadsafe registration of dependent dialects.
   /// I (Thomas) believe this is related to the conversation here

--- a/include/HAL/TargetSystem.h
+++ b/include/HAL/TargetSystem.h
@@ -129,7 +129,17 @@ public:
 
   virtual ~Target() = default;
 
+  /// @brief Enable timing from this point for the target and its methods
+  /// @param timingScope the root timer to nest timers from.
+  void enableTiming(mlir::TimingScope &timingScope);
+  /// @brief Disable(stop) ongoing timers
+  void disableTiming();
+
 protected:
+  /// @brief Get a nested timer instance from the root timer
+  /// @param name The name of the timing span
+  mlir::TimingScope getTimer(llvm::StringRef name);
+
   std::string name;
 
   // parent is already owned by unique_ptr
@@ -139,6 +149,9 @@ protected:
 
   /// @brief Children targets storage.
   std::vector<std::unique_ptr<Target>> children_;
+
+private:
+  mlir::TimingScope rootTimer;
 };
 
 class TargetSystem : public Target {

--- a/include/HAL/TargetSystem.h
+++ b/include/HAL/TargetSystem.h
@@ -51,8 +51,12 @@ protected:
   };
 
 public:
-  virtual const std::string &getName() const { return name; }
+  virtual llvm::StringRef getName() const { return name; }
   virtual llvm::StringRef getDescription() const { return ""; }
+  /// @brief Get the Target resource directory sub-path for this target
+  /// which will be used for resolving external static resources at runtime
+  /// that are configured through the build system.
+  virtual llvm::StringRef getResourcePath() const { return getName(); }
   Target *getParent() { return parent; }
   const Target *getParent() const { return parent; }
 

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -149,7 +149,7 @@ llvm::Expected<qssc::hal::TargetSystem &>
 buildTarget_(MLIRContext *context, const qssc::config::QSSConfig &config,
              mlir::TimingScope &timing) {
 
-  mlir::TimingScope buildTargetTiming = timing.nest("build-target");
+  mlir::TimingScope const buildTargetTiming = timing.nest("build-target");
 
   const auto &targetName = config.getTargetName();
   const auto &targetConfigPath = config.getTargetConfigPath();
@@ -207,7 +207,8 @@ llvm::Error generateQEM_(
     return err;
   targetCompilationManager->disableTiming();
 
-  mlir::TimingScope writePayloadTiming = buildQEMTiming.nest("write-payload");
+  mlir::TimingScope const writePayloadTiming =
+      buildQEMTiming.nest("write-payload");
   if (config.shouldEmitPlaintextPayload())
     payload->writePlain(*ostream);
   else

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -199,9 +199,9 @@ llvm::Error generateQEM_(
     llvm::raw_ostream *ostream, mlir::TimingScope &timing) {
 
   mlir::TimingScope buildQEMTiming = timing.nest("build-qem");
-
+  targetCompilationManager->enableTiming(buildQEMTiming);
   if (auto err = targetCompilationManager->compilePayload(
-          moduleOp, *payload, buildQEMTiming,
+          moduleOp, *payload,
           /* doCompileMLIR=*/!config.shouldBypassPayloadTargetCompilation()))
     return err;
 
@@ -270,7 +270,8 @@ llvm::Error emitMLIR_(
   if (config.shouldCompileTargetIR()) {
     // Check if we can run the target compilation scheduler.
     if (config.shouldAddTargetPasses()) {
-      if (auto err = targetCompilationManager.compileMLIR(moduleOp, emitMlirTiming))
+      targetCompilationManager.enableTiming(emitMlirTiming);
+      if (auto err = targetCompilationManager.compileMLIR(moduleOp))
         return llvm::joinErrors(
             llvm::createStringError(llvm::inconvertibleErrorCode(),
                                     "Failure while preparing target passes"),

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -203,7 +203,7 @@ llvm::Error generateQEM_(
   mlir::TimingScope buildQEMTiming = timing.nest("build-qem");
 
   if (auto err = targetCompilationManager->compilePayload(
-          moduleOp, *payload,
+          moduleOp, *payload, buildQEMTiming,
           /* doCompileMLIR=*/!config.shouldBypassPayloadTargetCompilation()))
     return err;
 
@@ -276,7 +276,7 @@ llvm::Error emitMLIR_(
   if (config.shouldCompileTargetIR()) {
     // Check if we can run the target compilation scheduler.
     if (config.shouldAddTargetPasses()) {
-      if (auto err = targetCompilationManager.compileMLIR(moduleOp))
+      if (auto err = targetCompilationManager.compileMLIR(moduleOp, emitMlirTiming))
         return llvm::joinErrors(
             llvm::createStringError(llvm::inconvertibleErrorCode(),
                                     "Failure while preparing target passes"),

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -183,8 +183,6 @@ buildTarget_(MLIRContext *context, const qssc::config::QSSConfig &config, mlir::
         std::move(err));
   }
 
-  buildTargetTiming.stop();
-
   return *created.get();
 }
 
@@ -212,10 +210,6 @@ llvm::Error generateQEM_(
     payload->writePlain(*ostream);
   else
     payload->write(*ostream);
-
-  writePayloadTiming.stop();
-
-  buildQEMTiming.stop();
 
   return llvm::Error::success();
 }
@@ -287,7 +281,6 @@ llvm::Error emitMLIR_(
   // Print the output.
   dumpMLIR_(ostream, moduleOp);
 
-  emitMlirTiming.stop();
   return llvm::Error::success();
 }
 
@@ -546,8 +539,6 @@ llvm::Error compile_(int argc, char const **argv, std::string *outputString,
             config.getEmitAction() == EmitAction::ASTPretty,
             config.getEmitAction() >= EmitAction::MLIR, moduleOp, diagnosticCb, loadQASM3Timing))
       return frontendError;
-
-    loadQASM3Timing.stop();
 
     if (config.getEmitAction() < EmitAction::MLIR)
       return llvm::Error::success();

--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -33,6 +33,7 @@
 #include "mlir/IR/Verifier.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/LogicalResult.h"
+#include "mlir/Support/Timing.h"
 
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/CommandLine.h"

--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -122,7 +122,6 @@ llvm::Error qssc::frontend::openqasm3::parse(
     std::optional<qssc::DiagnosticCallback> diagnosticCallback,
     mlir::TimingScope &timing) {
 
-
   mlir::TimingScope qasm3ParseTiming = timing.nest("parse-qasm3");
 
   // The QASM parser can only be called from a single thread.

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -133,7 +133,7 @@ void TargetCompilationManager::enableIRPrinting(
   this->printAfterTargetCompileFailure = printAfterTargetCompileFailure;
 }
 
-void TargetCompilationManager::printIR(llvm::StringRef msg, mlir::Operation *op,
+void TargetCompilationManager::printIR(llvm::Twine msg, mlir::Operation *op,
                                        llvm::raw_ostream &out) {
   out << "// -----// ";
   out << msg;

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -143,11 +143,3 @@ void TargetCompilationManager::printIR(llvm::StringRef msg, mlir::Operation *op,
   op->print(out, flags.useLocalScope());
   out << "\n";
 }
-
-// TODO: This should be replaced by a PassManager like instrumentation framework
-void TargetCompilationManager::setTimingScope(mlir::TimingScope &timing) {
-  timingScope = &timing;
-}
-mlir::TimingScope TargetCompilationManager::getNestedTimingScope(llvm::StringRef name) {
-  return timingScope->nest(name);
-}

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Support/Timing.h"
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ManagedStatic.h"

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -143,3 +143,11 @@ void TargetCompilationManager::printIR(llvm::StringRef msg, mlir::Operation *op,
   op->print(out, flags.useLocalScope());
   out << "\n";
 }
+
+void TargetCompilationManager::enableTiming(mlir::TimingScope &timingScope) {
+  rootTimer = timingScope;
+}
+
+mlir::TimingScope TargetCompilationManager::getTimer(llvm::StringRef name) {
+  return rootTimer.nest(name);
+}

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -19,6 +19,7 @@
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/Support/LogicalResult.h"
+#include "mlir/Support/Timing.h"
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/CommandLine.h"

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -83,8 +83,7 @@ TargetCompilationManager::TargetCompilationManager(
     : target(target), context(context) {}
 
 llvm::Error TargetCompilationManager::walkTargetModules(
-    Target *target, mlir::ModuleOp targetModuleOp,
-    mlir::TimingScope &timing,
+    Target *target, mlir::ModuleOp targetModuleOp, mlir::TimingScope &timing,
     const WalkTargetModulesFunction &walkFunc,
     const WalkTargetModulesFunction &postChildrenCallbackFunc) {
   // Call the input function for the walk on the target
@@ -145,8 +144,11 @@ void TargetCompilationManager::printIR(llvm::StringRef msg, mlir::Operation *op,
 }
 
 void TargetCompilationManager::enableTiming(mlir::TimingScope &timingScope) {
-  rootTimer = timingScope;
+  rootTimer = timingScope.nest("TargetCompilationManager");
+  rootTimer.hide();
 }
+
+void TargetCompilationManager::disableTiming() { rootTimer.stop(); }
 
 mlir::TimingScope TargetCompilationManager::getTimer(llvm::StringRef name) {
   return rootTimer.nest(name);

--- a/lib/HAL/Compile/ThreadedCompilationManager.cpp
+++ b/lib/HAL/Compile/ThreadedCompilationManager.cpp
@@ -30,6 +30,7 @@
 #include "mlir/Support/Timing.h"
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 

--- a/lib/HAL/Compile/ThreadedCompilationManager.cpp
+++ b/lib/HAL/Compile/ThreadedCompilationManager.cpp
@@ -147,9 +147,9 @@ llvm::Error ThreadedCompilationManager::walkTargetThreaded(
 }
 
 llvm::Error
-ThreadedCompilationManager::buildTargetPassManagers_(Target &target, mlir::TimingScope &timing) {
+ThreadedCompilationManager::buildTargetPassManagers_(Target &target) {
 
-  auto buildPMTiming = timing.nest("build-target-pass-managers");
+  auto buildPMTiming = getTimer("build-target-pass-managers");
 
   // Create dummy timing scope for pass manager building
   // as this is not significant enough to report for each individual target.
@@ -209,15 +209,15 @@ ThreadedCompilationManager::createTargetPassManager_(Target *target) {
   return targetPassManagers_.emplace(target, getContext()).first->second;
 }
 
-llvm::Error ThreadedCompilationManager::compileMLIR(mlir::ModuleOp moduleOp, mlir::TimingScope &timing) {
+llvm::Error ThreadedCompilationManager::compileMLIR(mlir::ModuleOp moduleOp) {
 
-  auto compileMLIRTiming = timing.nest("compile-mlir");
+  auto compileMLIRTiming = getTimer("compile-mlir");
 
   auto &target = getTargetSystem();
 
   /// Build target pass managers prior to compilation
   /// to ensure thread safety
-  if (auto err = buildTargetPassManagers_(target, compileMLIRTiming))
+  if (auto err = buildTargetPassManagers_(target))
     return err;
 
   auto threadedCompileMLIRTarget =
@@ -272,16 +272,15 @@ ThreadedCompilationManager::compileMLIRTarget_(Target &target,
 llvm::Error
 ThreadedCompilationManager::compilePayload(mlir::ModuleOp moduleOp,
                                            qssc::payload::Payload &payload,
-                                           mlir::TimingScope &timing,
                                            bool doCompileMLIR) {
 
-  auto compilePayloadTiming = timing.nest("compile-payload");
+  auto compilePayloadTiming = getTimer("compile-payload");
 
   auto &target = getTargetSystem();
 
   /// Build target pass managers prior to compilation
   /// to ensure thread safety
-  if (auto err = buildTargetPassManagers_(target, compilePayloadTiming))
+  if (auto err = buildTargetPassManagers_(target))
     return err;
 
   auto threadedCompilePayloadTarget =

--- a/lib/HAL/Compile/ThreadedCompilationManager.cpp
+++ b/lib/HAL/Compile/ThreadedCompilationManager.cpp
@@ -298,7 +298,7 @@ ThreadedCompilationManager::compilePayload(mlir::ModuleOp moduleOp,
       [&](hal::Target *target, mlir::ModuleOp targetModuleOp,
           mlir::TimingScope &timing) -> llvm::Error {
     auto emitToPayloadTiming = timing.nest("emit-to-payload-post-children");
-    // target->enableTiming(emitToPayloadTiming);
+    target->enableTiming(emitToPayloadTiming);
     if (auto err = target->emitToPayloadPostChildren(targetModuleOp, payload))
       return err;
     target->disableTiming();
@@ -340,8 +340,7 @@ llvm::Error ThreadedCompilationManager::compilePayloadTarget_(
   return llvm::Error::success();
 }
 
-void ThreadedCompilationManager::printIR(llvm::StringRef msg,
-                                         mlir::Operation *op,
+void ThreadedCompilationManager::printIR(llvm::Twine msg, mlir::Operation *op,
                                          llvm::raw_ostream &out) {
   const std::lock_guard<std::mutex> lock(printIRMutex_);
   TargetCompilationManager::printIR(msg, op, out);

--- a/lib/HAL/TargetSystem.cpp
+++ b/lib/HAL/TargetSystem.cpp
@@ -20,7 +20,9 @@
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/Timing.h"
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 
 #include <string>
@@ -36,6 +38,17 @@ Target::Target(std::string name, Target *parent)
 llvm::Error Target::emitToPayloadPostChildren(mlir::ModuleOp targetModuleOp,
                                               payload::Payload &payload) {
   return llvm::Error::success();
+}
+
+void Target::enableTiming(mlir::TimingScope &timingScope) {
+  rootTimer = timingScope.nest(getName());
+  rootTimer.hide();
+}
+
+void Target::disableTiming() { rootTimer.stop(); }
+
+mlir::TimingScope Target::getTimer(llvm::StringRef name) {
+  return rootTimer.nest(name);
 }
 
 TargetSystem::TargetSystem(std::string name, Target *parent)

--- a/lib/QSSC.cpp
+++ b/lib/QSSC.cpp
@@ -72,6 +72,6 @@ qssc::getTargetResourcesDir(qssc::hal::Target const *target) {
   // resource directory
   llvm::SmallString<128> path(getResourcesDir());
 
-  llvm::sys::path::append(path, "targets", target->getName());
+  llvm::sys::path::append(path, "targets", target->getResourcePath());
   return path;
 }

--- a/releasenotes/notes/add-timing-manager-support-9de5e2407fc95330.yaml
+++ b/releasenotes/notes/add-timing-manager-support-9de5e2407fc95330.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Support has been added for LLVM 17's TimingManager to the qss-compiler
+    tool. This includes support for timing integration in the TargetCompilationManager
+    and targets themselves. This allows fine-grained tracking of compilation
+    across targets and pass managers.

--- a/targets/systems/mock/test/static/integration/mlir/mlir-timing.mlir
+++ b/targets/systems/mock/test/static/integration/mlir/mlir-timing.mlir
@@ -38,6 +38,13 @@ func.func @main () -> i32 {
 // CHECK:               Canonicalizer
 // CHECK:               LLVMLegalizeForExport
 // CHECK:             emit-to-payload
+// CHECK:               build-llvm-payload
+// CHECK:                  init-llvm
+// CHECK:                  translate-to-llvm-mlir-dialect
+// CHECK:                  mlir-to-llvm-ir
+// CHECK:                  optimize-llvm
+// CHECK:                  build-object-file
+// CHECK:                  emit-binary
 // CHECK:             emit-to-payload-post-children
 // CHECK:           MockDrive_0
 // CHECK:             passes

--- a/targets/systems/mock/test/static/integration/mlir/mlir-timing.mlir
+++ b/targets/systems/mock/test/static/integration/mlir/mlir-timing.mlir
@@ -1,0 +1,57 @@
+// Redirect stderr (where timing is printed to) to stdout and then stdout to filecheck
+// RUN: qss-compiler %s --target mock --config %TEST_CFG --emit=qem --plaintext-payload --mlir-timing --mlir-disable-threading 2>&1 >/dev/null | FileCheck %s
+// (C) Copyright IBM 2024.
+//
+// This code is part of Qiskit.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+// Check timing output of empty payload.
+func.func @main () -> i32 {
+  %zero = arith.constant 0 : i32
+  return %zero : i32
+}
+
+
+// CHECK: build-config
+// CHECK: build-target
+// CHECK: parse-mlir
+// CHECK: command-line-passes
+// CHECK: build-qem
+// CHECK:   compile-payload
+// CHECK:     build-target-pass-managers
+// CHECK:     compile-system
+// CHECK:       MockSystem
+// CHECK:         passes
+// CHECK:           Canonicalizer
+// CHECK:         emit-to-payload
+// CHECK:         children
+// CHECK:           MockController
+// CHECK:             passes
+// CHECK:               qssc::targets::systems::mock::conversion::MockQUIRToStdPass
+// CHECK:               Canonicalizer
+// CHECK:               LLVMLegalizeForExport
+// CHECK:             emit-to-payload
+// CHECK:             emit-to-payload-post-children
+// CHECK:           MockDrive_0
+// CHECK:             passes
+// CHECK:             emit-to-payload
+// CHECK:             emit-to-payload-post-children
+// CHECK:           MockDrive_1
+// CHECK:             passes
+// CHECK:             emit-to-payload
+// CHECK:             emit-to-payload-post-children
+// CHECK:           MockAcquire_0
+// CHECK:             passes
+// CHECK:             emit-to-payload
+// CHECK:             emit-to-payload-post-children
+// CHECK:         emit-to-payload-post-children
+// CHECK:   write-payload
+// CHECK: Rest
+// CHECK: Total


### PR DESCRIPTION
Introduces support for the TimingManager which was a part of LLVM 17. This enables time tracing of (parallel) compilation across target systems. For example this is a report from the mock target.

```
===-------------------------------------------------------------------------===
                         ... Execution time report ...
===-------------------------------------------------------------------------===
  Total Execution Time: 0.0089 seconds

  ----User Time----  ----Wall Time----  ----Name----
    0.0000 (  0.1%)    0.0000 (  0.2%)  build-config
    0.0001 (  0.7%)    0.0001 (  1.3%)  build-target
    0.0004 (  2.7%)    0.0004 (  4.7%)  parse-mlir
    0.0000 (  0.1%)    0.0000 (  0.1%)  command-line-passes
    0.0143 ( 91.6%)    0.0076 ( 85.3%)  build-qem
    0.0142 ( 91.0%)    0.0075 ( 84.2%)    compile-payload
    0.0011 (  7.2%)    0.0011 ( 12.7%)      build-target-pass-managers
    0.0130 ( 83.5%)    0.0063 ( 71.0%)      compile-system
    0.0130 ( 83.5%)    0.0063 ( 71.0%)        MockSystem
    0.0019 ( 12.2%)    0.0010 ( 10.7%)          passes
    0.0001 (  0.4%)    0.0001 (  0.6%)            Canonicalizer
    0.0000 (  0.2%)    0.0000 (  0.3%)            mlir::quir::BreakResetPass
    0.0000 (  0.1%)    0.0000 (  0.1%)            mlir::quir::SubroutineCloningPass
    0.0000 (  0.0%)    0.0000 (  0.0%)            mlir::quir::RemoveQubitOperandsPass
    0.0000 (  0.0%)    0.0000 (  0.1%)            mlir::quir::ClassicalOnlyDetectionPass
    0.0001 (  0.5%)    0.0001 (  0.9%)            qssc::targets::systems::mock::MockQubitLocalizationPass
    0.0000 (  0.0%)    0.0000 (  0.0%)            qssc::targets::systems::mock::SymbolTableBuildPass
    0.0009 (  6.1%)    0.0005 (  5.4%)            'builtin.module' Pipeline
    0.0007 (  4.2%)    0.0004 (  4.6%)              qssc::targets::systems::mock::MockFunctionLocalizationPass
    0.0000 (  0.1%)    0.0000 (  0.1%)              mlir::quir::FunctionArgumentSpecializationPass
    0.0000 (  0.0%)    0.0000 (  0.0%)          emit-to-payload
    0.0110 ( 70.7%)    0.0053 ( 59.3%)          children
    0.0052 ( 33.1%)    0.0052 ( 58.2%)            MockController
    0.0004 (  2.5%)    0.0004 (  4.5%)              passes
    0.0002 (  1.3%)    0.0002 (  2.3%)                qssc::targets::systems::mock::conversion::MockQUIRToStdPass
    0.0000 (  0.1%)    0.0000 (  0.2%)                Canonicalizer
    0.0000 (  0.0%)    0.0000 (  0.0%)                LLVMLegalizeForExport
    0.0048 ( 30.5%)    0.0048 ( 53.6%)              emit-to-payload
    0.0000 (  0.0%)    0.0000 (  0.0%)              emit-to-payload-post-children
    0.0002 (  1.5%)    0.0002 (  2.6%)            MockDrive_0
    0.0000 (  0.0%)    0.0000 (  0.1%)              passes
    0.0002 (  1.4%)    0.0002 (  2.4%)              emit-to-payload
    0.0000 (  0.0%)    0.0000 (  0.0%)              emit-to-payload-post-children
    0.0002 (  1.4%)    0.0002 (  2.5%)            MockAcquire_0
    0.0000 (  0.0%)    0.0000 (  0.0%)              passes
    0.0002 (  1.3%)    0.0002 (  2.3%)              emit-to-payload
    0.0000 (  0.0%)    0.0000 (  0.0%)              emit-to-payload-post-children
    0.0001 (  1.0%)    0.0001 (  1.7%)            MockDrive_1
    0.0000 (  0.1%)    0.0000 (  0.3%)              passes
    0.0001 (  0.6%)    0.0001 (  1.1%)              emit-to-payload
    0.0000 (  0.0%)    0.0000 (  0.0%)              emit-to-payload-post-children
    0.0000 (  0.0%)    0.0000 (  0.0%)          emit-to-payload-post-children
    0.0001 (  0.6%)    0.0001 (  1.0%)    write-payload
    0.0007 (  4.8%)    0.0007 (  8.4%)  Rest
    0.0156 (100.0%)    0.0089 (100.0%)  Total
```