### PR TITLE
Test for overlap with all quantum operations in MergeCircuitsPass

### DIFF
--- a/lib/Dialect/QUIR/Transforms/MergeCircuits.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuits.cpp
@@ -96,17 +96,16 @@ struct CircuitAndCircuitPattern : public OpRewritePattern<CallCircuitOp> {
       if (nextCallCircuitOp)
         break;
 
-      // check for overlapping BarrierOp and fail if found
-      auto barrierOp = dyn_cast<BarrierOp>(*secondOp);
-      if (barrierOp) {
-        std::set<uint> firstQubits =
-            QubitOpInterface::getOperatedQubits(callCircuitOp);
-        std::set<uint> secondQubits =
-            QubitOpInterface::getOperatedQubits(barrierOp);
+      // check for overlap in qubits between the circuit and the
+      // next quantum circuit which is not a CallCircuit
+      // fail if there is overlap
+      std::set<uint> firstQubits =
+          QubitOpInterface::getOperatedQubits(callCircuitOp);
+      std::set<uint> secondQubits =
+          QubitOpInterface::getOperatedQubits(*secondOp);
 
-        if (QubitOpInterface::qubitSetsOverlap(firstQubits, secondQubits))
-          return failure();
-      }
+      if (QubitOpInterface::qubitSetsOverlap(firstQubits, secondQubits))
+        return failure();
 
       searchOp = *secondOp;
     }

--- a/releasenotes/notes/test-overlap-all-5d170626357867d6.yaml
+++ b/releasenotes/notes/test-overlap-all-5d170626357867d6.yaml
@@ -3,4 +3,4 @@ fixes:
   - |
     Fixes bug related to assumption in MergeCircuitsPass that all quantum instructions
     are located in a quir.circuit when attempting to merge circuits. Applies the qubit overlap
-    test to all quantum operations in between quir.call_circuit calls. 
+    test to all quantum operations in between quir.call_circuit calls.

--- a/releasenotes/notes/test-overlap-all-5d170626357867d6.yaml
+++ b/releasenotes/notes/test-overlap-all-5d170626357867d6.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes bug related to assumption in MergeCircuitsPass that all quantum instructions
+    are located in a quir.circuit when attempting to merge circuits. Applies the qubit overlap
+    test to all quantum operations in between quir.call_circuit calls. 

--- a/test/Dialect/QUIR/Transforms/merge-circuits.mlir
+++ b/test/Dialect/QUIR/Transforms/merge-circuits.mlir
@@ -57,6 +57,11 @@ module {
     %1 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
     quir.return %0, %1: i1, i1
   }
+  quir.circuit @circuit_9(%arg0: !quir.qubit<1>) -> (i1, i1) {
+    %0 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
+    %1 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
+    quir.return %0, %1: i1, i1
+  }
   // CHECK: @circuit_0_q0_circuit_1_q1(%arg0: !quir.qubit<1>
   // CHECK: %0 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
   // CHECK: %1 = quir.measure(%arg1) : (!quir.qubit<1>) -> i1
@@ -125,6 +130,15 @@ module {
     quir.barrier %0 : (!quir.qubit<1>) -> ()
     %17:2 = quir.call_circuit @circuit_8(%0) : (!quir.qubit<1>) -> (i1, i1)
     // CHECK-NOT: %{{.*}}:4 = quir.call_circuit @circuit_8_q0_circuit_8_q0(%0) : (!quir.qubit<1>) -> (i1, i1, i1, i1)
+
+    quir.barrier %0, %1, %200, %201, %202 : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> ()
+    %18:2 = quir.call_circuit @circuit_9(%0) : (!quir.qubit<1>) -> (i1, i1)
+    // CHECK: %{{.*}}:2 = quir.call_circuit @circuit_9_q0(%0) : (!quir.qubit<1>) -> (i1, i1)
+    %19 = quir.measure(%0) {quir.noReportRuntime} : (!quir.qubit<1>) -> i1
+    // CHECK: %{{.*}} = quir.measure(%0) {quir.noReportRuntime} : (!quir.qubit<1>) -> i1
+    %20:2 = quir.call_circuit @circuit_9(%0) : (!quir.qubit<1>) -> (i1, i1)
+    // CHECK: %{{.*}}:2 = quir.call_circuit @circuit_9_q0(%0) : (!quir.qubit<1>) -> (i1, i1)
+    // CHECK-NOT: %{{.*}}:4 = quir.call_circuit @circuit_9_q0_circuit_9_q0(%0) : (!quir.qubit<1>) -> (i1, i1, i1, i1)
 
     %c0_i32 = arith.constant 0 : i32
     return %c0_i32 : i32


### PR DESCRIPTION
The `MergeCircuitsPass` assumed that the only quantum operation between `quir.call_circuits` operations would be `quir.barriers`. This assumption failed with the `BreakResetsPass` which currently inserts `quir.measure` and `quir.call_gate @x` in the `main` function. 

One way to fix this would be to adjust `BreakResetsPass` to be `--enable-circuits` aware. The alternative implemented here is to handle operations other than barriers between `quir.circuit_ops` and test for qubit overlap in the same way currently being applied to `quir.barriers`. 

This alternative was chosen so that existing and future passes would not be required to be "quir.circuit" aware and therefore `MergeCircuitsPass` would be more robust to that situation. 