### PR TITLE
Add getName method to MLIR passes

### DIFF
--- a/include/Conversion/QUIRToPulse/LoadPulseCals.h
+++ b/include/Conversion/QUIRToPulse/LoadPulseCals.h
@@ -57,6 +57,7 @@ struct LoadPulseCalsPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 
   // optionally, one can override the path to default pulse calibrations with
   // this option; e.g., to write a LIT test one can invoke this pass with

--- a/include/Conversion/QUIRToPulse/QUIRToPulse.h
+++ b/include/Conversion/QUIRToPulse/QUIRToPulse.h
@@ -49,6 +49,7 @@ struct QUIRToPulsePass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 
   // optionally, one can override the path to pulse waveform container file with
   // this option; e.g., to write a LIT test one can invoke this pass with

--- a/include/Dialect/OQ3/Transforms/LimitCBitWidth.h
+++ b/include/Dialect/OQ3/Transforms/LimitCBitWidth.h
@@ -38,6 +38,7 @@ public:
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 
   Option<uint> maxCBitWidthOption{
       *this, "max-cbit-width",

--- a/include/Dialect/Pulse/Transforms/ClassicalOnlyDetection.h
+++ b/include/Dialect/Pulse/Transforms/ClassicalOnlyDetection.h
@@ -37,6 +37,7 @@ struct ClassicalOnlyDetectionPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // end struct ClassicalOnlyDetectionPass
 
 } // namespace mlir::pulse

--- a/include/Dialect/Pulse/Transforms/InlineRegion.h
+++ b/include/Dialect/Pulse/Transforms/InlineRegion.h
@@ -33,6 +33,7 @@ public:
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 };
 
 } // namespace mlir::pulse

--- a/include/Dialect/Pulse/Transforms/MergeDelays.h
+++ b/include/Dialect/Pulse/Transforms/MergeDelays.h
@@ -36,6 +36,7 @@ public:
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 };
 } // namespace mlir::pulse
 

--- a/include/Dialect/Pulse/Transforms/RemoveUnusedArguments.h
+++ b/include/Dialect/Pulse/Transforms/RemoveUnusedArguments.h
@@ -37,6 +37,7 @@ public:
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 };
 } // namespace mlir::pulse
 

--- a/include/Dialect/Pulse/Transforms/SchedulePort.h
+++ b/include/Dialect/Pulse/Transforms/SchedulePort.h
@@ -45,6 +45,7 @@ public:
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 
 private:
   using mixedFrameMap_t = std::map<uint32_t, std::vector<Operation *>>;

--- a/include/Dialect/Pulse/Transforms/Scheduling.h
+++ b/include/Dialect/Pulse/Transforms/Scheduling.h
@@ -50,6 +50,7 @@ public:
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 
   // optionally, one can override the scheduling method with this option
   Option<std::string> schedulingMethod{

--- a/include/Dialect/Pulse/Transforms/SystemCreation.h
+++ b/include/Dialect/Pulse/Transforms/SystemCreation.h
@@ -51,6 +51,7 @@ struct SystemCreationPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 };
 
 struct SystemPlotPass : public PassWrapper<SystemPlotPass, OperationPass<>> {
@@ -67,6 +68,7 @@ struct SystemPlotPass : public PassWrapper<SystemPlotPass, OperationPass<>> {
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 };
 
 } // namespace mlir::pulse

--- a/include/Dialect/QCS/Utils/ParameterInitialValueAnalysis.h
+++ b/include/Dialect/QCS/Utils/ParameterInitialValueAnalysis.h
@@ -59,6 +59,7 @@ struct ParameterInitialValueAnalysisPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct ParameterInitialValueAnalysisPass
 
 // TODO: move registerQCSPasses to separate header if additional passes

