### PR TITLE
Switch to bottom up traversal in parallel reset

### DIFF
--- a/lib/Dialect/QUIR/Transforms/MergeParallelResets.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeParallelResets.cpp
@@ -104,9 +104,8 @@ void MergeResetsLexicographicPass::runOnOperation() {
   mlir::RewritePatternSet patterns(&getContext());
   mlir::GreedyRewriteConfig config;
 
-  // use cheaper top-down traversal (in this case, bottom-up would not behave
-  // any differently)
-  config.useTopDownTraversal = true;
+  // Bottom up traversal is 3x as fast
+  config.useTopDownTraversal = false;
   // Disable to improve performance
   config.enableRegionSimplification = false;
 
@@ -214,9 +213,8 @@ void MergeResetsTopologicalPass::runOnOperation() {
   mlir::RewritePatternSet patterns(&getContext());
   mlir::GreedyRewriteConfig config;
 
-  // use cheaper top-down traversal (in this case, bottom-up would not behave
-  // any differently)
-  config.useTopDownTraversal = true;
+  // Bottom up traversal is 3x as fast
+  config.useTopDownTraversal = false;
   // Disable to improve performance
   config.enableRegionSimplification = false;
 

--- a/releasenotes/notes/parallel-reset-bottom-up-traversal-0ad69d49e9d6e6e1.yaml
+++ b/releasenotes/notes/parallel-reset-bottom-up-traversal-0ad69d49e9d6e6e1.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Parallel reset merging passes have been switched to a bottom up traversal
+    as this is roughly 3x faster.


### PR DESCRIPTION
Yields a roughly 3x performance improvement on my local machine.