### PR TITLE
[Backport 3.7] Backport CI changes to 3.7

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# This file defines the set of people responsible for different sections of the
+# codebase
+#
+# Being listed as a code owner on a section here means that user is empowered
+# to approve and merge pull requests for that section of code. It also comes
+# with an expected responsibility to review and maintain those subsections of
+# the repository.
+#
+# A PR can be merged when approved by at least one codeowner. For PRs that touch
+# more than one section with non-overlapping codeowners more than one codeowner
+# may be required to approve a PR.
+#
+# However, every contributor to the project can (and should!) review open PRs. This
+# file is just about outlining responsibility for maintainership and final
+# review/merging of PRs in different subsections of the repository.
+
+# Global rule, unless specialized by a later one
+* @openqasm/qe-maintainers
+
+# folders (also their corresponding tests)
+
+# Override the release notes directories to have _no_ code owners, so any review
+# from somebody with write access is acceptable.
+/releasenotes/notes

--- a/.github/renos_updated.sh
+++ b/.github/renos_updated.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This script makes sure a reno has been updated in the PR.
+
+reno lint
+
+CHANGED_FILES=$(git diff --name-only origin/main $GITHUB_SHA)
+for file in $CHANGED_FILES
+do
+   root=$(echo "./$file" | awk -F/ '{print FS $2}' | cut -c2-)
+   if [ "$root" = "releasenotes" ]; then
+       exit 0;
+   fi
+done
+
+echo Please add or update a release note in ./releasenotes >&2
+exit 1

--- a/.github/workflows/clang_tidy_review_comments.yml
+++ b/.github/workflows/clang_tidy_review_comments.yml
@@ -1,0 +1,37 @@
+# (C) Copyright IBM 2024.
+#
+# This code is part of Qiskit.
+#
+# This code is licensed under the Apache License, Version 2.0 with LLVM
+# Exceptions. You may obtain a copy of this license in the LICENSE.txt
+# file in the root directory of this source tree.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Workaround CI permissions for forks
+# https://github.com/ZedThree/clang-tidy-review?tab=readme-ov-file#usage-in-fork-environments-split-workflow
+name: Post clang-tidy review comments
+
+on:
+  workflow_run:
+    # The name field of the lint action
+    # Defined in lint.yml workflow
+    workflows:
+      - Static Checks
+    types:
+      - completed
+
+jobs:
+  post-clang-tidy:
+    name: Post clang-tidy review comments
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ZedThree/clang-tidy-review/post@v0.14.0
+        # lgtm_comment_body, max_comments, and annotations need to be set on the posting workflow in a split setup
+        with:
+          # adjust options as necessary
+          lgtm_comment_body: ''
+          annotations: false
+          max_comments: 10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,15 +43,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
-      - name: Static checks
-        id: static_checks
-        if: github.event_name == 'pull_request'
-        run: pre-commit run --all-files --show-diff-on-failure
-      - name: Validate releasenotes
-        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-reno')
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-        run: ./.github/renos_updated.sh
       - name: Export QSSC_VERSION from Git version tag
         run: |
           version=`python -c "from setuptools_scm import get_version; print(get_version())"`

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,16 +78,20 @@ jobs:
         working-directory: build
         run: |
           export CONAN_LLVM_GIT_CACHE="${{ runner.temp }}/llvm-project"
-          build_requires=$(conan info .. -pr:h default -pr:b default --build=outdated 2>/dev/null)
-          if [[ "$build_requires" == *"Outdated package!"* ]];
+          conan info .. -pr:h default -pr:b default --build=outdated --json build_requires.json
+          build_requires=$(cat build_requires.json)
+          if [[ "$build_requires" == *"[]"* ]];
           then
-              all_in_cache=false
-          else
               all_in_cache=true
+          else
+              all_in_cache=false
           fi
           echo "all_in_cache=$all_in_cache" >> $GITHUB_OUTPUT
           echo "Conan build requires: $build_requires"
           echo "Conan cache is complete: $all_in_cache"
+      # If we have a cache miss on 'main', clear the cache.
+      # A dependency was updated, so we need to drop the old one
+      # to prevent unbounded cache growth over time.
       - name: Conan install
         id: conan_install
         working-directory: build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,15 +71,16 @@ jobs:
         working-directory: build
         run: |
           export CONAN_LLVM_GIT_CACHE="${{ runner.temp }}/llvm-project"
