### PR TITLE
Disable test-config.tst when using build with asserts.

### DIFF
--- a/test/Config/test-config.tst
+++ b/test/Config/test-config.tst
@@ -2,6 +2,7 @@
 // RUN:          --add-target-passes=false --verbosity=info --show-config | FileCheck %s --check-prefix CLI
 // RUN: QSSC_TARGET_NAME="MockEnv" QSSC_TARGET_CONFIG_PATH="path/to/config/Env" QSSC_VERBOSITY=DEBUG \
 // RUN:          qss-compiler --allow-unregistered-dialect=false --add-target-passes=false --show-config | FileCheck %s --check-prefix ENV
+// REQUIRES: !asserts
 
 // CLI: inputSource: -
 // CLI: directInput: 0


### PR DESCRIPTION
This test is failing for debug builds as the output checks whether verification is enabled (which it is for debug builds). 
The REQUIRES will disable this test when asserts are enabled.