--- a/include/Dialect/QUIR/IR/QUIRTestInterfaces.h
+++ b/include/Dialect/QUIR/IR/QUIRTestInterfaces.h
@@ -35,6 +35,7 @@ struct TestQubitOpInterfacePass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 };
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/AddShotLoop.h
+++ b/include/Dialect/QUIR/Transforms/AddShotLoop.h
@@ -53,6 +53,7 @@ struct AddShotLoopPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 
   void getDependentDialects(mlir::DialectRegistry &registry) const override {
     registry.insert<mlir::quir::QUIRDialect>();

--- a/include/Dialect/QUIR/Transforms/AngleConversion.h
+++ b/include/Dialect/QUIR/Transforms/AngleConversion.h
@@ -36,6 +36,7 @@ struct QUIRAngleConversionPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 
 private:
   std::unordered_map<std::string, mlir::func::FuncOp> functionOps;

--- a/include/Dialect/QUIR/Transforms/BreakReset.h
+++ b/include/Dialect/QUIR/Transforms/BreakReset.h
@@ -52,6 +52,7 @@ struct BreakResetPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct BreakResetPass
 } // namespace mlir::quir
 

--- a/include/Dialect/QUIR/Transforms/ConvertDurationUnits.h
+++ b/include/Dialect/QUIR/Transforms/ConvertDurationUnits.h
@@ -73,6 +73,7 @@ struct ConvertDurationUnitsPass
   virtual double getDtTimestep();
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 
 }; // struct ConvertDurationUnitsPass
 

--- a/include/Dialect/QUIR/Transforms/FunctionArgumentSpecialization.h
+++ b/include/Dialect/QUIR/Transforms/FunctionArgumentSpecialization.h
@@ -48,6 +48,7 @@ struct FunctionArgumentSpecializationPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct FunctionArgumentSpecializationPass
 } // namespace mlir::quir
 

--- a/include/Dialect/QUIR/Transforms/LoadElimination.h
+++ b/include/Dialect/QUIR/Transforms/LoadElimination.h
@@ -31,6 +31,7 @@ struct LoadEliminationPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct LoadEliminationPass
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/MergeCircuits.h
+++ b/include/Dialect/QUIR/Transforms/MergeCircuits.h
@@ -43,6 +43,7 @@ struct MergeCircuitsPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct MergeCircuitsPass
 } // namespace mlir::quir
 #endif // QUIR_MERGE_CIRCUITS_H

--- a/include/Dialect/QUIR/Transforms/MergeMeasures.h
+++ b/include/Dialect/QUIR/Transforms/MergeMeasures.h
@@ -34,6 +34,7 @@ struct MergeMeasuresLexographicalPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct MergeMeasuresLexographicalPass
 
 /// @brief Merge together measures in a circuit that are topologically
@@ -44,6 +45,7 @@ struct MergeMeasuresTopologicalPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct MergeMeasuresTopologicalPass
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/MergeParallelResets.h
+++ b/include/Dialect/QUIR/Transforms/MergeParallelResets.h
@@ -38,6 +38,7 @@ struct MergeResetsLexicographicPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct MergeResetsLexicographicPass
 
 /// This pass merges qubit reset operations that can be parallelized into a
@@ -52,6 +53,7 @@ struct MergeResetsTopologicalPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct MergeResetsTopologicalPass
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/Passes.h
+++ b/include/Dialect/QUIR/Transforms/Passes.h
@@ -53,6 +53,7 @@ struct ClassicalOnlyDetectionPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // end struct ClassicalOnlyDetectionPass
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.h
+++ b/include/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.h
@@ -70,6 +70,7 @@ struct QUIRCircuitAnalysisPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // QUIRCircuitAnalysisPass
 
 llvm::Expected<double>

--- a/include/Dialect/QUIR/Transforms/QuantumDecoration.h
+++ b/include/Dialect/QUIR/Transforms/QuantumDecoration.h
@@ -51,6 +51,7 @@ struct QuantumDecorationPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // QuantumDecorationPass
 } // namespace mlir::quir
 

--- a/include/Dialect/QUIR/Transforms/RemoveQubitOperands.h
+++ b/include/Dialect/QUIR/Transforms/RemoveQubitOperands.h
@@ -49,6 +49,7 @@ struct RemoveQubitOperandsPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct SubroutineCloningPass
 } // namespace mlir::quir
 

