### PR TITLE
Add diagnostic tracking to target and an error for too long sequences

### DIFF
--- a/include/API/api.h
+++ b/include/API/api.h
@@ -75,7 +75,7 @@ llvm::Error compileMain(llvm::raw_ostream &outputStream,
                         std::unique_ptr<llvm::MemoryBuffer> buffer,
                         mlir::DialectRegistry &registry,
                         const qssc::config::QSSConfig &config,
-                        std::optional<DiagnosticCallback> diagnosticCb,
+                        OptDiagnosticCallback diagnosticCb,
                         mlir::TimingScope &timing);
 
 /// Implementation for tools like `qss-compiler`.
@@ -90,7 +90,7 @@ llvm::Error compileMain(int argc, const char **argv,
                         llvm::StringRef inputFilename,
                         llvm::StringRef outputFilename,
                         mlir::DialectRegistry &registry,
-                        std::optional<DiagnosticCallback> diagnosticCb);
+                        OptDiagnosticCallback diagnosticCb);
 
 /// Implementation for tools like `qss-compiler`.
 /// @param argc Commandline argc to parse.
@@ -100,7 +100,7 @@ llvm::Error compileMain(int argc, const char **argv,
 /// @param diagnosticCb callback for error diagnostic processsing.
 llvm::Error compileMain(int argc, const char **argv, llvm::StringRef toolName,
                         mlir::DialectRegistry &registry,
-                        std::optional<DiagnosticCallback> diagnosticCb);
+                        OptDiagnosticCallback diagnosticCb);
 
 /// Implementation for tools like `qss-compiler` with provided registry with
 /// default project dialects loaded
@@ -108,7 +108,7 @@ llvm::Error compileMain(int argc, const char **argv, llvm::StringRef toolName,
 /// @param argv Commandline argv to parse.
 /// @param diagnosticCb callback for error diagnostic processsing.
 llvm::Error compileMain(int argc, const char **argv, llvm::StringRef toolName,
-                        std::optional<DiagnosticCallback> diagnosticCb);
+                        OptDiagnosticCallback diagnosticCb);
 
 /// Helper wrapper to return the result of compileMain directly from main
 inline int asMainReturnCode(llvm::Error err) {
@@ -130,7 +130,7 @@ int bindArguments(std::string_view target, std::string_view configPath,
                   std::unordered_map<std::string, double> const &arguments,
                   bool treatWarningsAsErrors, bool enableInMemoryInput,
                   std::string *inMemoryOutput,
-                  const std::optional<DiagnosticCallback> &onDiagnostic);
+                  const OptDiagnosticCallback &onDiagnostic);
 
 } // namespace qssc
 #endif // QSS_COMPILER_LIB_H

--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -36,6 +36,7 @@ enum class ErrorCategory {
   QSSCompilerCommunicationFailure,
   QSSCompilerEOFFailure,
   QSSCompilerNonZeroStatus,
+  QSSCompilerSequenceTooLong,
   QSSCompilationFailure,
   QSSLinkerNotImplemented,
   QSSLinkSignatureWarning,

--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -69,6 +69,7 @@ public:
 };
 
 using DiagnosticCallback = std::function<void(const Diagnostic &)>;