-          conan install .. -pr:h default -pr:b default
-          if [ $? -ne 0 ]
+          build_requires=$(conan info .. -pr:h default -pr:b default --build=outdated 2>/dev/null)
+          if [[ "$build_requires" == *"Outdated package!"* ]];
           then
-              cache_hit=false
+              all_in_cache=false
           else
-              cache_hit=true
+              all_in_cache=true
           fi
-          echo "cache_hit=$cache_hit" >> $GITHUB_OUTPUT
-          echo "Cache was hit: $cache_hit"
+          echo "all_in_cache=$all_in_cache" >> $GITHUB_OUTPUT
+          echo "Conan build requires: $build_requires"
+          echo "Conan cache is complete: $all_in_cache"
       - name: Conan install
         id: conan_install
         working-directory: build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,42 +56,22 @@ jobs:
         run: |
           version=`python -c "from setuptools_scm import get_version; print(get_version())"`
           echo "QSSC_VERSION=$version" >> $GITHUB_ENV
+      - name: Prepare Conan
+        run: |
+          conan profile new default --detect || true
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+          # Add QASM, LLVM, and clang tools recipes to Conan cache.
+          ./conan_deps.sh
+          conan lock create conanfile.py -pr:h default -pr:b default --build=outdated
       - name: Load Conan cache
         id: cache
         uses: actions/cache/restore@v3
         with:
           path: .conan
           key: conan-${{ runner.os }}
-          restore-keys: conan-${{ runner.os }}
-      - name: Create Conan default profile
-        run: |
-          conan profile new default --detect || true
-          conan profile update settings.compiler.libcxx=libstdc++11 default
-      - name: Add QASM, LLVM, and clang tools recipes to Conan cache.
-        run: ./conan_deps.sh
+          restore-keys: conan-${{ runner.os }}-${{ hashFiles('conan.lock') }}
       - name: Create build dir
         run: mkdir build
-      # Check if all conan packages are within the cache. If not
-      # we will need to build packages (and if on main flush the cache)
-      - name : Check Conan dependencies are cached
-        id: check_conan_cache
-        working-directory: build
-        run: |
-          export CONAN_LLVM_GIT_CACHE="${{ runner.temp }}/llvm-project"
-          conan info .. -pr:h default -pr:b default --build=outdated --json build_requires.json
-          build_requires=$(cat build_requires.json)
-          if [[ "$build_requires" == *"[]"* ]];
-          then
-              all_in_cache=true
-          else
-              all_in_cache=false
-          fi
-          echo "all_in_cache=$all_in_cache" >> $GITHUB_OUTPUT
-          echo "Conan build requires: $build_requires"
-          echo "Conan cache is complete: $all_in_cache"
-      # If we have a cache miss on 'main', clear the cache.
-      # A dependency was updated, so we need to drop the old one
-      # to prevent unbounded cache growth over time.
       - name: Conan install
         id: conan_install
         working-directory: build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,14 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 name: Static Checks
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release/**'
+      - '**/release/**'
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 jobs:
   Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2024.
 #
 # This code is part of Qiskit.
 #
@@ -9,7 +9,7 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-name: Continuous Integration
+name: Static Checks
 on: [push, pull_request]
 jobs:
   Build:
@@ -20,7 +20,7 @@ jobs:
       - name: free-up-space
         run: |
           df -h
-          sudo rm -rf /usr/share/dotnet   
+          sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
@@ -28,11 +28,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      # -- REMOVE ONCE OPEN SOURCE
-      # Needed until Qiskit/qss-qasm is public.
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -41,27 +36,26 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
+      - name: Static checks
+        id: static_checks
+        if: github.event_name == 'pull_request'
+        run: pre-commit run --all-files --show-diff-on-failure
+      - name: Validate releasenotes
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-reno')
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        run: ./.github/renos_updated.sh
       - name: Export QSSC_VERSION from Git version tag
         run: |
           version=`python -c "from setuptools_scm import get_version; print(get_version())"`
           echo "QSSC_VERSION=$version" >> $GITHUB_ENV
-      - name: Try load Conan cache
+      - name: Load Conan cache
         id: cache
         uses: actions/cache/restore@v3
         with:
           path: .conan
-          key: conan-${{ runner.os }}-${{ hashFiles('conandata.yml', 'conanfile.py', 'conan/**/*.py', 'conan/**/*.yml') }}
+          key: conan-${{ runner.os }}
           restore-keys: conan-${{ runner.os }}
