### PR TITLE
Register Pulse Dialect with LoadPulseCals pass.

### DIFF
--- a/include/Conversion/QUIRToPulse/LoadPulseCals.h
+++ b/include/Conversion/QUIRToPulse/LoadPulseCals.h
@@ -55,6 +55,8 @@ struct LoadPulseCalsPass
 
   void runOnOperation() override;
 
+  void getDependentDialects(mlir::DialectRegistry &registry) const override;
+
   llvm::StringRef getArgument() const override;
   llvm::StringRef getDescription() const override;
   llvm::StringRef getName() const override;

--- a/lib/Conversion/QUIRToPulse/LoadPulseCals.cpp
+++ b/lib/Conversion/QUIRToPulse/LoadPulseCals.cpp
@@ -20,6 +20,7 @@
 
 #include "Conversion/QUIRToPulse/LoadPulseCals.h"
 
+#include "Dialect/Pulse/IR/PulseDialect.h"
 #include "Dialect/Pulse/IR/PulseOps.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
 #include "Dialect/QUIR/IR/QUIRTraits.h"
@@ -667,4 +668,8 @@ llvm::StringRef LoadPulseCalsPass::getDescription() const {
 
 llvm::StringRef LoadPulseCalsPass::getName() const {
   return "Load Pulse Calibrations Pass";
+}
+
+void LoadPulseCalsPass::getDependentDialects(DialectRegistry &registry) const {
+  registry.insert<PulseDialect>();
 }


### PR DESCRIPTION
This fixes an assertion in the debug builds by registering the pulse dialect before the ThreadedCompilationManager is run.