### PR TITLE
Add support for setting the maximum number of threads

### DIFF
--- a/include/Config/EnvVarConfig.h
+++ b/include/Config/EnvVarConfig.h
@@ -29,8 +29,10 @@ namespace qssc::config {
 /// These currently are:
 /// - `QSSC_TARGET_NAME`: Sets QSSConfig::targetName.
 /// - `QSSC_TARGET_CONFIG_PATH`: Sets QSSConfig::targetConfigPath.
-/// - `QSSC_VERBOSITY`: Set the compiler output verbosity. One of "ERROR/WARN/INFO/DEBUG".
-/// - `QSSC_MAX_THREADS`: Sets the maximum number of compiler threads when initializing the MLIR context's threadpool.
+/// - `QSSC_VERBOSITY`: Set the compiler output verbosity. One of
+/// "ERROR/WARN/INFO/DEBUG".
+/// - `QSSC_MAX_THREADS`: Sets the maximum number of compiler threads when
+/// initializing the MLIR context's threadpool.
 ///
 class EnvVarConfigBuilder : public QSSConfigBuilder {
 public:

--- a/include/Config/EnvVarConfig.h
+++ b/include/Config/EnvVarConfig.h
@@ -29,6 +29,8 @@ namespace qssc::config {
 /// These currently are:
 /// - `QSSC_TARGET_NAME`: Sets QSSConfig::targetName.
 /// - `QSSC_TARGET_CONFIG_PATH`: Sets QSSConfig::targetConfigPath.
+/// - `QSSC_VERBOSITY`: Set the compiler output verbosity. One of "ERROR/WARN/INFO/DEBUG".
+/// - `QSSC_MAX_THREADS`: Sets the maximum number of compiler threads when initializing the MLIR context's threadpool.
 ///
 class EnvVarConfigBuilder : public QSSConfigBuilder {
 public:
@@ -38,6 +40,7 @@ private:
   llvm::Error populateConfigurationPath_(QSSConfig &config);
   llvm::Error populateTarget_(QSSConfig &config);
   llvm::Error populateVerbosity_(QSSConfig &config);
+  llvm::Error populateMaxThreads_(QSSConfig &config);
 };
 
 } // namespace qssc::config

--- a/include/Config/QSSConfig.h
+++ b/include/Config/QSSConfig.h
@@ -197,6 +197,14 @@ public:
   }
   const std::vector<std::string> &getDialectPlugins() { return dialectPlugins; }
 
+  QSSConfig &setMaxThreads(unsigned int maxThreads_) {
+    maxThreads = std::move(maxThreads_);
+    return *this;
+  }
+  std::optional<unsigned int> getMaxThreads() const {
+    return maxThreads;
+  }
+
 public:
   /// @brief Emit the configuration to stdout.
   void emit(llvm::raw_ostream &out) const;
@@ -234,6 +242,8 @@ protected:
   std::vector<std::string> passPlugins;
   /// @brief Dialect plugin paths
   std::vector<std::string> dialectPlugins;
+  /// @brief If set, enforces the maximum number of MLIR context threads
+  std::optional<unsigned int> maxThreads;
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const QSSConfig &config);

--- a/include/Config/QSSConfig.h
+++ b/include/Config/QSSConfig.h
@@ -201,9 +201,7 @@ public:
     maxThreads = std::move(maxThreads_);
     return *this;
   }
-  std::optional<unsigned int> getMaxThreads() const {
-    return maxThreads;
-  }
+  std::optional<unsigned int> getMaxThreads() const { return maxThreads; }
 
 public:
   /// @brief Emit the configuration to stdout.