-      - name : Print cache hit/miss
-        run: |
-          echo "Cache was hit: ${{ steps.cache.outputs.cache-hit }}"
-      # If we have a cache miss on 'main', clear the cache.
-      # A dependency was updated, so we need to drop the old one
-      # to prevent unbounded cache growth over time.
-      - name : Clear Conan cache
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.cache.outputs.cache-hit != 'true'
-        run: |
-          rm -rf ./.conan
       - name: Create Conan default profile
         run: |
           conan profile new default --detect || true
@@ -70,43 +64,43 @@ jobs:
         run: ./conan_deps.sh
       - name: Create build dir
         run: mkdir build
+      # Check if all conan packages are within the cache. If not
+      # we will need to build packages (and if on main flush the cache)
+      - name : Check Conan dependencies are cached
+        id: check_conan_cache
+        working-directory: build
+        run: |
+          export CONAN_LLVM_GIT_CACHE="${{ runner.temp }}/llvm-project"
+          conan install .. -pr:h default -pr:b default
+          if [ $? -ne 0 ]
+          then
+              cache_hit=false
+          else
+              cache_hit=true
+          fi
+          echo "cache_hit=$cache_hit" >> $GITHUB_OUTPUT
+          echo "Cache was hit: $cache_hit"
       - name: Conan install
         id: conan_install
         working-directory: build
         run: |
           export CONAN_LLVM_GIT_CACHE="${{ runner.temp }}/llvm-project"
           conan install .. --build=outdated -pr:h default -pr:b default
-      - name: Build
-        id: build
+      - name: Configure
+        id: configure
         working-directory: build
         run: |
-          conan build ..
-      - name: Test
-        id: test
-        working-directory: build
-        run: conan build .. --test
-
-      # On 'pull_request' run Clang tidy
+          conan build .. --configure
+      # Workaround CI permissions for forks
+      # https://github.com/ZedThree/clang-tidy-review?tab=readme-ov-file#usage-in-fork-environments-split-workflow
+      # The name is sensitive make sure to also update `clang-tidy-review-comments.yml` workflow
       - name: Clang tidy
-        uses: ZedThree/clang-tidy-review@v0.10.0
+        uses: ZedThree/clang-tidy-review@v0.14.0
         id: clang_tidy
         if: github.event_name == 'pull_request'
         with:
           config_file: '.clang-tidy'
           build_dir: build
-
-      # On 'pull_request' run Clang format and commit the changes
-      - name: Clang format
-        id: clang_format
-        if: github.event_name == 'pull_request'
-        working-directory: build
-        run: ninja check-format
-
-      # On 'main' branch, always save the cache if Conan install succeeded.
-      # Note: we only update the cache from 'main' to avoid "cache thrashing", which would result in the 'main'
-      #       cache getting LRU-evicted for every PR, since a single run uses most of the 10GB repo limit.
-      - uses: actions/cache/save@v3
-        if: always() && (github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.conan_install.outcome == 'success' && steps.cache.outputs.cache-hit != 'true')
-        with:
-          path: .conan
-          key: conan-${{ runner.os }}-${{ hashFiles('conandata.yml', 'conanfile.py', 'conan/**/*.py', 'conan/**/*.yml') }}
+          split_workflow: true
+      - name: Clang tidy upload
+        uses: ZedThree/clang-tidy-review/upload@v0.14.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,12 +62,13 @@ jobs:
         working-directory: build
         run: |
           export CONAN_LLVM_GIT_CACHE="${{ runner.temp }}/llvm-project"
-          build_requires=$(conan info .. -pr:h default -pr:b default --build=outdated 2>/dev/null)
-          if [[ "$build_requires" == *"Outdated package!"* ]];
+          conan info .. -pr:h default -pr:b default --build=outdated --json build_requires.json
+          build_requires=$(cat build_requires.json)
+          if [[ "$build_requires" == *"[]"* ]];
           then
-              all_in_cache=false
-          else
               all_in_cache=true
