### PR TITLE
Register LLVM Dialect with the context.

### DIFF
--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -55,6 +55,8 @@
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Support/Timing.h"
+#include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Tools/ParseUtilities.h"
 
 #include "llvm/ADT/StringRef.h"
@@ -431,6 +433,11 @@ llvm::Error compile_(int argc, char const **argv, std::string *outputString,
   context.appendDialectRegistry(registry);
   context.allowUnregisteredDialects(config.shouldAllowUnregisteredDialects());
   context.printOpOnDiagnostic(!config.shouldVerifyDiagnostics());
+
+  // Register LLVM dialect and all infrastructure required for translation to
+  // LLVM IR
+  mlir::registerBuiltinDialectTranslation(context);
+  mlir::registerLLVMDialectTranslation(context);
 
   if (config.shouldShowDialects()) {
     showDialects_(registry);


### PR DESCRIPTION
We need to register the LLVM Dialect as a valid translation target. 
This had previously been done later in the pipeline, but since registering dialects is not thread safe, we need to register it earlier before we start the ThreadedCompilationManager. 