--- a/include/Config/QSSConfig.h
+++ b/include/Config/QSSConfig.h
@@ -198,7 +198,7 @@ public:
   const std::vector<std::string> &getDialectPlugins() { return dialectPlugins; }
 
   QSSConfig &setMaxThreads(unsigned int maxThreads_) {
-    maxThreads = std::move(maxThreads_);
+    maxThreads = maxThreads_;
     return *this;
   }
   std::optional<unsigned int> getMaxThreads() const { return maxThreads; }

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -60,6 +60,7 @@
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -628,6 +629,15 @@ llvm::Error qssc::compileMain(llvm::raw_ostream &outputStream,
   // The MLIR context for this compilation event.
   // Instantiate after parsing command line options.
   MLIRContext context{};
+
+  std::unique_ptr<llvm::ThreadPool> threadPool;
+  // Override default threadpool threads
+  if (context.isMultithreadingEnabled() && config.getMaxThreads().has_value()) {
+    llvm::ThreadPoolStrategy strategy;
+    strategy.ThreadsRequested = config.getMaxThreads().value();
+    threadPool = std::make_unique<llvm::ThreadPool>(strategy);
+    context.setThreadPool(*threadPool.get());
+  }
 
   qssc::config::setContextConfig(&context, config);
 

--- a/lib/Config/CLIConfig.cpp
+++ b/lib/Config/CLIConfig.cpp
@@ -313,8 +313,10 @@ struct QSSConfigCLOptions : public QSSConfig {
             llvm::cl::cat(qssc::config::getQSSOptCLCategory()));
 
     static llvm::cl::opt<int> maxThreads_(
-    "max-threads", llvm::cl::desc(
-        "Set the maximum number of threads for the MLIR context."), llvm::cl::init(-1));
+        "max-threads",
+        llvm::cl::desc(
+            "Set the maximum number of threads for the MLIR context."),
+        llvm::cl::init(-1));
 
     maxThreads_.setCallback([&](const int &cliMaxThreads) {
       if (cliMaxThreads > 0)

--- a/lib/Config/CLIConfig.cpp
+++ b/lib/Config/CLIConfig.cpp
@@ -311,6 +311,15 @@ struct QSSConfigCLOptions : public QSSConfig {
             llvm::cl::values(clEnumValN(QSSVerbosity::Debug, "debug",
                                         "Also emit debug messages")),
             llvm::cl::cat(qssc::config::getQSSOptCLCategory()));
+
+    static llvm::cl::opt<int> maxThreads_(
+    "max-threads", llvm::cl::desc(
+        "Set the maximum number of threads for the MLIR context."), llvm::cl::init(-1));
+
+    maxThreads_.setCallback([&](const int &cliMaxThreads) {
+      if (cliMaxThreads > 0)
+        maxThreads = cliMaxThreads;
+    });
   }
 
   /// Pointer to static dialectPlugins variable in constructor, needed by
@@ -420,6 +429,9 @@ llvm::Error CLIConfigBuilder::populateConfig(QSSConfig &config) {
   config.dialectPlugins.insert(config.dialectPlugins.end(),
                                clOptionsConfig->dialectPlugins.begin(),
                                clOptionsConfig->dialectPlugins.end());
+
+  if (clOptionsConfig->maxThreads.has_value())
+    config.maxThreads = clOptionsConfig->maxThreads;
 
   // opt
   config.allowUnregisteredDialectsFlag =

--- a/lib/Config/EnvVarConfig.cpp
+++ b/lib/Config/EnvVarConfig.cpp
@@ -33,6 +33,9 @@ llvm::Error EnvVarConfigBuilder::populateConfig(QSSConfig &config) {
   if (auto err = populateVerbosity_(config))
     return err;
 
+  if (auto err = populateMaxThreads_(config))
+    return err;
+
   return llvm::Error::success();
 }
 
@@ -47,6 +50,22 @@ llvm::Error EnvVarConfigBuilder::populateTarget_(QSSConfig &config) {
     config.targetName = targetStr;
   return llvm::Error::success();
 }
+
+llvm::Error EnvVarConfigBuilder::populateMaxThreads_(QSSConfig &config) {
+  if (const char *maxThreads = std::getenv("QSSC_MAX_THREADS")) {
+    llvm::StringRef maxThreadsStr(maxThreads);
+    unsigned int maxThreadsInt;
+    if (maxThreadsStr.consumeInteger<unsigned int>(0, maxThreadsInt))
+      return llvm::createStringError(
+          llvm::inconvertibleErrorCode(),
+          "Unable to parse maximum threads from \"" + maxThreadsStr + "\"\n");
+
+    config.maxThreads = maxThreadsInt;
+  }
+
+  return llvm::Error::success();
+}
+
 
 llvm::Error EnvVarConfigBuilder::populateVerbosity_(QSSConfig &config) {
   if (const char *verbosity = std::getenv("QSSC_VERBOSITY")) {

--- a/lib/Config/EnvVarConfig.cpp
+++ b/lib/Config/EnvVarConfig.cpp
@@ -56,16 +56,15 @@ llvm::Error EnvVarConfigBuilder::populateMaxThreads_(QSSConfig &config) {
     llvm::StringRef maxThreadsStr(maxThreads);
     unsigned int maxThreadsInt;
     if (maxThreadsStr.consumeInteger<unsigned int>(0, maxThreadsInt))
-      return llvm::createStringError(
-          llvm::inconvertibleErrorCode(),
-          "Unable to parse maximum threads from \"" + maxThreadsStr + "\"\n");
+      return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                     "Unable to parse maximum threads from \"" +
+                                         maxThreadsStr + "\"\n");
 
     config.maxThreads = maxThreadsInt;
   }
 
   return llvm::Error::success();
 }
-
 
 llvm::Error EnvVarConfigBuilder::populateVerbosity_(QSSConfig &config) {
   if (const char *verbosity = std::getenv("QSSC_VERBOSITY")) {

--- a/lib/Config/QSSConfig.cpp
+++ b/lib/Config/QSSConfig.cpp
@@ -72,6 +72,7 @@ void qssc::config::QSSConfig::emit(llvm::raw_ostream &os) const {
   os << "compileTargetIR: " << shouldCompileTargetIR() << "\n";
   os << "bypassPayloadTargetCompilation: "
      << shouldBypassPayloadTargetCompilation() << "\n";
+  os << "maxThreads: " << (getMaxThreads().has_value() ? std::to_string(getMaxThreads().value()) : "None") << "\n";
   os << "\n";
 
   // Mlir opt configuration

--- a/lib/Config/QSSConfig.cpp
+++ b/lib/Config/QSSConfig.cpp
@@ -72,7 +72,10 @@ void qssc::config::QSSConfig::emit(llvm::raw_ostream &os) const {
   os << "compileTargetIR: " << shouldCompileTargetIR() << "\n";
   os << "bypassPayloadTargetCompilation: "
      << shouldBypassPayloadTargetCompilation() << "\n";
-  os << "maxThreads: " << (getMaxThreads().has_value() ? std::to_string(getMaxThreads().value()) : "None") << "\n";
+  os << "maxThreads: "
+     << (getMaxThreads().has_value() ? std::to_string(getMaxThreads().value())
+                                     : "None")
+     << "\n";
   os << "\n";
 
   // Mlir opt configuration

--- a/lib/Config/QSSConfig.cpp
+++ b/lib/Config/QSSConfig.cpp
@@ -73,6 +73,7 @@ void qssc::config::QSSConfig::emit(llvm::raw_ostream &os) const {
   os << "bypassPayloadTargetCompilation: "
      << shouldBypassPayloadTargetCompilation() << "\n";
   os << "maxThreads: "
+     // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
      << (getMaxThreads().has_value() ? std::to_string(getMaxThreads().value())
                                      : "None")
      << "\n";

--- a/releasenotes/notes/add-max-threads-4073cc0b39df6d68.yaml
+++ b/releasenotes/notes/add-max-threads-4073cc0b39df6d68.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    It is now possible to set the maximum number of threads for the MLIR context.
+    This can be done through the CLI option ``--max-threads=<uint>`` or the
+    environment variable ``export QSSC_MAX_THREADS=<uint>``.

--- a/test/Config/test-config.tst
+++ b/test/Config/test-config.tst
@@ -1,6 +1,6 @@
 // RUN: qss-compiler --target Mock --config path/to/config --allow-unregistered-dialect=false \
-// RUN:          --add-target-passes=false --verbosity=info --show-config - | FileCheck %s --check-prefix CLI
-// RUN: QSSC_TARGET_NAME="MockEnv" QSSC_TARGET_CONFIG_PATH="path/to/config/Env" QSSC_VERBOSITY=DEBUG \
+// RUN:          --add-target-passes=false --verbosity=info --max-threads=5 --show-config - | FileCheck %s --check-prefix CLI
+// RUN: QSSC_TARGET_NAME="MockEnv" QSSC_TARGET_CONFIG_PATH="path/to/config/Env" QSSC_VERBOSITY=DEBUG QSSC_MAX_THREADS=10 \
 // RUN:          qss-compiler --allow-unregistered-dialect=false --add-target-passes=false --show-config - | FileCheck %s --check-prefix ENV
 // REQUIRES: !asserts
 
@@ -18,6 +18,7 @@
 // CLI: includeSource: 0
 // CLI: compileTargetIR: 0
 // CLI: bypassPayloadTargetCompilation: 0
+// CLI: maxThreads: 5
 
 // CLI: allowUnregisteredDialects: 0
 // CLI: dumpPassPipeline: 0
@@ -36,4 +37,5 @@
 // ENV: targetConfigPath: path/to/config/Env
 // ENV: verbosity: Debug
 // ENV: addTargetPasses: 0
+// ENV: maxThreads: 10
 // ENV: allowUnregisteredDialects: 0


### PR DESCRIPTION
Adds support for setting the maximum number of threads used by the qss-compiler's MLIR context. This can be done through the CLI option ``--max-threads=<uint>`` or the environment variable ``export QSSC_MAX_THREADS=<uint>``.