--- a/include/Dialect/QUIR/Transforms/ReorderCircuits.h
+++ b/include/Dialect/QUIR/Transforms/ReorderCircuits.h
@@ -32,6 +32,7 @@ struct ReorderCircuitsPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct ReorderCircuitsPass
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/ReorderMeasurements.h
+++ b/include/Dialect/QUIR/Transforms/ReorderMeasurements.h
@@ -32,6 +32,7 @@ struct ReorderMeasurementsPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct ReorderMeasurementsPass
 
 } // namespace mlir::quir

--- a/include/Dialect/QUIR/Transforms/SubroutineCloning.h
+++ b/include/Dialect/QUIR/Transforms/SubroutineCloning.h
@@ -55,6 +55,7 @@ struct SubroutineCloningPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct SubroutineCloningPass
 } // namespace mlir::quir
 

--- a/include/Dialect/QUIR/Transforms/UnusedVariable.h
+++ b/include/Dialect/QUIR/Transforms/UnusedVariable.h
@@ -37,6 +37,7 @@ struct UnusedVariablePass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct UnusedVariablePass
 } // namespace mlir::quir
 

--- a/include/Dialect/QUIR/Transforms/VariableElimination.h
+++ b/include/Dialect/QUIR/Transforms/VariableElimination.h
@@ -39,6 +39,7 @@ struct VariableEliminationPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 
   void getDependentDialects(mlir::DialectRegistry &registry) const override {
     registry.insert<mlir::memref::MemRefDialect>();

--- a/lib/Conversion/QUIRToPulse/LoadPulseCals.cpp
+++ b/lib/Conversion/QUIRToPulse/LoadPulseCals.cpp
@@ -664,3 +664,7 @@ llvm::StringRef LoadPulseCalsPass::getArgument() const {
 llvm::StringRef LoadPulseCalsPass::getDescription() const {
   return "Load the pulse calibrations, and add them to module";
 }
+
+llvm::StringRef LoadPulseCalsPass::getName() const {
+  return "Load Pulse Calibrations Pass";
+}

--- a/lib/Conversion/QUIRToPulse/QUIRToPulse.cpp
+++ b/lib/Conversion/QUIRToPulse/QUIRToPulse.cpp
@@ -700,3 +700,7 @@ llvm::StringRef QUIRToPulsePass::getArgument() const { return "quir-to-pulse"; }
 llvm::StringRef QUIRToPulsePass::getDescription() const {
   return "Convert quir circuit to pulse sequence.";
 }
+
+llvm::StringRef QUIRToPulsePass::getName() const {
+  return "QUIR to Pulse Pass";
+}

--- a/lib/Dialect/OQ3/Transforms/LimitCBitWidth.cpp
+++ b/lib/Dialect/OQ3/Transforms/LimitCBitWidth.cpp
@@ -258,3 +258,7 @@ llvm::StringRef LimitCBitWidthPass::getArgument() const {
 llvm::StringRef LimitCBitWidthPass::getDescription() const {
   return "Limit classical bit register width";
 }
+
+llvm::StringRef LimitCBitWidthPass::getName() const {
+  return "Limit CBit Width Pass";
+}

--- a/lib/Dialect/Pulse/Transforms/ClassicalOnlyDetection.cpp
+++ b/lib/Dialect/Pulse/Transforms/ClassicalOnlyDetection.cpp
@@ -82,4 +82,8 @@ llvm::StringRef ClassicalOnlyDetectionPass::getDescription() const {
   return "Detect control flow blocks that contain only classical (non-quantum) "
          "operations, and decorate them with a classicalOnly bool attribute";
 }
+
+llvm::StringRef ClassicalOnlyDetectionPass::getName() const {
+  return "Classical Only Detection Pass";
+}
 } // namespace mlir::pulse

--- a/lib/Dialect/Pulse/Transforms/InlineRegion.cpp
+++ b/lib/Dialect/Pulse/Transforms/InlineRegion.cpp
@@ -94,4 +94,9 @@ llvm::StringRef InlineRegionPass::getArgument() const { return "pulse-inline"; }
 llvm::StringRef InlineRegionPass::getDescription() const {
   return "Inline all dialects.";
 }
+
+llvm::StringRef InlineRegionPass::getName() const {
+  return "Inline Region Pass";
+}
+
 } // namespace mlir::pulse

--- a/lib/Dialect/Pulse/Transforms/MergeDelays.cpp
+++ b/lib/Dialect/Pulse/Transforms/MergeDelays.cpp
@@ -122,3 +122,5 @@ llvm::StringRef MergeDelayPass::getArgument() const {
 llvm::StringRef MergeDelayPass::getDescription() const {
   return "Merge sequencial delays on the same physical channel";
 }
+
+llvm::StringRef MergeDelayPass::getName() const { return "Merge Delay Pass"; }

--- a/lib/Dialect/Pulse/Transforms/RemoveUnusedArguments.cpp
+++ b/lib/Dialect/Pulse/Transforms/RemoveUnusedArguments.cpp
@@ -155,3 +155,7 @@ llvm::StringRef RemoveUnusedArgumentsPass::getArgument() const {
 llvm::StringRef RemoveUnusedArgumentsPass::getDescription() const {
   return "Remove sequence arguments that are unused by physical channel";
 }
+
+llvm::StringRef RemoveUnusedArgumentsPass::getName() const {
+  return "Remove Unused Argument Pass";
+}

--- a/lib/Dialect/Pulse/Transforms/SchedulePort.cpp
+++ b/lib/Dialect/Pulse/Transforms/SchedulePort.cpp
@@ -343,3 +343,7 @@ llvm::StringRef SchedulePortPass::getArgument() const {
 llvm::StringRef SchedulePortPass::getDescription() const {
   return "Schedule operations on the same port in a sequence";
 }
+
+llvm::StringRef SchedulePortPass::getName() const {
+  return "Schedule Port Pass";
+}

--- a/lib/Dialect/Pulse/Transforms/Scheduling.cpp
+++ b/lib/Dialect/Pulse/Transforms/Scheduling.cpp
@@ -213,3 +213,7 @@ llvm::StringRef QuantumCircuitPulseSchedulingPass::getArgument() const {
 llvm::StringRef QuantumCircuitPulseSchedulingPass::getDescription() const {
   return "Scheduling a quantum circuit at pulse level.";
 }
+
+llvm::StringRef QuantumCircuitPulseSchedulingPass::getName() const {
+  return "Quantum Circuit Pulse Scheduling Pass";
+}

--- a/lib/Dialect/QCS/Utils/ParameterInitialValueAnalysis.cpp
+++ b/lib/Dialect/QCS/Utils/ParameterInitialValueAnalysis.cpp
@@ -95,6 +95,10 @@ llvm::StringRef ParameterInitialValueAnalysisPass::getDescription() const {
   return "Run ParameterInitialValueAnalysis";
 }
 
+llvm::StringRef ParameterInitialValueAnalysisPass::getName() const {
+  return "Parameters Initial Value Analysis Pass";
+}
+
 // TODO: move registerQCSPasses to separate source file if additional passes
 // are added to the QCS Dialect
 void mlir::qcs::registerQCSPasses() {

--- a/lib/Dialect/QUIR/IR/QUIRTestInterfaces.cpp
+++ b/lib/Dialect/QUIR/IR/QUIRTestInterfaces.cpp
@@ -63,3 +63,7 @@ llvm::StringRef TestQubitOpInterfacePass::getDescription() const {
   return "Test QubitOpInterface by attributing operations with operated "
          "qubits.";
 }
+
+llvm::StringRef TestQubitOpInterfacePass::getName() const {
+  return "Test Qubit Op Interface Pass";
+}

--- a/lib/Dialect/QUIR/Transforms/AddShotLoop.cpp
+++ b/lib/Dialect/QUIR/Transforms/AddShotLoop.cpp
@@ -112,3 +112,7 @@ llvm::StringRef AddShotLoopPass::getDescription() const {
   return "Add a for loop wrapping the main function body iterating over the "
          "number of shots";
 }
+
+llvm::StringRef AddShotLoopPass::getName() const {
+  return "Add Shot Loop Pass";
+}

--- a/lib/Dialect/QUIR/Transforms/AngleConversion.cpp
+++ b/lib/Dialect/QUIR/Transforms/AngleConversion.cpp
@@ -116,3 +116,7 @@ llvm::StringRef QUIRAngleConversionPass::getDescription() const {
   return "Convert the angle types in CallGateOp "
          "based on the corresponding mlir::func::FuncOp args";
 }
+
+llvm::StringRef QUIRAngleConversionPass::getName() const {
+  return "QUIR Angle Conversion Pass";
+}

--- a/lib/Dialect/QUIR/Transforms/BreakReset.cpp
+++ b/lib/Dialect/QUIR/Transforms/BreakReset.cpp
@@ -142,3 +142,5 @@ llvm::StringRef BreakResetPass::getArgument() const { return "break-reset"; }
 llvm::StringRef BreakResetPass::getDescription() const {
   return "Break reset ops into repeated measure and conditional x gate calls";
 }
+
+llvm::StringRef BreakResetPass::getName() const { return "Break Reset Pass"; }

--- a/lib/Dialect/QUIR/Transforms/ConvertDurationUnits.cpp
+++ b/lib/Dialect/QUIR/Transforms/ConvertDurationUnits.cpp
@@ -358,3 +358,7 @@ llvm::StringRef ConvertDurationUnitsPass::getDescription() const {
   return "Convert the units of all duration types within the module to the "
          "specified units.";
 }
+
+llvm::StringRef ConvertDurationUnitsPass::getName() const {
+  return "Convert Duration Units Pass";
+}

--- a/lib/Dialect/QUIR/Transforms/FunctionArgumentSpecialization.cpp
+++ b/lib/Dialect/QUIR/Transforms/FunctionArgumentSpecialization.cpp
@@ -184,3 +184,7 @@ llvm::StringRef FunctionArgumentSpecializationPass::getDescription() const {
          "cloned, the call is updated to match the cloned def, and the "
          "original function def is left unchanged";
 }
+
+llvm::StringRef FunctionArgumentSpecializationPass::getName() const {
+  return "Function Argument Specialization Pass";
+}

--- a/lib/Dialect/QUIR/Transforms/LoadElimination.cpp
+++ b/lib/Dialect/QUIR/Transforms/LoadElimination.cpp
@@ -127,4 +127,8 @@ llvm::StringRef LoadEliminationPass::getDescription() const {
          "to a variable to subsequent uses of the variable.";
 }
 
+llvm::StringRef LoadEliminationPass::getName() const {
+  return "Load Elimination Pass";
+}
+
 } // namespace mlir::quir

--- a/lib/Dialect/QUIR/Transforms/MergeCircuits.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuits.cpp
@@ -429,3 +429,7 @@ llvm::StringRef MergeCircuitsPass::getArgument() const {
 llvm::StringRef MergeCircuitsPass::getDescription() const {
   return "Merge back-to-back call_circuits ";
 }
+
+llvm::StringRef MergeCircuitsPass::getName() const {
+  return "Merge Circuits Pass";
+}

--- a/lib/Dialect/QUIR/Transforms/MergeMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeMeasures.cpp
@@ -140,6 +140,10 @@ llvm::StringRef MergeMeasuresLexographicalPass::getDescription() const {
          "single measurement operation with lexographicalal ordering";
 }
 
+llvm::StringRef MergeMeasuresLexographicalPass::getName() const {
+  return "Merge Measures Lexographical Pass";
+}
+
 namespace {
 // This pattern matches on two MeasureOps that are only interspersed by
 // classical non-control flow ops and merges them into one measure op
@@ -208,4 +212,8 @@ llvm::StringRef MergeMeasuresTopologicalPass::getArgument() const {
 llvm::StringRef MergeMeasuresTopologicalPass::getDescription() const {
   return "Merge qubit-parallel measurement operations into a "
          "single measurement operation with topological ordering";
+}
+
+llvm::StringRef MergeMeasuresTopologicalPass::getName() const {
+  return "Merge Measures Topological Pass";
 }

--- a/lib/Dialect/QUIR/Transforms/MergeParallelResets.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeParallelResets.cpp
@@ -124,6 +124,10 @@ llvm::StringRef MergeResetsLexicographicPass::getDescription() const {
          "single operation lexicographically.";
 }
 
+llvm::StringRef MergeResetsLexicographicPass::getName() const {
+  return "Merge Resets Lexicographical Pass";
+}
+
 namespace {
 // This pattern merges qubit reset operations that can be parallelized into a
 // single reset op topologically.
@@ -231,4 +235,8 @@ llvm::StringRef MergeResetsTopologicalPass::getArgument() const {
 llvm::StringRef MergeResetsTopologicalPass::getDescription() const {
   return "Merge qubit reset ops that can be parallelized into a "
          "single operation topologically.";
+}
+
+llvm::StringRef MergeResetsTopologicalPass::getName() const {
+  return "Merge Resets Topological Pass";
 }

--- a/lib/Dialect/QUIR/Transforms/Passes.cpp
+++ b/lib/Dialect/QUIR/Transforms/Passes.cpp
@@ -207,6 +207,11 @@ llvm::StringRef ClassicalOnlyDetectionPass::getDescription() const {
   return "Detect control flow blocks that contain only classical (non-quantum) "
          "operations, and decorate them with a classicalOnly bool attribute";
 }
+
+llvm::StringRef ClassicalOnlyDetectionPass::getName() const {
+  return "Classical Only Detection Pass";
+}
+
 /////////////// End ClassicalOnlyDetectionPass functions ///////////////////
 
 struct DumpVariableDominanceInfoPass

--- a/lib/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.cpp
+++ b/lib/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.cpp
@@ -228,4 +228,8 @@ llvm::StringRef QUIRCircuitAnalysisPass::getDescription() const {
   return "Analyze Circuit Inputs";
 }
 
+llvm::StringRef QUIRCircuitAnalysisPass::getName() const {
+  return "QUIR Circuit Analysis Pass";
+}
+
 } // namespace mlir::quir

--- a/lib/Dialect/QUIR/Transforms/QuantumDecoration.cpp
+++ b/lib/Dialect/QUIR/Transforms/QuantumDecoration.cpp
@@ -175,3 +175,7 @@ llvm::StringRef QuantumDecorationPass::getDescription() const {
   return "Detect and add attributes to ops describing which "
          "qubits are involved within those ops";
 }
+
+llvm::StringRef QuantumDecorationPass::getName() const {
+  return "Quantum Decoration Pass";
+}

--- a/lib/Dialect/QUIR/Transforms/RemoveQubitOperands.cpp
+++ b/lib/Dialect/QUIR/Transforms/RemoveQubitOperands.cpp
@@ -163,3 +163,7 @@ llvm::StringRef RemoveQubitOperandsPass::getDescription() const {
   return "Remove qubit arguments from subroutine defs and calls, replacing "
          "them with qubit declarations inside the subroutine body";
 }
+
+llvm::StringRef RemoveQubitOperandsPass::getName() const {
+  return "Remove Qubit Operands Pass";
+}

--- a/lib/Dialect/QUIR/Transforms/ReorderCircuits.cpp
+++ b/lib/Dialect/QUIR/Transforms/ReorderCircuits.cpp
@@ -115,3 +115,7 @@ llvm::StringRef ReorderCircuitsPass::getArgument() const {
 llvm::StringRef ReorderCircuitsPass::getDescription() const {
   return "Move call_circuits later if possible.";
 }
+
+llvm::StringRef ReorderCircuitsPass::getName() const {
+  return "Reorder Circuits Pass";
+}

--- a/lib/Dialect/QUIR/Transforms/ReorderMeasurements.cpp
+++ b/lib/Dialect/QUIR/Transforms/ReorderMeasurements.cpp
@@ -235,3 +235,7 @@ llvm::StringRef ReorderMeasurementsPass::getDescription() const {
   return "Move qubits to be as lexicograpically as late as possible without "
          "affecting the topological ordering.";
 }
+
+llvm::StringRef ReorderMeasurementsPass::getName() const {
+  return "Reorder Measurement Pass";
+}

--- a/lib/Dialect/QUIR/Transforms/SubroutineCloning.cpp
+++ b/lib/Dialect/QUIR/Transforms/SubroutineCloning.cpp
@@ -226,3 +226,7 @@ llvm::StringRef SubroutineCloningPass::getDescription() const {
          "the qubit arguments of the cloned def are decorated with attributes "
          "listing the id that the qubit should have";
 }
+
+llvm::StringRef SubroutineCloningPass::getName() const {
+  return "Subroutine Cloning Pass";
+}

--- a/lib/Dialect/QUIR/Transforms/UnusedVariable.cpp
+++ b/lib/Dialect/QUIR/Transforms/UnusedVariable.cpp
@@ -99,3 +99,7 @@ llvm::StringRef UnusedVariablePass::getArgument() const {
 llvm::StringRef UnusedVariablePass::getDescription() const {
   return "Remove variables that are not outputs and do not have any loads/uses";
 }
+
+llvm::StringRef UnusedVariablePass::getName() const {
+  return "Unused Variable Pass";
+}

--- a/lib/Dialect/QUIR/Transforms/VariableElimination.cpp
+++ b/lib/Dialect/QUIR/Transforms/VariableElimination.cpp
@@ -354,4 +354,8 @@ llvm::StringRef VariableEliminationPass::getDescription() const {
   return "Replace QUIR variables by memref and simplify with store-forwarding.";
 }
 
+llvm::StringRef VariableEliminationPass::getName() const {
+  return "Variable Elimination Pass";
+}
+
 } // namespace mlir::quir

--- a/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.cpp
+++ b/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.cpp
@@ -284,4 +284,8 @@ llvm::StringRef MockQUIRToStdPass::getDescription() const {
   return "Convert QUIR ops to std dialect";
 }
 
+llvm::StringRef MockQUIRToStdPass::getName() const {
+  return "Mock QUIR to Std Pass";
+}
+
 } // namespace qssc::targets::systems::mock::conversion

--- a/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.h
+++ b/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.h
@@ -43,6 +43,7 @@ struct MockQUIRToStdPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 };
 } // namespace qssc::targets::systems::mock::conversion
 

--- a/targets/systems/mock/Transforms/QubitLocalization.cpp
+++ b/targets/systems/mock/Transforms/QubitLocalization.cpp
@@ -915,3 +915,7 @@ llvm::StringRef MockQubitLocalizationPass::getArgument() const {
 llvm::StringRef MockQubitLocalizationPass::getDescription() const {
   return "Create modules for Mock code blocks.";
 }
+
+llvm::StringRef MockQubitLocalizationPass::getName() const {
+  return "Mock Qubit Localization Pass";
+}

--- a/targets/systems/mock/Transforms/QubitLocalization.h
+++ b/targets/systems/mock/Transforms/QubitLocalization.h
@@ -106,6 +106,7 @@ struct MockQubitLocalizationPass
 
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
 }; // struct MockQubitLocalizationPass
 
 } // namespace qssc::targets::systems::mock

--- a/targets/systems/mock/test/static/integration/mlir/mlir-timing.mlir
+++ b/targets/systems/mock/test/static/integration/mlir/mlir-timing.mlir
@@ -34,7 +34,7 @@ func.func @main () -> i32 {
 // CHECK:         children
 // CHECK:           MockController
 // CHECK:             passes
-// CHECK:               qssc::targets::systems::mock::conversion::MockQUIRToStdPass
+// CHECK:               Mock QUIR to Std Pass
 // CHECK:               Canonicalizer
 // CHECK:               LLVMLegalizeForExport
 // CHECK:             emit-to-payload


### PR DESCRIPTION
Add `getName` method to all the MLIR passes.