+using OptDiagnosticCallback = std::optional<DiagnosticCallback>;
 
 llvm::Error emitDiagnostic(std::optional<DiagnosticCallback> onDiagnostic,
                            const Diagnostic &diag,

--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -74,10 +74,10 @@ using DiagRefList = std::list<std::reference_wrapper<const Diagnostic>>;
 using DiagnosticCallback = std::function<void(const Diagnostic &)>;
 using OptDiagnosticCallback = std::optional<DiagnosticCallback>;
 
-llvm::Error emitDiagnostic(std::optional<DiagnosticCallback> onDiagnostic,
+llvm::Error emitDiagnostic(const OptDiagnosticCallback &onDiagnostic,
                            const Diagnostic &diag,
                            std::error_code ec = llvm::inconvertibleErrorCode());
-llvm::Error emitDiagnostic(std::optional<DiagnosticCallback> onDiagnostic,
+llvm::Error emitDiagnostic(const OptDiagnosticCallback &onDiagnostic,
                            Severity severity, ErrorCategory category,
                            std::string message,
                            std::error_code ec = llvm::inconvertibleErrorCode());

--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -24,6 +24,7 @@
 #include "llvm/Support/Error.h"
 
 #include <functional>
+#include <list>
 #include <optional>
 #include <string>
 
@@ -68,6 +69,8 @@ public:
   std::string toString() const;
 };
 
+using DiagList = std::list<Diagnostic>;
+using DiagRefList = std::list<std::reference_wrapper<const Diagnostic>>;
 using DiagnosticCallback = std::function<void(const Diagnostic &)>;
 using OptDiagnosticCallback = std::optional<DiagnosticCallback>;
 

--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -71,6 +71,9 @@ public:
 using DiagnosticCallback = std::function<void(const Diagnostic &)>;
 
 llvm::Error emitDiagnostic(std::optional<DiagnosticCallback> onDiagnostic,
+                           const Diagnostic &diag,
+                           std::error_code ec = llvm::inconvertibleErrorCode());
+llvm::Error emitDiagnostic(std::optional<DiagnosticCallback> onDiagnostic,
                            Severity severity, ErrorCategory category,
                            std::string message,
                            std::error_code ec = llvm::inconvertibleErrorCode());

--- a/include/Arguments/Arguments.h
+++ b/include/Arguments/Arguments.h
@@ -35,7 +35,6 @@
 namespace qssc::arguments {
 
 using ArgumentType = std::variant<std::optional<double>>;
-using OptDiagnosticCallback = std::optional<qssc::DiagnosticCallback>;
 
 class ArgumentSource {
 public:

--- a/include/Arguments/Signature.h
+++ b/include/Arguments/Signature.h
@@ -73,8 +73,7 @@ public:
   std::string serialize();
 
   static llvm::Expected<Signature>
-  deserialize(llvm::StringRef,
-              const std::optional<qssc::DiagnosticCallback> &onDiagnostic,
+  deserialize(llvm::StringRef, const qssc::OptDiagnosticCallback &onDiagnostic,
               bool treatWarningsAsError = false);
 
   bool isEmpty() { return patchPointsByBinary.size() == 0; }

--- a/include/Frontend/OpenQASM3/OpenQASM3Frontend.h
+++ b/include/Frontend/OpenQASM3/OpenQASM3Frontend.h
@@ -46,7 +46,7 @@ namespace qssc::frontend::openqasm3 {
 /// otherwise
 llvm::Error parse(llvm::SourceMgr &sourceMgr, bool emitRawAST,
                   bool emitPrettyAST, bool emitMLIR, mlir::ModuleOp newModule,
-                  std::optional<DiagnosticCallback> diagnosticCb,
+                  OptDiagnosticCallback diagnosticCb,
                   mlir::TimingScope &timing);
 
 }; // namespace qssc::frontend::openqasm3

--- a/include/HAL/Compile/TargetCompilationManager.h
+++ b/include/HAL/Compile/TargetCompilationManager.h
@@ -117,6 +117,10 @@ protected:
   /// @param name The name of the timing span
   mlir::TimingScope getTimer(llvm::StringRef name);
 
+  /// @brief Emit diagnostics capatured in the Target
+  /// @return Was an error or fatal diagnostic detected
+  bool emitDiagnostics();
+
 private:
   hal::TargetSystem &target;
   mlir::MLIRContext *context;

--- a/include/HAL/Compile/TargetCompilationManager.h
+++ b/include/HAL/Compile/TargetCompilationManager.h
@@ -22,6 +22,7 @@
 #define TARGETCOMPILATIONMANAGER_H
 
 #include "API/errors.h"
+#include "Config/QSSConfig.h"
 #include "HAL/TargetSystem.h"
 
 #include "mlir/IR/BuiltinOps.h"
@@ -43,6 +44,7 @@ class TargetCompilationManager {
 protected:
   TargetCompilationManager(hal::TargetSystem &target,
                            mlir::MLIRContext *context,
+                           const config::QSSConfig &config,
                            const qssc::OptDiagnosticCallback &callback);
 
   using WalkTargetModulesFunction = std::function<llvm::Error(
@@ -118,6 +120,7 @@ protected:
 private:
   hal::TargetSystem &target;
   mlir::MLIRContext *context;
+  const config::QSSConfig &config;
   const qssc::OptDiagnosticCallback &diagnosticCb;
 
   bool printBeforeAllTargetPasses = false;

--- a/include/HAL/Compile/TargetCompilationManager.h
+++ b/include/HAL/Compile/TargetCompilationManager.h
@@ -119,7 +119,7 @@ protected:
 
   /// @brief Emit diagnostics capatured in the Target
   /// @return Was an error or fatal diagnostic detected
-  bool emitDiagnostics();
+  bool emitTargetDiagnostics();
 
 private:
   hal::TargetSystem &target;

--- a/include/HAL/Compile/TargetCompilationManager.h
+++ b/include/HAL/Compile/TargetCompilationManager.h
@@ -43,9 +43,7 @@ namespace qssc::hal::compile {
 class TargetCompilationManager {
 protected:
   TargetCompilationManager(hal::TargetSystem &target,
-                           mlir::MLIRContext *context,
-                           const config::QSSConfig &config,
-                           const qssc::OptDiagnosticCallback &callback);
+                           mlir::MLIRContext *context);
 
   using WalkTargetModulesFunction = std::function<llvm::Error(
       hal::Target *, mlir::ModuleOp, mlir::TimingScope &timing)>;
@@ -98,6 +96,9 @@ public:
                         bool printBeforeAllTargetPayload,
                         bool printAfterTargetCompileFailure);
 
+  /// @brief Take the diagnostics capatured in the Target
+  qssc::DiagList takeTargetDiagnostics() { return target.takeDiagnostics(); }
+
   void enableTiming(mlir::TimingScope &timingScope);
   void disableTiming();
 
@@ -117,15 +118,9 @@ protected:
   /// @param name The name of the timing span
   mlir::TimingScope getTimer(llvm::StringRef name);
 
-  /// @brief Emit diagnostics capatured in the Target
-  /// @return Was an error or fatal diagnostic detected
-  bool emitTargetDiagnostics();
-
 private:
   hal::TargetSystem &target;
   mlir::MLIRContext *context;
-  const config::QSSConfig &config;
-  const qssc::OptDiagnosticCallback &diagnosticCb;
 
   bool printBeforeAllTargetPasses = false;
   bool printAfterAllTargetPasses = false;

--- a/include/HAL/Compile/TargetCompilationManager.h
+++ b/include/HAL/Compile/TargetCompilationManager.h
@@ -21,6 +21,7 @@
 #ifndef TARGETCOMPILATIONMANAGER_H
 #define TARGETCOMPILATIONMANAGER_H
 
+#include "API/errors.h"
 #include "HAL/TargetSystem.h"
 
 #include "mlir/IR/BuiltinOps.h"
@@ -41,7 +42,8 @@ namespace qssc::hal::compile {
 class TargetCompilationManager {
 protected:
   TargetCompilationManager(hal::TargetSystem &target,
-                           mlir::MLIRContext *context);
+                           mlir::MLIRContext *context,
+                           const qssc::OptDiagnosticCallback &callback);
 
   using WalkTargetModulesFunction = std::function<llvm::Error(
       hal::Target *, mlir::ModuleOp, mlir::TimingScope &timing)>;
@@ -116,6 +118,7 @@ protected:
 private:
   hal::TargetSystem &target;
   mlir::MLIRContext *context;
+  const qssc::OptDiagnosticCallback &diagnosticCb;
 
   bool printBeforeAllTargetPasses = false;
   bool printAfterAllTargetPasses = false;

--- a/include/HAL/Compile/ThreadedCompilationManager.h
+++ b/include/HAL/Compile/ThreadedCompilationManager.h
@@ -21,6 +21,7 @@
 #ifndef THREADEDCOMPILATIONMANAGER_H
 #define THREADEDCOMPILATIONMANAGER_H
 
+#include "Config/QSSConfig.h"
 #include "HAL/Compile/TargetCompilationManager.h"
 
 #include <mutex>
@@ -64,6 +65,7 @@ public:
 
   ThreadedCompilationManager(qssc::hal::TargetSystem &target,
                              mlir::MLIRContext *context,
+                             const config::QSSConfig &config,
                              const qssc::OptDiagnosticCallback &diagnosticCb,
                              PMBuilder pmBuilder);
   virtual ~ThreadedCompilationManager() = default;

--- a/include/HAL/Compile/ThreadedCompilationManager.h
+++ b/include/HAL/Compile/ThreadedCompilationManager.h
@@ -63,7 +63,9 @@ public:
   using PMBuilder = std::function<llvm::Error(mlir::PassManager &)>;
 
   ThreadedCompilationManager(qssc::hal::TargetSystem &target,
-                             mlir::MLIRContext *context, PMBuilder pmBuilder);
+                             mlir::MLIRContext *context,
+                             const qssc::OptDiagnosticCallback &diagnosticCb,
+                             PMBuilder pmBuilder);
   virtual ~ThreadedCompilationManager() = default;
   virtual const std::string getName() const override;
 

--- a/include/HAL/Compile/ThreadedCompilationManager.h
+++ b/include/HAL/Compile/ThreadedCompilationManager.h
@@ -64,10 +64,7 @@ public:
   using PMBuilder = std::function<llvm::Error(mlir::PassManager &)>;
 
   ThreadedCompilationManager(qssc::hal::TargetSystem &target,
-                             mlir::MLIRContext *context,
-                             const config::QSSConfig &config,
-                             const qssc::OptDiagnosticCallback &diagnosticCb,
-                             PMBuilder pmBuilder);
+                             mlir::MLIRContext *context, PMBuilder pmBuilder);
   virtual ~ThreadedCompilationManager() = default;
   virtual const std::string getName() const override;
 

--- a/include/HAL/TargetSystem.h
+++ b/include/HAL/TargetSystem.h
@@ -144,7 +144,6 @@ public:
   // Diagnostic creation and access
   /// @brief Add a diagnostic to this target
   void addDiagnostic(const qssc::Diagnostic &diag) {
-    // NOLINTNEXTLINE(clang-diagnostic-ctad-maybe-unsupported)
     const std::lock_guard<std::mutex> lock(diagnosticsMutex_);
     diagnostics_.emplace_back(diag);
   }

--- a/include/HAL/TargetSystem.h
+++ b/include/HAL/TargetSystem.h
@@ -147,16 +147,16 @@ public:
     const std::lock_guard<std::mutex> lock(diagnosticsMutex_);
     diagnostics_.emplace_back(diag);
   }
-  /// @brief Return the diagnostics that this target and its subtargets hold
-  ///        and clear the diagnostic lists of the targets.
-  qssc::DiagList getDiagnostics() {
+  /// @brief Return the diagnostics from this target and its sub-targets.
+  ///        Take and clear the diagnostic lists of the targets.
+  qssc::DiagList takeDiagnostics() {
     const std::lock_guard<std::mutex> lock(diagnosticsMutex_);
     qssc::DiagList retDiagList;
-    // Steal the elements of the given list and move them to the calling list
+    // Take the elements of the given list and move them to the calling list
     retDiagList.splice(retDiagList.end(), diagnostics_);
 
     for (auto &child : getChildren_())
-      retDiagList.splice(retDiagList.end(), child->getDiagnostics());
+      retDiagList.splice(retDiagList.end(), child->takeDiagnostics());
 
     return retDiagList;
   }

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -347,7 +347,7 @@ llvm::Error emitQEM_(
 /// @param config Config data holding the verbosity level for output
 /// @return True iff target contains any error or fatal diagnostics
 bool emitAllDiagnosticsAndCheckForErrors_(
-    hal::TargetSystem &target, qssc::OptDiagnosticCallback diagnosticCb,
+    hal::TargetSystem &target, const qssc::OptDiagnosticCallback &diagnosticCb,
     const QSSConfig &config) {
   bool foundError = false;
   for (auto &diag : target.getDiagnosticsRecursive()) {
@@ -373,6 +373,7 @@ bool emitAllDiagnosticsAndCheckForErrors_(
       case Severity::Fatal:
       case Severity::Error:
         foundError = true;
+        [[fallthrough]];
       case Severity::Warning:
         (void)qssc::emitDiagnostic(diagnosticCb, diag);
         llvm::errs() << diag.get().toString() << "\n";
@@ -388,6 +389,7 @@ bool emitAllDiagnosticsAndCheckForErrors_(
       case Severity::Fatal:
       case Severity::Error:
         foundError = true;
+        [[fallthrough]];
       case Severity::Warning:
         (void)qssc::emitDiagnostic(diagnosticCb, diag);
         llvm::errs() << diag.get().toString() << "\n";

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -408,9 +408,9 @@ llvm::Error applyEmitAction(
 /// @param diagnosticCb Handle to python diagnostic callback
 /// @param config Config data holding the verbosity level for output
 /// @return True iff target contains any error or fatal diagnostics
-bool emitDiagnosticsAndCheckForErrors(qssc::DiagList diagnostics,
-                                      qssc::OptDiagnosticCallback diagnosticCb,
-                                      const QSSConfig &config) {
+bool emitDiagnosticsAndCheckForErrors(
+    const qssc::DiagList &diagnostics,
+    const qssc::OptDiagnosticCallback &diagnosticCb, const QSSConfig &config) {
   // NOLINTNEXTLINE(misc-const-correctness)
   bool foundError = false;
   for (auto &diag : diagnostics) {

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -328,7 +328,7 @@ llvm::Error emitQEM(
 ///  @param diagnostic MLIR diagnostic from the Diagnostic Engine
 ///  @param diagnosticCb Handle to python diagnostic callback
 void diagEngineHandler(mlir::Diagnostic &diagnostic,
-                       qssc::OptDiagnosticCallback diagnosticCb) {
+                       const qssc::OptDiagnosticCallback &diagnosticCb) {
 
   // map diagnostic severity to qssc severity
   auto severity = diagnostic.getSeverity();
@@ -346,7 +346,7 @@ void diagEngineHandler(mlir::Diagnostic &diagnostic,
   }
   // emit diagnostic cast to void to discard result as it is not needed here
   if (qssc_severity == qssc::Severity::Error) {
-    (void)qssc::emitDiagnostic(std::move(diagnosticCb), qssc_severity,
+    (void)qssc::emitDiagnostic(diagnosticCb, qssc_severity,
                                qssc::ErrorCategory::QSSCompilationFailure,
                                diagnostic.str());
   }
@@ -708,7 +708,7 @@ llvm::Error qssc::compileMain(llvm::raw_ostream &outputStream,
                               std::unique_ptr<llvm::MemoryBuffer> buffer,
                               DialectRegistry &registry,
                               const qssc::config::QSSConfig &config,
-                              std::optional<DiagnosticCallback> diagnosticCb,
+                              OptDiagnosticCallback diagnosticCb,
                               mlir::TimingScope &timing) {
 
   // The MLIR context for this compilation event.
@@ -736,7 +736,7 @@ llvm::Error qssc::compileMain(int argc, const char **argv,
                               llvm::StringRef inputFilename,
                               llvm::StringRef outputFilename,
                               mlir::DialectRegistry &registry,
-                              std::optional<DiagnosticCallback> diagnosticCb) {
+                              OptDiagnosticCallback diagnosticCb) {
 
   llvm::InitLLVM const y(argc, argv);
 
@@ -807,7 +807,7 @@ llvm::Error qssc::compileMain(int argc, const char **argv,
 llvm::Error qssc::compileMain(int argc, const char **argv,
                               llvm::StringRef toolName,
                               mlir::DialectRegistry &registry,
-                              std::optional<DiagnosticCallback> diagnosticCb) {
+                              OptDiagnosticCallback diagnosticCb) {
 
   // Register and parse command line options.
   std::string inputFilename, outputFilename;
@@ -820,7 +820,7 @@ llvm::Error qssc::compileMain(int argc, const char **argv,
 
 llvm::Error qssc::compileMain(int argc, const char **argv,
                               llvm::StringRef toolName,
-                              std::optional<DiagnosticCallback> diagnosticCb) {
+                              OptDiagnosticCallback diagnosticCb) {
   // Register the standard passes with MLIR.
   // Must precede the command line parsing.
   if (auto err = qssc::dialect::registerPasses())

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -698,7 +698,8 @@ llvm::Error compile_(int argc, char const **argv, std::string *outputString,
 
   auto targetCompilationManager =
       qssc::hal::compile::ThreadedCompilationManager(
-          target, &context, [&](mlir::PassManager &pm) -> llvm::Error {
+          target, &context, diagnosticCb,
+          [&](mlir::PassManager &pm) -> llvm::Error {
             if (auto err = buildPassManager_(pm, verifyPasses))
               return err;
             return llvm::Error::success();

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -698,7 +698,7 @@ llvm::Error compile_(int argc, char const **argv, std::string *outputString,
 
   auto targetCompilationManager =
       qssc::hal::compile::ThreadedCompilationManager(
-          target, &context, diagnosticCb,
+          target, &context, config, diagnosticCb,
           [&](mlir::PassManager &pm) -> llvm::Error {
             if (auto err = buildPassManager_(pm, verifyPasses))
               return err;

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -350,8 +350,8 @@ bool emitAllDiagnosticsAndCheckForErrors_(
     hal::TargetSystem &target, const qssc::OptDiagnosticCallback &diagnosticCb,
     const QSSConfig &config) {
   bool foundError = false;
-  for (auto &diag : target.getDiagnosticsRecursive()) {
-    auto severity = diag.get().severity;
+  for (auto &diag : target.getDiagnostics()) {
+    auto severity = diag.severity;
     switch (config.getVerbosityLevel()) {
     case QSSVerbosity::Error:
       switch (severity) {
@@ -359,7 +359,7 @@ bool emitAllDiagnosticsAndCheckForErrors_(
       case Severity::Error:
         foundError = true;
         (void)qssc::emitDiagnostic(diagnosticCb, diag);
-        llvm::errs() << diag.get().toString() << "\n";
+        llvm::errs() << diag.toString() << "\n";
         break;
       case Severity::Warning:
       case Severity::Info:
@@ -376,7 +376,7 @@ bool emitAllDiagnosticsAndCheckForErrors_(
         [[fallthrough]];
       case Severity::Warning:
         (void)qssc::emitDiagnostic(diagnosticCb, diag);
-        llvm::errs() << diag.get().toString() << "\n";
+        llvm::errs() << diag.toString() << "\n";
         break;
       case Severity::Info:
       default:
@@ -392,7 +392,7 @@ bool emitAllDiagnosticsAndCheckForErrors_(
         [[fallthrough]];
       case Severity::Warning:
         (void)qssc::emitDiagnostic(diagnosticCb, diag);
-        llvm::errs() << diag.get().toString() << "\n";
+        llvm::errs() << diag.toString() << "\n";
         break;
       case Severity::Info:
       default:

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -118,14 +118,19 @@ std::string Diagnostic::toString() const {
 }
 
 llvm::Error emitDiagnostic(std::optional<DiagnosticCallback> onDiagnostic,
-                           Severity severity, ErrorCategory category,
-                           std::string message, std::error_code ec) {
+                           const Diagnostic &diag, std::error_code ec) {
   auto *diagnosticCallback =
       onDiagnostic.has_value() ? &onDiagnostic.value() : nullptr;
-  qssc::Diagnostic const diag{severity, category, std::move(message)};
   if (diagnosticCallback)
     (*diagnosticCallback)(diag);
   return llvm::createStringError(ec, diag.toString());
+}
+
+llvm::Error emitDiagnostic(std::optional<DiagnosticCallback> onDiagnostic,
+                           Severity severity, ErrorCategory category,
+                           std::string message, std::error_code ec) {
+  qssc::Diagnostic const diag{severity, category, std::move(message)};
+  return emitDiagnostic(onDiagnostic, diag, ec);
 }
 
 } // namespace qssc

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -24,7 +24,6 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include <optional>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -117,7 +116,7 @@ std::string Diagnostic::toString() const {
   return str;
 }
 
-llvm::Error emitDiagnostic(std::optional<DiagnosticCallback> onDiagnostic,
+llvm::Error emitDiagnostic(const OptDiagnosticCallback &onDiagnostic,
                            const Diagnostic &diag, std::error_code ec) {
   auto *diagnosticCallback =
       onDiagnostic.has_value() ? &onDiagnostic.value() : nullptr;
@@ -126,11 +125,11 @@ llvm::Error emitDiagnostic(std::optional<DiagnosticCallback> onDiagnostic,
   return llvm::createStringError(ec, diag.toString());
 }
 
-llvm::Error emitDiagnostic(std::optional<DiagnosticCallback> onDiagnostic,
+llvm::Error emitDiagnostic(const OptDiagnosticCallback &onDiagnostic,
                            Severity severity, ErrorCategory category,
                            std::string message, std::error_code ec) {
   qssc::Diagnostic const diag{severity, category, std::move(message)};
-  return emitDiagnostic(std::move(onDiagnostic), diag, ec);
+  return emitDiagnostic(onDiagnostic, diag, ec);
 }
 
 } // namespace qssc

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -130,7 +130,7 @@ llvm::Error emitDiagnostic(std::optional<DiagnosticCallback> onDiagnostic,
                            Severity severity, ErrorCategory category,
                            std::string message, std::error_code ec) {
   qssc::Diagnostic const diag{severity, category, std::move(message)};
-  return emitDiagnostic(onDiagnostic, diag, ec);
+  return emitDiagnostic(std::move(onDiagnostic), diag, ec);
 }
 
 } // namespace qssc

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -53,6 +53,9 @@ std::string_view getErrorCategoryAsString(qssc::ErrorCategory category) {
   case ErrorCategory::QSSCompilerNonZeroStatus:
     return "Errored because non-zero status is returned";
 
+  case ErrorCategory::QSSCompilerSequenceTooLong:
+    return "Error because input sequence is too long";
+
   case ErrorCategory::QSSCompilationFailure:
     return "Failure during compilation";
 

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -54,7 +54,7 @@ std::string_view getErrorCategoryAsString(qssc::ErrorCategory category) {
     return "Errored because non-zero status is returned";
 
   case ErrorCategory::QSSCompilerSequenceTooLong:
-    return "Error because input sequence is too long";
+    return "Input sequence is too long";
 
   case ErrorCategory::QSSCompilationFailure:
     return "Failure during compilation";

--- a/lib/Arguments/Signature.cpp
+++ b/lib/Arguments/Signature.cpp
@@ -29,7 +29,6 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <cstdint>
-#include <optional>
 #include <sstream>
 #include <string>
 #include <sys/types.h>

--- a/lib/Arguments/Signature.cpp
+++ b/lib/Arguments/Signature.cpp
@@ -86,10 +86,10 @@ std::string Signature::serialize() {
   return s.str();
 }
 
-llvm::Expected<Signature> Signature::deserialize(
-    llvm::StringRef buffer,
-    const std::optional<qssc::DiagnosticCallback> &onDiagnostic,
-    bool treatWarningsAsErrors) {
+llvm::Expected<Signature>
+Signature::deserialize(llvm::StringRef buffer,
+                       const qssc::OptDiagnosticCallback &onDiagnostic,
+                       bool treatWarningsAsErrors) {
 
   Signature sig;
 

--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -120,8 +120,7 @@ parseDurationStr(const std::string &durationStr) {
 llvm::Error qssc::frontend::openqasm3::parse(
     llvm::SourceMgr &sourceMgr, bool emitRawAST, bool emitPrettyAST,
     bool emitMLIR, mlir::ModuleOp newModule,
-    std::optional<qssc::DiagnosticCallback> diagnosticCallback,
-    mlir::TimingScope &timing) {
+    qssc::OptDiagnosticCallback diagnosticCallback, mlir::TimingScope &timing) {
 
   const llvm::MemoryBuffer *sourceBuffer =
       sourceMgr.getMemoryBuffer(sourceMgr.getMainFileID());

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -82,8 +82,10 @@ mlir::LogicalResult qssc::hal::compile::applyTargetCompilationManagerCLOptions(
 
 TargetCompilationManager::TargetCompilationManager(
     qssc::hal::TargetSystem &target, mlir::MLIRContext *context,
+    const config::QSSConfig &config,
     const qssc::OptDiagnosticCallback &diagnosticCb_)
-    : target(target), context(context), diagnosticCb(diagnosticCb_) {}
+    : target(target), context(context), config(config),
+      diagnosticCb(diagnosticCb_) {}
 
 llvm::Error TargetCompilationManager::walkTargetModules(
     Target *target, mlir::ModuleOp targetModuleOp, mlir::TimingScope &timing,

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -163,7 +163,7 @@ mlir::TimingScope TargetCompilationManager::getTimer(llvm::StringRef name) {
   return rootTimer.nest(name);
 }
 
-bool TargetCompilationManager::emitDiagnostics() {
+bool TargetCompilationManager::emitTargetDiagnostics() {
   using namespace qssc::config;
   // NOLINTNEXTLINE(misc-const-correctness)
   bool foundError = false;

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -161,6 +161,7 @@ mlir::TimingScope TargetCompilationManager::getTimer(llvm::StringRef name) {
 
 bool TargetCompilationManager::emitDiagnostics() {
   using namespace qssc::config;
+  // NOLINTNEXTLINE(misc-const-correctness)
   bool foundError = false;
   DiagList diagnostics(target.getDiagnostics());
   for (auto &diag : diagnostics) {

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -81,8 +81,9 @@ mlir::LogicalResult qssc::hal::compile::applyTargetCompilationManagerCLOptions(
 }
 
 TargetCompilationManager::TargetCompilationManager(
-    qssc::hal::TargetSystem &target, mlir::MLIRContext *context)
-    : target(target), context(context) {}
+    qssc::hal::TargetSystem &target, mlir::MLIRContext *context,
+    const qssc::OptDiagnosticCallback &diagnosticCb_)
+    : target(target), context(context), diagnosticCb(diagnosticCb_) {}
 
 llvm::Error TargetCompilationManager::walkTargetModules(
     Target *target, mlir::ModuleOp targetModuleOp, mlir::TimingScope &timing,

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -16,8 +16,6 @@
 
 #include "HAL/Compile/TargetCompilationManager.h"
 
-#include "API/errors.h"
-#include "Config/QSSConfig.h"
 #include "HAL/TargetSystem.h"
 
 #include "mlir/IR/BuiltinOps.h"

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -14,6 +14,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "API/errors.h"
+#include "Config/QSSConfig.h"
+#include "HAL/Compile/TargetCompilationManager.h"
+#include "HAL/TargetSystem.h"
+
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Operation.h"
@@ -25,11 +30,9 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/raw_ostream.h"
-
-#include "HAL/Compile/TargetCompilationManager.h"
-#include "HAL/TargetSystem.h"
 
 using namespace qssc::hal::compile;
 
@@ -163,7 +166,7 @@ bool TargetCompilationManager::emitDiagnostics() {
   using namespace qssc::config;
   // NOLINTNEXTLINE(misc-const-correctness)
   bool foundError = false;
-  DiagList diagnostics(target.getDiagnostics());
+  const DiagList diagnostics(target.getDiagnostics());
   for (auto &diag : diagnostics) {
     auto severity = diag.severity;
     switch (config.getVerbosityLevel()) {

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -221,6 +221,6 @@ bool TargetCompilationManager::emitDiagnostics() {
     default:
       llvm_unreachable("Unknown verbosity level");
     } // end switch for config verbosity
-  } // end for diag in diagnostics list
+  }   // end for diag in diagnostics list
   return foundError;
 }

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -197,6 +197,7 @@ bool TargetCompilationManager::emitDiagnostics() {
         llvm::errs() << diag.toString() << "\n";
         break;
       case Severity::Info:
+        break;
       default:
         llvm_unreachable("Unknown diagnostic severity");
       }
@@ -209,17 +210,17 @@ bool TargetCompilationManager::emitDiagnostics() {
         foundError = true;
         [[fallthrough]];
       case Severity::Warning:
+      case Severity::Info:
         (void)qssc::emitDiagnostic(diagnosticCb, diag);
         llvm::errs() << diag.toString() << "\n";
         break;
-      case Severity::Info:
       default:
         llvm_unreachable("Unknown diagnostic severity");
       }
       break;
     default:
       llvm_unreachable("Unknown verbosity level");
-    }
-  }
+    } // end switch for config verbosity
+  } // end for diag in diagnostics list
   return foundError;
 }

--- a/lib/HAL/Compile/TargetCompilationManager.cpp
+++ b/lib/HAL/Compile/TargetCompilationManager.cpp
@@ -14,9 +14,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "HAL/Compile/TargetCompilationManager.h"
+
 #include "API/errors.h"
 #include "Config/QSSConfig.h"
-#include "HAL/Compile/TargetCompilationManager.h"
 #include "HAL/TargetSystem.h"
 
 #include "mlir/IR/BuiltinOps.h"

--- a/lib/HAL/Compile/ThreadedCompilationManager.cpp
+++ b/lib/HAL/Compile/ThreadedCompilationManager.cpp
@@ -45,8 +45,9 @@ using namespace qssc::hal::compile;
 
 ThreadedCompilationManager::ThreadedCompilationManager(
     qssc::hal::TargetSystem &target, mlir::MLIRContext *context,
+    const OptDiagnosticCallback &diagnosticCb,
     ThreadedCompilationManager::PMBuilder pmBuilder)
-    : TargetCompilationManager(target, context),
+    : TargetCompilationManager(target, context, diagnosticCb),
       pmBuilder(std::move(pmBuilder)) {}
 
 const std::string ThreadedCompilationManager::getName() const {

--- a/lib/HAL/Compile/ThreadedCompilationManager.cpp
+++ b/lib/HAL/Compile/ThreadedCompilationManager.cpp
@@ -16,8 +16,6 @@
 
 #include "HAL/Compile/ThreadedCompilationManager.h"
 
-#include "API/errors.h"
-#include "Config/QSSConfig.h"
 #include "HAL/Compile/TargetCompilationManager.h"
 #include "HAL/TargetSystem.h"
 #include "Payload/Payload.h"

--- a/lib/HAL/Compile/ThreadedCompilationManager.cpp
+++ b/lib/HAL/Compile/ThreadedCompilationManager.cpp
@@ -245,7 +245,7 @@ llvm::Error ThreadedCompilationManager::compileMLIR(mlir::ModuleOp moduleOp) {
   auto err = walkTargetModulesThreaded(&target, moduleOp, targetsTiming,
                                        threadedCompileMLIRTarget,
                                        postChildrenEmitToPayload);
-  emitDiagnostics();
+  emitTargetDiagnostics();
   return err;
 }
 
@@ -315,7 +315,7 @@ ThreadedCompilationManager::compilePayload(mlir::ModuleOp moduleOp,
   auto err = walkTargetModulesThreaded(&target, moduleOp, targetsTiming,
                                        threadedCompilePayloadTarget,
                                        postChildrenEmitToPayload);
-  emitDiagnostics();
+  emitTargetDiagnostics();
   return err;
 }
 

--- a/lib/HAL/Compile/ThreadedCompilationManager.cpp
+++ b/lib/HAL/Compile/ThreadedCompilationManager.cpp
@@ -16,6 +16,8 @@
 
 #include "HAL/Compile/ThreadedCompilationManager.h"
 
+#include "API/errors.h"
+#include "Config/QSSConfig.h"
 #include "HAL/Compile/TargetCompilationManager.h"
 #include "HAL/TargetSystem.h"
 #include "Payload/Payload.h"

--- a/lib/HAL/Compile/ThreadedCompilationManager.cpp
+++ b/lib/HAL/Compile/ThreadedCompilationManager.cpp
@@ -47,9 +47,8 @@ using namespace qssc::hal::compile;
 
 ThreadedCompilationManager::ThreadedCompilationManager(
     qssc::hal::TargetSystem &target, mlir::MLIRContext *context,
-    const config::QSSConfig &config, const OptDiagnosticCallback &diagnosticCb,
     ThreadedCompilationManager::PMBuilder pmBuilder)
-    : TargetCompilationManager(target, context, config, diagnosticCb),
+    : TargetCompilationManager(target, context),
       pmBuilder(std::move(pmBuilder)) {}
 
 const std::string ThreadedCompilationManager::getName() const {
@@ -245,7 +244,6 @@ llvm::Error ThreadedCompilationManager::compileMLIR(mlir::ModuleOp moduleOp) {
   auto err = walkTargetModulesThreaded(&target, moduleOp, targetsTiming,
                                        threadedCompileMLIRTarget,
                                        postChildrenEmitToPayload);
-  emitTargetDiagnostics();
   return err;
 }
 
@@ -315,7 +313,6 @@ ThreadedCompilationManager::compilePayload(mlir::ModuleOp moduleOp,
   auto err = walkTargetModulesThreaded(&target, moduleOp, targetsTiming,
                                        threadedCompilePayloadTarget,
                                        postChildrenEmitToPayload);
-  emitTargetDiagnostics();
   return err;
 }
 

--- a/lib/HAL/Compile/ThreadedCompilationManager.cpp
+++ b/lib/HAL/Compile/ThreadedCompilationManager.cpp
@@ -45,9 +45,9 @@ using namespace qssc::hal::compile;
 
 ThreadedCompilationManager::ThreadedCompilationManager(
     qssc::hal::TargetSystem &target, mlir::MLIRContext *context,
-    const OptDiagnosticCallback &diagnosticCb,
+    const config::QSSConfig &config, const OptDiagnosticCallback &diagnosticCb,
     ThreadedCompilationManager::PMBuilder pmBuilder)
-    : TargetCompilationManager(target, context, diagnosticCb),
+    : TargetCompilationManager(target, context, config, diagnosticCb),
       pmBuilder(std::move(pmBuilder)) {}
 
 const std::string ThreadedCompilationManager::getName() const {

--- a/lib/HAL/Compile/ThreadedCompilationManager.cpp
+++ b/lib/HAL/Compile/ThreadedCompilationManager.cpp
@@ -243,6 +243,7 @@ llvm::Error ThreadedCompilationManager::compileMLIR(mlir::ModuleOp moduleOp) {
   auto err = walkTargetModulesThreaded(&target, moduleOp, targetsTiming,
                                        threadedCompileMLIRTarget,
                                        postChildrenEmitToPayload);
+  emitDiagnostics();
   return err;
 }
 
@@ -312,6 +313,7 @@ ThreadedCompilationManager::compilePayload(mlir::ModuleOp moduleOp,
   auto err = walkTargetModulesThreaded(&target, moduleOp, targetsTiming,
                                        threadedCompilePayloadTarget,
                                        postChildrenEmitToPayload);
+  emitDiagnostics();
   return err;
 }
 

--- a/python_lib/qss_compiler/compile.py
+++ b/python_lib/qss_compiler/compile.py
@@ -302,7 +302,7 @@ def _do_compile(
         for diag in diagnostics:
             if diag.category == ErrorCategory.QSSCompilerSequenceTooLong:
                 raise exceptions.QSSCompilerSequenceTooLong(
-                    diag.message, # TODO: Code reviewers: Is this safe?
+                    diag.message,  # TODO: Code reviewers: Is this safe?
                     diagnostics,
                     return_diagnostics=return_diagnostics,
                 )
@@ -398,9 +398,7 @@ async def compile_file_async(
     execution = _CompilerExecution(input_file=input_file, options=compile_options)
     with ThreadPoolExecutor() as executor:
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(
-            executor, _do_compile, execution, return_diagnostics
-        )
+        return await loop.run_in_executor(executor, _do_compile, execution, return_diagnostics)
     # As an alternative, ProcessPoolExecutor has somewhat higher overhead yet
     # reduces complexity of integration by not requiring the preparatory call
     # to set_start_method.
@@ -462,9 +460,7 @@ async def compile_str_async(
     execution = _CompilerExecution(input_str=input_str, options=compile_options)
     with ThreadPoolExecutor() as executor:
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(
-            executor, _do_compile, execution, return_diagnostics
-        )
+        return await loop.run_in_executor(executor, _do_compile, execution, return_diagnostics)
     # As an alternative, ProcessPoolExecutor has somewhat higher overhead yet
     # reduces complexity of integration by not requiring the preparatory call
     # to set_start_method.

--- a/python_lib/qss_compiler/compile.py
+++ b/python_lib/qss_compiler/compile.py
@@ -293,7 +293,7 @@ class _CompilationManager:
             for diag in diagnostics:
                 if diag.category == ErrorCategory.QSSCompilerSequenceTooLong:
                     raise exceptions.QSSCompilerSequenceTooLong(
-                        diag.message,  # TODO: Code reviewers: Is this safe?
+                        diag.message,
                         diagnostics,
                         return_diagnostics=self.return_diagnostics,
                     )

--- a/python_lib/qss_compiler/compile.py
+++ b/python_lib/qss_compiler/compile.py
@@ -220,9 +220,7 @@ class _CompilationManager:
         parent_side, child_side = mp_ctx.Pipe(duplex=True)
 
         try:
-            childproc = mp_ctx.Process(
-                target=self._compile_child_runner, args=(child_side,)
-            )
+            childproc = mp_ctx.Process(target=self._compile_child_runner, args=(child_side,))
             childproc.start()
 
             parent_side.send(None)
@@ -324,9 +322,7 @@ class _CompilationManager:
 
 
 class _CompileFile(_CompilationManager):
-    def __init__(
-        self, compile_options: CompileOptions, return_diagnostics: bool, input_file: str
-    ):
+    def __init__(self, compile_options: CompileOptions, return_diagnostics: bool, input_file: str):
         super().__init__(compile_options, return_diagnostics)
         self.input_file = stringify_path(input_file)
 

--- a/python_lib/qss_compiler/exceptions.py
+++ b/python_lib/qss_compiler/exceptions.py
@@ -65,6 +65,10 @@ class QSSCompilerNonZeroStatus(QSSCompilerError):
     """Raised when non-zero status is returned."""
 
 
+class QSSCompilerSequenceTooLong(QSSCompilerError):
+    """Raised when input sequence is too long."""
+
+
 class QSSCompilationFailure(QSSCompilerError):
     """Raised during other compilation failure."""
 

--- a/python_lib/qss_compiler/lib_enums.cpp
+++ b/python_lib/qss_compiler/lib_enums.cpp
@@ -24,6 +24,8 @@ void addErrorCategory(py::module &m) {
              qssc::ErrorCategory::QSSCompilerEOFFailure)
       .value("QSSCompilerNonZeroStatus",
              qssc::ErrorCategory::QSSCompilerNonZeroStatus)
+      .value("QSSCompilerSequenceTooLong",
+             qssc::ErrorCategory::QSSCompilerSequenceTooLong)
       .value("QSSCompilationFailure",
              qssc::ErrorCategory::QSSCompilationFailure)
       .value("QSSLinkerNotImplemented",

--- a/releasenotes/notes/user-error-updates-3fe6706fbf8ffab8.yaml
+++ b/releasenotes/notes/user-error-updates-3fe6706fbf8ffab8.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    User-facing diagnostics will now be collected from targets for forwarding
+    to the python library. The python library will raise exceptions specific to
+    user-facing diagnostics as appropriate. As an example, a new user diagnostic
+    was added for jobs that are too long.


### PR DESCRIPTION
This PR supersedes #211 

Adds diagnostic tracking to targets, updates the API to check for and emit diagnostics stored in the target, updates the python interface to raise exceptions based on returned diagnostics, and adds a new error/exception for sequences that are too long.