+          else
+              all_in_cache=false
           fi
           echo "all_in_cache=$all_in_cache" >> $GITHUB_OUTPUT
           echo "Conan build requires: $build_requires"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,104 @@
+# (C) Copyright IBM 2023, 2024.
+#
+# This code is part of Qiskit.
+#
+# This code is licensed under the Apache License, Version 2.0 with LLVM
+# Exceptions. You may obtain a copy of this license in the LICENSE.txt
+# file in the root directory of this source tree.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+name: Build
+on: [push, pull_request]
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    env:
+      CONAN_USER_HOME: ${{ github.workspace }}
+    steps:
+      - name: free-up-space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          df -h
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10.9'
+      - name: Install pip packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Export QSSC_VERSION from Git version tag
+        run: |
+          version=`python -c "from setuptools_scm import get_version; print(get_version())"`
+          echo "QSSC_VERSION=$version" >> $GITHUB_ENV
+      - name: Load Conan cache
+        id: cache
+        uses: actions/cache/restore@v3
+        with:
+          path: .conan
+          key: conan-${{ runner.os }}
+          restore-keys: conan-${{ runner.os }}
+      - name: Create Conan default profile
+        run: |
+          conan profile new default --detect || true
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+      - name: Add QASM, LLVM, and clang tools recipes to Conan cache.
+        run: ./conan_deps.sh
+      - name: Create build dir
+        run: mkdir build
+      # Check if all conan packages are within the cache. If not
+      # we will need to build packages (and if on main flush the cache)
+      - name : Check Conan dependencies are cached
+        id: check_conan_cache
+        working-directory: build
+        run: |
+          export CONAN_LLVM_GIT_CACHE="${{ runner.temp }}/llvm-project"
+          conan install .. -pr:h default -pr:b default
+          if [ $? -ne 0 ]
+          then
+              cache_hit=false
+          else
+              cache_hit=true
+          fi
+          echo "cache_hit=$cache_hit" >> $GITHUB_OUTPUT
+          echo "Cache was hit: $cache_hit"
+      # If we have a cache miss on 'main', clear the cache.
+      # A dependency was updated, so we need to drop the old one
+      # to prevent unbounded cache growth over time.
+      - name : Clear Conan cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check_conan_cache.outputs.cache_hit != 'true'
+        run: |
+          echo "Cache was hit: ${{ steps.check_conan_cache.outputs.cache_hit }}"
+          rm -rf ./.conan
+      - name: Conan install
+        id: conan_install
+        working-directory: build
+        run: |
+          export CONAN_LLVM_GIT_CACHE="${{ runner.temp }}/llvm-project"
+          conan install .. --build=outdated -pr:h default -pr:b default
+      - name: Build
+        id: build
+        working-directory: build
+        run: |
+          conan build ..
+      - name: Test
+        id: test
+        working-directory: build
+        run: conan build .. --test
+      # On 'main' branch, always save the cache if Conan install succeeded.
+      # Note: we only update the cache from 'main' to avoid "cache thrashing", which would result in the 'main'
+      #       cache getting LRU-evicted for every PR, since a single run uses most of the 10GB repo limit.
+      - uses: actions/cache/save@v3
+        if: always() && (github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.conan_install.outcome == 'success' && steps.check_conan_cache.outputs.cache_hit != 'true')
+        with:
+          path: .conan
+          key: conan-${{ runner.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 name: Build
-on:
-  push:
-    branches:
-      - 'main'
-      - 'release/**'
-      - '**/release/**'
-  pull_request:
-    types: [opened, reopened, labeled, unlabeled, synchronize]
+on: [push, pull_request]
 jobs:
   Build:
     runs-on: ubuntu-latest
@@ -86,6 +79,8 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check_conan_cache.outputs.all_in_cache != 'true'
         run: |
           rm -rf ./.conan
+          # Re-add conan deps after flushing the conan cache before building packages.
+          ./conan_deps.sh
       - name: Conan install
         id: conan_install
         working-directory: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,14 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 name: Build
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release/**'
+      - '**/release/**'
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 jobs:
   Build:
     runs-on: ubuntu-latest
@@ -62,22 +69,22 @@ jobs:
         working-directory: build
         run: |
           export CONAN_LLVM_GIT_CACHE="${{ runner.temp }}/llvm-project"
-          conan install .. -pr:h default -pr:b default
-          if [ $? -ne 0 ]
+          build_requires=$(conan info .. -pr:h default -pr:b default --build=outdated 2>/dev/null)
+          if [[ "$build_requires" == *"Outdated package!"* ]];
           then
-              cache_hit=false
+              all_in_cache=false
           else
-              cache_hit=true
+              all_in_cache=true
           fi
-          echo "cache_hit=$cache_hit" >> $GITHUB_OUTPUT
-          echo "Cache was hit: $cache_hit"
+          echo "all_in_cache=$all_in_cache" >> $GITHUB_OUTPUT
+          echo "Conan build requires: $build_requires"
+          echo "Conan cache is complete: $all_in_cache"
       # If we have a cache miss on 'main', clear the cache.
       # A dependency was updated, so we need to drop the old one
       # to prevent unbounded cache growth over time.
       - name : Clear Conan cache
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check_conan_cache.outputs.cache_hit != 'true'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check_conan_cache.outputs.all_in_cache != 'true'
         run: |
-          echo "Cache was hit: ${{ steps.check_conan_cache.outputs.cache_hit }}"
           rm -rf ./.conan
       - name: Conan install
         id: conan_install
@@ -98,7 +105,7 @@ jobs:
       # Note: we only update the cache from 'main' to avoid "cache thrashing", which would result in the 'main'
       #       cache getting LRU-evicted for every PR, since a single run uses most of the 10GB repo limit.
       - uses: actions/cache/save@v3
-        if: always() && (github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.conan_install.outcome == 'success' && steps.check_conan_cache.outputs.cache_hit != 'true')
+        if: always() && (github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.conan_install.outcome == 'success' && steps.check_conan_cache.outputs.all_in_cache != 'true')
         with:
           path: .conan
           key: conan-${{ runner.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,8 @@ jobs:
         run: |
           rm -rf ./.conan
           # Re-add conan deps after flushing the conan cache before building packages.
+          conan profile new default --detect || true
+          conan profile update settings.compiler.libcxx=libstdc++11 default
           ./conan_deps.sh
       - name: Conan install
         id: conan_install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 name: Build
 on: [push, pull_request]
+
 jobs:
   Build:
     runs-on: ubuntu-latest
@@ -40,19 +41,20 @@ jobs:
         run: |
           version=`python -c "from setuptools_scm import get_version; print(get_version())"`
           echo "QSSC_VERSION=$version" >> $GITHUB_ENV
+      - name: Prepare Conan
+        run: |
+          conan profile new default --detect || true
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+          # Add QASM, LLVM, and clang tools recipes to Conan cache.
+          ./conan_deps.sh
+          conan lock create conanfile.py -pr:h default -pr:b default --build=outdated
       - name: Load Conan cache
         id: cache
         uses: actions/cache/restore@v3
         with:
           path: .conan
           key: conan-${{ runner.os }}
-          restore-keys: conan-${{ runner.os }}
-      - name: Create Conan default profile
-        run: |
-          conan profile new default --detect || true
-          conan profile update settings.compiler.libcxx=libstdc++11 default
-      - name: Add QASM, LLVM, and clang tools recipes to Conan cache.
-        run: ./conan_deps.sh
+          restore-keys: conan-${{ runner.os }}-${{ hashFiles('conan.lock') }}
       - name: Create build dir
         run: mkdir build
       # Check if all conan packages are within the cache. If not
@@ -61,7 +63,6 @@ jobs:
         id: check_conan_cache
         working-directory: build
         run: |
-          export CONAN_LLVM_GIT_CACHE="${{ runner.temp }}/llvm-project"
           conan info .. -pr:h default -pr:b default --build=outdated --json build_requires.json
           build_requires=$(cat build_requires.json)
           if [[ "$build_requires" == *"[]"* ]];
@@ -84,6 +85,7 @@ jobs:
           conan profile new default --detect || true
           conan profile update settings.compiler.libcxx=libstdc++11 default
           ./conan_deps.sh
+          conan lock create conanfile.py -pr:h default -pr:b default --build=outdated
       - name: Conan install
         id: conan_install
         working-directory: build
@@ -106,4 +108,4 @@ jobs:
         if: always() && (github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.conan_install.outcome == 'success' && steps.check_conan_cache.outputs.all_in_cache != 'true')
         with:
           path: .conan
-          key: conan-${{ runner.os }}
+          key: conan-${{ runner.os }}-${{ hashFiles('conan.lock') }}

--- a/conan/qasm/conanfile.py
+++ b/conan/qasm/conanfile.py
@@ -37,11 +37,7 @@ class QasmConan(ConanFile):
     description = "Compiler for OpenQASM3 language."
 
     def source(self):
-        token = os.environ.get("GITHUB_PAT")
-        if token is not None:
-            self.run(f"git clone https://{token}@github.com/Qiskit/qe-qasm.git .")
-        else:
-            self.run(f"git clone git@github.com:Qiskit/qe-qasm.git .")
+        self.run("git clone https://github.com/openqasm/qe-qasm.git .")
 
         commit_hash = self.conan_data["sources"]["hash"]
         self.run(f"git checkout {commit_hash}")

--- a/conan/qasm/conanfile.py
+++ b/conan/qasm/conanfile.py
@@ -21,7 +21,7 @@ import subprocess
 class QasmConan(ConanFile):
     name = "qasm"
     version = "0.2.14"
-    url = "https://github.com/Qiskit/qss-qasm.git"
+    url = "https://github.com/Qiskit/qe-qasm.git"
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False], "examples": [True, False]}
     default_options = {
@@ -39,9 +39,9 @@ class QasmConan(ConanFile):
     def source(self):
         token = os.environ.get("GITHUB_PAT")
         if token is not None:
-            self.run(f"git clone https://{token}@github.com/Qiskit/qss-qasm.git .")
+            self.run(f"git clone https://{token}@github.com/Qiskit/qe-qasm.git .")
         else:
-            self.run(f"git clone git@github.com:Qiskit/qss-qasm.git .")
+            self.run(f"git clone git@github.com:Qiskit/qe-qasm.git .")
 
         commit_hash = self.conan_data["sources"]["hash"]
         self.run(f"git checkout {commit_hash}")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,4 @@
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2024.
 #
 # This code is part of Qiskit.
 #
@@ -12,7 +12,6 @@
 import os
 
 from conans import ConanFile, CMake, tools
-from conans.tools import load
 
 
 # Get version from environment variable.
@@ -34,11 +33,10 @@ class QSSCompilerConan(ConanFile):
     author = "IBM Quantum development team"
     topics = ("Compiler", "Scheduler", "OpenQASM3")
     description = "An LLVM- and MLIR-based Quantum compiler that consumes OpenQASM 3.0"
-    generators = ["CMakeToolchain", "CMakeDeps"]
+    generators = ["CMakeToolchain", "CMakeDeps", "VirtualBuildEnv"]
     exports_sources = "*"
 
     def requirements(self):
-        tool_pkgs = ["llvm", "clang-tools-extra"]
         for req in self.conan_data["requirements"]:
             self.requires(req)
 
@@ -65,15 +63,18 @@ class QSSCompilerConan(ConanFile):
 
     def build(self):
         cmake = self._configure_cmake()
-        cmake.verbose = True
-        cmake.configure()
-        cmake.build()
 
-        if self.options.pythonlib:
-            self.run(
-            f"cd {self.build_folder}/python_lib \
-                    && pip install -e .[test]"
-            )
+        if self.should_configure:
+            cmake.configure()
+
+        if self.should_build:
+            cmake.build()
+
+            if self.options.pythonlib:
+                self.run(
+                    f"cd {self.build_folder}/python_lib \
+                        && pip install -e .[test]"
+                )
 
         if self.should_test:
             self.test(cmake)
@@ -85,7 +86,7 @@ class QSSCompilerConan(ConanFile):
 
         if self.options.pythonlib:
             self.run(
-            f"cd {self.build_folder}/python_lib \
+                f"cd {self.build_folder}/python_lib \
                     && pip install .[test]"
             )
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 breathe
 cmake>=3.23
-conan==1.59.0
+conan==1.62.0
 Jinja2==3.0.3 # https://github.com/sphinx-doc/sphinx/issues/10291
 lit>=12.0.0
 markupsafe==2.0.1


### PR DESCRIPTION
Backports changes to the `.github` directory only from the main branch to the `release_v3.7` branch. 