### PR TITLE
Add MergeCircuitMeasuresPass

### DIFF
--- a/include/Dialect/QUIR/Transforms/MergeCircuitMeasures.h
+++ b/include/Dialect/QUIR/Transforms/MergeCircuitMeasures.h
@@ -1,0 +1,42 @@
+//===- MergeCircuitMeasures.h - Merge measurement ops in circuits - C++ -*-===//
+//
+// (C) Copyright IBM 2024.
+//
+// This code is part of Qiskit.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+///
+///  This file declares the pass for merging measurements inside circuits into a
+///  single measure op
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef QUIR_MERGE_CIRCUIT_MEASURES_H
+#define QUIR_MERGE_CIRCUIT_MEASURES_H
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::quir {
+
+/// @brief Merge together measures in a circuit that are topologically
+/// adjacent into a single variadic measurement.
+struct MergeCircuitMeasuresTopologicalPass
+    : public PassWrapper<MergeCircuitMeasuresTopologicalPass, OperationPass<>> {
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const override;
+  llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+}; // struct MergeCircuitMeasuresTopologicalPass
+
+} // namespace mlir::quir
+
+#endif // QUIR_MERGE_CIRCUIT_MEASURES_H

--- a/include/Dialect/QUIR/Transforms/Passes.h
+++ b/include/Dialect/QUIR/Transforms/Passes.h
@@ -29,6 +29,7 @@
 #include "MergeParallelResets.h"
 #include "QuantumDecoration.h"
 #include "RemoveQubitOperands.h"
+#include "RemoveUnusedCircuits.h"
 #include "ReorderCircuits.h"
 #include "ReorderMeasurements.h"
 #include "SubroutineCloning.h"

--- a/include/Dialect/QUIR/Transforms/Passes.h
+++ b/include/Dialect/QUIR/Transforms/Passes.h
@@ -23,6 +23,7 @@
 #include "ConvertDurationUnits.h"
 #include "FunctionArgumentSpecialization.h"
 #include "LoadElimination.h"
+#include "MergeCircuitMeasures.h"
 #include "MergeCircuits.h"
 #include "MergeMeasures.h"
 #include "MergeParallelResets.h"

--- a/include/Dialect/QUIR/Transforms/RemoveUnusedCircuits.h
+++ b/include/Dialect/QUIR/Transforms/RemoveUnusedCircuits.h
@@ -1,0 +1,41 @@
+//===- RemoveUnusedCircuits.h - Remove Unused Circuits  ----------- C++ -*-===//
+//
+// (C) Copyright IBM 2024.
+//
+// This code is part of Qiskit.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+///
+///  This file declares the pass for removing unused circuits.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef QUIR_REMOVE_UNUSED_CIRCUITS_H
+#define QUIR_REMOVE_UNUSED_CIRCUITS_H
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::quir {
+
+/// @brief Merge together measures in a circuit that are topologically
+/// adjacent into a single variadic measurement.
+struct RemoveUnusedCircuitsPass
+    : public PassWrapper<RemoveUnusedCircuitsPass, OperationPass<>> {
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const override;
+  llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+}; // struct RemoveUnusedCircuits
+
+} // namespace mlir::quir
+
+#endif // QUIR_REMOVE_UNUSED_CIRCUITS_H

--- a/lib/Dialect/QUIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/QUIR/Transforms/CMakeLists.txt
@@ -26,6 +26,7 @@ add_mlir_dialect_library(MLIRQUIRTransforms
     QuantumDecoration.cpp
     QUIRCircuitAnalysis.cpp
     RemoveQubitOperands.cpp
+    RemoveUnusedCircuits.cpp
     ReorderMeasurements.cpp
     ReorderCircuits.cpp
     SubroutineCloning.cpp

--- a/lib/Dialect/QUIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/QUIR/Transforms/CMakeLists.txt
@@ -19,6 +19,7 @@ add_mlir_dialect_library(MLIRQUIRTransforms
     FunctionArgumentSpecialization.cpp
     LoadElimination.cpp
     MergeCircuits.cpp
+    MergeCircuitMeasures.cpp
     MergeMeasures.cpp
     MergeParallelResets.cpp
     Passes.cpp

--- a/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
@@ -167,11 +167,11 @@ static void buildOutputs(llvm::SmallVector<Type> &outputTypes,
                       returnOp->getOperands().end());
 
   auto resultType =
-      mergedOp->getResultTypes().begin() + measureOp.getNumResults() + 1;
+      mergedOp->getResultTypes().begin() + measureOp.getNumResults();
   for (; resultType != mergedOp->getResultTypes().end(); ++resultType)
     outputTypes.push_back(*resultType);
 
-  auto result = mergedOp->getResults().begin() + measureOp.getNumResults() + 1;
+  auto result = mergedOp->getResults().begin() + measureOp.getNumResults();
   for (; result != mergedOp->getResults().end(); ++result)
     outputValues.push_back(*result);
 }

--- a/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
@@ -1,0 +1,389 @@
+//===- MergeMeasures.cpp - Merge measurement ops ----------------*- C++ -*-===//
+//
+// (C) Copyright IBM 2023.
+//
+// This code is part of Qiskit.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+///
+///  This file implements the pass for merging measurements into a single
+///  measure op
+///
+//===----------------------------------------------------------------------===//
+
+#include "Dialect/QUIR/Transforms/MergeCircuitMeasures.h"
+#include "Dialect/QUIR/IR/QUIRAttributes.h"
+
+#include "Dialect/QUIR/IR/QUIRInterfaces.h"
+#include "Dialect/QUIR/IR/QUIROps.h"
+#include "Dialect/QUIR/Utils/Utils.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/TypeRange.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "llvm/ADT/StringRef.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <iterator>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/StringMap.h>
+#include <llvm/Support/raw_ostream.h>
+#include <mlir/IR/Block.h>
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/SymbolTable.h>
+#include <mlir/IR/Value.h>
+#include <optional>
+#include <set>
+#include <string>
+#include <sys/types.h>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using namespace mlir;
+using namespace mlir::quir;
+
+namespace {
+
+static void mergeMeasurements(PatternRewriter &rewriter,
+                              CallCircuitOp callCircuitOp,
+                              CallCircuitOp nextCallCircuitOp,
+                              CircuitOp circuitOp, CircuitOp nextCircuitOp,
+                              MeasureOp measureOp, MeasureOp nextMeasureOp,
+                              llvm::StringMap<Operation *> &symbolMap) {
+
+  // copy circuitOp in case there are multiple calls
+  rewriter.setInsertionPoint(circuitOp);
+  rewriter.clone(*circuitOp);
+  symbolMap[nextCircuitOp.getSymName()] = circuitOp;
+
+  // merge circuit names with an additional m for the merge
+  std::string const newName1 =
+      (circuitOp.getSymName() + "_" + nextCircuitOp.getSymName()).str() + "+m";
+
+  // rename first circuit to the new name
+  circuitOp->setAttr(SymbolTable::getSymbolAttrName(),
+                     StringAttr::get(circuitOp->getContext(), newName1));
+  symbolMap[newName1] = circuitOp;
+
+  // copy nextCircuitOp in case there are multiple calls
+  rewriter.setInsertionPoint(nextCircuitOp);
+  rewriter.clone(*nextCircuitOp);
+  symbolMap[nextCircuitOp.getSymName()] = nextCircuitOp;
+
+  // merge circuit names with an additional m for the merge
+  auto newName = nextCircuitOp.getSymName().str() + "-m";
+  nextCircuitOp->setAttr(SymbolTable::getSymbolAttrName(),
+                         StringAttr::get(circuitOp->getContext(), newName));
+  symbolMap[newName] = nextCircuitOp;
+
+  // merge measurements
+  std::vector<Type> typeVec;
+  std::vector<Value> valVec;
+  typeVec.reserve(measureOp.getNumResults() + nextMeasureOp.getNumResults());
+  valVec.reserve(measureOp.getNumResults() + nextMeasureOp.getNumResults());
+
+  typeVec.insert(typeVec.end(), measureOp.result_type_begin(),
+                 measureOp.result_type_end());
+  typeVec.insert(typeVec.end(), nextMeasureOp.result_type_begin(),
+                 nextMeasureOp.result_type_end());
+  valVec.insert(valVec.end(), measureOp.getQubits().begin(),
+                measureOp.getQubits().end());
+
+  // remap measurement arguments
+  // - build list of arguments to map to
+  std::unordered_map<uint32_t, BlockArgument> circuitArguments;
+  for (uint argNum = 0; argNum < circuitOp.getNumArguments(); argNum++) {
+    auto argAttr = circuitOp.getArgAttrOfType<IntegerAttr>(
+        argNum, mlir::quir::getPhysicalIdAttrName());
+    circuitArguments[argAttr.getInt()] = circuitOp.getArgument(argNum);
+    circuitArguments[argAttr.getInt()].dump();
+  }
+
+  // // - remap arguments
+  for (auto argument : nextMeasureOp.getQubits()) {
+    auto blockArgument = dyn_cast<BlockArgument>(argument);
+    assert(blockArgument && "expect qubit to be a block argument");
+    auto argNum = blockArgument.getArgNumber();
+    auto argAttr = nextCircuitOp.getArgAttrOfType<IntegerAttr>(
+        argNum, mlir::quir::getPhysicalIdAttrName());
+    auto search = circuitArguments.find(argAttr.getInt());
+    if (search == circuitArguments.end())
+      assert(false && "TODO: need to append argument");
+    valVec.push_back(search->second);
+  }
+
+  // find return and update
+  auto returnOp = dyn_cast<quir::ReturnOp>(&circuitOp.back().back());
+  assert(returnOp && "quir.circuit must end end a quir.return");
+
+  rewriter.setInsertionPoint(measureOp);
+  auto mergedOp = rewriter.create<MeasureOp>(
+      measureOp.getLoc(), TypeRange(typeVec), ValueRange(valVec));
+
+  returnOp->dump();
+
+  rewriter.replaceOp(measureOp, ResultRange(mergedOp.getOuts().begin(),
+                                            mergedOp.getOuts().end()));
+
+  llvm::SmallVector<Type> outputTypes;
+  llvm::SmallVector<Value> outputValues;
+
+  outputTypes.append(returnOp->getOperandTypes().begin(),
+                     returnOp->getOperandTypes().end());
+
+  outputValues.append(returnOp->getOperands().begin(),
+                      returnOp->getOperands().end());
+
+  auto resultType =
+      mergedOp->getResultTypes().begin() + measureOp.getNumResults() + 1;
+  for (; resultType != mergedOp->getResultTypes().end(); ++resultType)
+    outputTypes.push_back(*resultType);
+
+  auto result = mergedOp->getResults().begin() + measureOp.getNumResults() + 1;
+  for (; result != mergedOp->getResults().end(); ++result)
+    outputValues.push_back(*result);
+
+  rewriter.setInsertionPointAfter(returnOp);
+  auto newReturnOp =
+      rewriter.create<quir::ReturnOp>(returnOp->getLoc(), outputValues);
+  newReturnOp.dump();
+  rewriter.replaceOp(returnOp, newReturnOp->getResults());
+
+  // change the input / output types for the quir.circuit
+  auto opType = circuitOp.getFunctionType();
+  circuitOp.setType(rewriter.getFunctionType(
+      /*inputs=*/opType.getInputs(),
+      /*results=*/ArrayRef<Type>(outputTypes)));
+
+  // new call circuit ops
+  rewriter.setInsertionPointAfter(callCircuitOp);
+  auto newCallOp = rewriter.create<mlir::quir::CallCircuitOp>(
+      callCircuitOp->getLoc(), newName1, TypeRange(outputTypes),
+      ValueRange(callCircuitOp->getOperands()));
+
+  // drop nextMeasure
+  auto nextReturnOp = dyn_cast<quir::ReturnOp>(&nextCircuitOp.back().back());
+  assert(nextReturnOp && "quir.circuit must end end a quir.return");
+  outputTypes.clear();
+  outputValues.clear();
+  std::vector<int> eraseList;
+  for (uint idx = 0; idx < nextReturnOp.getNumOperands(); idx++)
+    if (nextReturnOp->getOperand(idx).getDefiningOp() ==
+        nextMeasureOp.getOperation())
+      eraseList.push_back(idx);
+
+  while (!eraseList.empty()) {
+    nextReturnOp->eraseOperand(eraseList.back());
+    eraseList.pop_back();
+  }
+
+  rewriter.eraseOp(nextMeasureOp);
+
+  outputTypes.append(nextReturnOp->getOperandTypes().begin(),
+                     nextReturnOp->getOperandTypes().end());
+
+  opType = nextCircuitOp.getFunctionType();
+  nextCircuitOp.setType(rewriter.getFunctionType(
+      /*inputs=*/opType.getInputs(),
+      /*results=*/ArrayRef<Type>(outputTypes)));
+
+  // dice the output so we can specify which results to replace
+  auto iterSep = newCallOp.result_begin() + callCircuitOp.getNumResults();
+  rewriter.replaceOp(callCircuitOp,
+                     ResultRange(newCallOp.result_begin(), iterSep));
+  rewriter.replaceOp(nextCallCircuitOp,
+                     ResultRange(iterSep, newCallOp.result_end()));
+
+  llvm::errs() << "First Circuit:\n";
+  circuitOp.dump();
+
+  llvm::errs() << "Second Circuit:\n";
+  nextCircuitOp.dump();
+
+  llvm::errs() << "\n\n\n\n\n";
+
+  // delete the nextCircuit if it is now empty (starts with a return)
+  auto firstReturnOp = dyn_cast<quir::ReturnOp>(&nextCircuitOp.front().front());
+  if (firstReturnOp)
+    rewriter.eraseOp(nextCircuitOp);
+}
+
+// This pattern matches on two MeasureOps that are only interspersed by
+// classical non-control flow ops and merges them into one measure op
+struct CallCircuitAndCallCircuitTopologicalPattern
+    : public OpRewritePattern<CallCircuitOp> {
+  explicit CallCircuitAndCallCircuitTopologicalPattern(
+      MLIRContext *ctx, llvm::StringMap<Operation *> &symbolMap)
+      : OpRewritePattern<CallCircuitOp>(ctx) {
+    _symbolMap = &symbolMap;
+  }
+
+  llvm::StringMap<Operation *> *_symbolMap;
+
+  LogicalResult matchAndRewrite(CallCircuitOp callCircuitOp,
+                                PatternRewriter &rewriter) const override {
+
+    // Two types of measurements to merge
+    // 1. Two measurements in the same circuit (possibly covered by
+    // MergeMeasuresTopologicalPass)
+    // 2. Two measurements in different circuits
+
+    // is there a measure in the current circuit
+    auto search1 = _symbolMap->find(callCircuitOp.getCallee());
+    assert(search1 != _symbolMap->end() && "matching circuit not found");
+
+    auto firstCircuit = dyn_cast<CircuitOp>(search1->second);
+
+    MeasureOp firstMeasureOp;
+    std::set<uint32_t> currMeasureQubits;
+
+    auto *firstOp = &firstCircuit.getBody().front().front();
+
+    if (isa<MeasureOp>(firstOp)) {
+      firstMeasureOp = dyn_cast<MeasureOp>(firstOp);
+      currMeasureQubits = QubitOpInterface::getOperatedQubits(firstMeasureOp);
+    } else {
+      auto firstMeasureOpt =
+          QubitOpInterface::getNextQubitOpOfType<MeasureOp>(firstOp);
+      if (!firstMeasureOpt.has_value())
+        return failure();
+      firstMeasureOp = firstMeasureOpt.value();
+      currMeasureQubits = firstMeasureOp.getOperatedQubits();
+    }
+
+    auto nextCallCircuitOp =
+        QubitOpInterface::getNextQubitOpOfType<CallCircuitOp>(callCircuitOp);
+
+    if (!nextCallCircuitOp.has_value())
+      return failure();
+
+    auto search2 = _symbolMap->find(nextCallCircuitOp->getCallee());
+    assert(search2 != _symbolMap->end() && "matching circuit not found");
+
+    auto secondCircuit = dyn_cast<CircuitOp>(search2->second);
+
+    // Find the next measurement operation accumulating qubits along the
+    // topological path if it exists
+
+    firstOp = &secondCircuit.getBody().front().front();
+
+    MeasureOp nextMeasureOp;
+    std::set<uint32_t> observedQubits;
+
+    if (isa<MeasureOp>(firstOp)) {
+      nextMeasureOp = dyn_cast<MeasureOp>(firstOp);
+    } else {
+      std::optional<MeasureOp> nextMeasureOpt;
+      std::tie(nextMeasureOpt, observedQubits) =
+          QubitOpInterface::getNextQubitOpOfTypeWithQubits<MeasureOp>(firstOp);
+
+      if (!nextMeasureOpt.has_value())
+        return failure();
+      nextMeasureOp = nextMeasureOpt.value();
+    }
+
+    llvm::errs() << "First Circuit: \n";
+    firstCircuit.dump();
+
+    llvm::errs() << "First Measure: \n";
+    firstMeasureOp.dump();
+
+    llvm::errs() << "Operated Qubits = \n";
+    for (auto qubit : currMeasureQubits)
+      llvm::errs() << qubit << "\n";
+
+    llvm::errs() << "Second Circuit: \n";
+    // secondCircuit.dump();
+
+    llvm::errs() << "Next Measure: \n";
+    nextMeasureOp->dump();
+
+    llvm::errs() << "Observed Qubits = \n";
+    for (auto qubit : observedQubits)
+      llvm::errs() << qubit << "\n";
+
+    llvm::errs() << "Found circuits to try an merge\n";
+
+    // If any qubit along path touches the same qubits we cannot merge the next
+    // measurement.
+    currMeasureQubits.insert(observedQubits.begin(), observedQubits.end());
+
+    // found a measure and a measure, now make sure they aren't working on the
+    // same qubit and that we can resolve them both
+    auto nextMeasureQubits = nextMeasureOp.getOperatedQubits();
+
+    // If there is an intersection we cannot merge
+    std::set<int> mergeMeasureIntersection;
+    std::set_intersection(currMeasureQubits.begin(), currMeasureQubits.end(),
+                          nextMeasureQubits.begin(), nextMeasureQubits.end(),
+                          std::inserter(mergeMeasureIntersection,
+                                        mergeMeasureIntersection.begin()));
+
+    llvm::errs() << "Test Intersection = \n";
+    for (auto qubit : mergeMeasureIntersection)
+      llvm::errs() << qubit << "\n";
+
+    if (!mergeMeasureIntersection.empty())
+      return failure();
+
+    // good to merge
+    llvm::errs() << "Good to Merge\n";
+    mergeMeasurements(rewriter, callCircuitOp, *nextCallCircuitOp, firstCircuit,
+                      secondCircuit, firstMeasureOp, nextMeasureOp,
+                      *_symbolMap);
+
+    return success();
+  } // matchAndRewrite
+};  // struct CircuitAndCircuitTopologicalPattern
+} // end anonymous namespace
+
+void MergeCircuitMeasuresTopologicalPass::runOnOperation() {
+  Operation *moduleOperation = getOperation();
+
+  llvm::StringMap<Operation *> circuitOpsMap;
+
+  moduleOperation->walk([&](CircuitOp circuitOp) {
+    circuitOpsMap[circuitOp.getSymName()] = circuitOp.getOperation();
+  });
+
+  RewritePatternSet patterns(&getContext());
+  patterns.add<CallCircuitAndCallCircuitTopologicalPattern>(&getContext(),
+                                                            circuitOpsMap);
+
+  mlir::GreedyRewriteConfig config;
+  // Disable to improve performance
+  config.enableRegionSimplification = false;
+
+  if (failed(applyPatternsAndFoldGreedily(moduleOperation, std::move(patterns),
+                                          config)))
+    signalPassFailure();
+} // runOnOperation
+
+llvm::StringRef MergeCircuitMeasuresTopologicalPass::getArgument() const {
+  return "merge-circuit-measures-topological";
+}
+llvm::StringRef MergeCircuitMeasuresTopologicalPass::getDescription() const {
+  return "Merge qubit-parallel measurement operations inside circuits into a "
+         "single measurement operation with topological ordering";
+}
+
+llvm::StringRef MergeCircuitMeasuresTopologicalPass::getName() const {
+  return "Merge Circuit Measures Topological Pass";
+}

--- a/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
@@ -81,11 +81,12 @@ static void mergeMeasurements(PatternRewriter &rewriter,
   int cnt = 0;
   while (symbolMap.contains(testName))
     testName += std::to_string(cnt++);
+  newName1 = testName;
 
   // rename first circuit to the new name
   circuitOp->setAttr(SymbolTable::getSymbolAttrName(),
-                     StringAttr::get(circuitOp->getContext(), testName));
-  symbolMap[testName] = circuitOp;
+                     StringAttr::get(circuitOp->getContext(), newName1));
+  symbolMap[newName1] = circuitOp;
 
   // copy nextCircuitOp in case there are multiple calls
   rewriter.setInsertionPoint(nextCircuitOp);
@@ -93,15 +94,16 @@ static void mergeMeasurements(PatternRewriter &rewriter,
   symbolMap[nextCircuitOp.getSymName()] = oldNexCircuitOp;
 
   // merge circuit names with an additional m for the merge
-  auto newName2= nextCircuitOp.getSymName().str() + "-m";
+  auto newName2 = nextCircuitOp.getSymName().str() + "-m";
   testName = newName2;
   cnt = 0;
   while (symbolMap.contains(testName))
     testName += std::to_string(cnt++);
+  newName2 = testName;
 
   nextCircuitOp->setAttr(SymbolTable::getSymbolAttrName(),
-                         StringAttr::get(circuitOp->getContext(), testName));
-  symbolMap[testName] = nextCircuitOp;
+                         StringAttr::get(circuitOp->getContext(), newName2));
+  symbolMap[newName2] = nextCircuitOp;
 
   // merge measurements
   std::vector<Type> typeVec;

--- a/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
@@ -20,8 +20,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "Dialect/QUIR/Transforms/MergeCircuitMeasures.h"
-#include "Dialect/QUIR/IR/QUIRAttributes.h"
 
+#include "Dialect/QUIR/IR/QUIRAttributes.h"
 #include "Dialect/QUIR/IR/QUIRInterfaces.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
 #include "Dialect/QUIR/Utils/Utils.h"
@@ -64,10 +64,10 @@ namespace {
 static std::string duplicateCircuit(PatternRewriter &rewriter,
                                     CircuitOp circuitOp,
                                     llvm::StringMap<Operation *> &symbolMap,
-                                    std::string newNameTemplate,
-                                    std::string salt) {
+                                    const std::string& newNameTemplate,
+                                    const std::string& salt) {
   rewriter.setInsertionPoint(circuitOp);
-  auto oldCircuitOp = rewriter.clone(*circuitOp);
+  auto *oldCircuitOp = rewriter.clone(*circuitOp);
   symbolMap[circuitOp.getSymName()] = oldCircuitOp;
 
   // merge circuit names with an additional salt for the merge
@@ -239,7 +239,7 @@ static void mergeMeasurements(PatternRewriter &rewriter,
                               llvm::StringMap<Operation *> &symbolMap) {
 
   // copy circuitOp in case there are multiple calls
-  std::string newNameTemplate =
+  std::string const newNameTemplate =
       (circuitOp.getSymName() + "_" + nextCircuitOp.getSymName()).str();
   auto newName1 =
       duplicateCircuit(rewriter, circuitOp, symbolMap, newNameTemplate, "+m");
@@ -278,7 +278,7 @@ static void mergeMeasurements(PatternRewriter &rewriter,
 
   dropNextMeasure(rewriter, outputTypes, outputValues, nextCircuitOp,
                   nextMeasureOp);
-                  
+
   // dice the output so we can specify which results to replace
   auto iterSep = newCallOp.result_begin() + callCircuitOp.getNumResults();
   rewriter.replaceOp(callCircuitOp,

--- a/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
@@ -64,8 +64,8 @@ namespace {
 static std::string duplicateCircuit(PatternRewriter &rewriter,
                                     CircuitOp circuitOp,
                                     llvm::StringMap<Operation *> &symbolMap,
-                                    const std::string& newNameTemplate,
-                                    const std::string& salt) {
+                                    const std::string &newNameTemplate,
+                                    const std::string &salt) {
   rewriter.setInsertionPoint(circuitOp);
   auto *oldCircuitOp = rewriter.clone(*circuitOp);
   symbolMap[circuitOp.getSymName()] = oldCircuitOp;

--- a/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
@@ -268,8 +268,9 @@ struct CallCircuitAndCallCircuitTopologicalPattern
       currMeasureQubits = firstMeasureOp.getOperatedQubits();
     }
 
-    auto [nextCallCircuitOp, observedQubits]  =
-        QubitOpInterface::getNextQubitOpOfTypeWithQubits<CallCircuitOp>(callCircuitOp);
+    auto [nextCallCircuitOp, observedQubits] =
+        QubitOpInterface::getNextQubitOpOfTypeWithQubits<CallCircuitOp>(
+            callCircuitOp);
 
     if (!nextCallCircuitOp.has_value())
       return failure();
@@ -292,7 +293,8 @@ struct CallCircuitAndCallCircuitTopologicalPattern
       auto [nextMeasureOpt, additionalObservedQubits] =
           QubitOpInterface::getNextQubitOpOfTypeWithQubits<MeasureOp>(firstOp);
 
-      observedQubits.insert(additionalObservedQubits.begin(), additionalObservedQubits.end());
+      observedQubits.insert(additionalObservedQubits.begin(),
+                            additionalObservedQubits.end());
       if (!nextMeasureOpt.has_value())
         return failure();
       nextMeasureOp = nextMeasureOpt.value();

--- a/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
@@ -42,7 +42,6 @@
 #include <iterator>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/StringMap.h>
-#include <llvm/Support/raw_ostream.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/SymbolTable.h>
@@ -113,13 +112,13 @@ static void mergeMeasurements(PatternRewriter &rewriter,
     auto argAttr = circuitOp.getArgAttrOfType<IntegerAttr>(
         argNum, mlir::quir::getPhysicalIdAttrName());
     circuitArguments[argAttr.getInt()] = circuitOp.getArgument(argNum);
-    circuitArguments[argAttr.getInt()].dump();
+    // circuitArguments[argAttr.getInt()].dump();
   }
 
   auto maxArgument = circuitOp.getNumArguments();
 
-  auto theseIdsAttr = circuitOp->getAttrOfType<ArrayAttr>(
-      mlir::quir::getPhysicalIdsAttrName());
+  auto theseIdsAttr =
+      circuitOp->getAttrOfType<ArrayAttr>(mlir::quir::getPhysicalIdsAttrName());
 
   // collect all of the first circuit's ids
   std::vector<int> allIds;
@@ -153,7 +152,7 @@ static void mergeMeasurements(PatternRewriter &rewriter,
   }
 
   circuitOp->setAttr(mlir::quir::getPhysicalIdsAttrName(),
-                      rewriter.getI32ArrayAttr(ArrayRef<int>(allIds)));
+                     rewriter.getI32ArrayAttr(ArrayRef<int>(allIds)));
 
   // find return and update
   auto returnOp = dyn_cast<quir::ReturnOp>(&circuitOp.back().back());
@@ -163,7 +162,7 @@ static void mergeMeasurements(PatternRewriter &rewriter,
   auto mergedOp = rewriter.create<MeasureOp>(
       measureOp.getLoc(), TypeRange(typeVec), ValueRange(valVec));
 
-  returnOp->dump();
+  // returnOp->dump();
 
   rewriter.replaceOp(measureOp, ResultRange(mergedOp.getOuts().begin(),
                                             mergedOp.getOuts().end()));
@@ -189,7 +188,7 @@ static void mergeMeasurements(PatternRewriter &rewriter,
   rewriter.setInsertionPointAfter(returnOp);
   auto newReturnOp =
       rewriter.create<quir::ReturnOp>(returnOp->getLoc(), outputValues);
-  newReturnOp.dump();
+  // newReturnOp.dump();
   rewriter.replaceOp(returnOp, newReturnOp->getResults());
 
   // change the input / output types for the quir.circuit
@@ -237,13 +236,13 @@ static void mergeMeasurements(PatternRewriter &rewriter,
   rewriter.replaceOp(nextCallCircuitOp,
                      ResultRange(iterSep, newCallOp.result_end()));
 
-  llvm::errs() << "First Circuit:\n";
-  circuitOp.dump();
+  // llvm::errs() << "First Circuit:\n";
+  // circuitOp.dump();
 
-  llvm::errs() << "Second Circuit:\n";
-  nextCircuitOp.dump();
+  // llvm::errs() << "Second Circuit:\n";
+  // nextCircuitOp.dump();
 
-  llvm::errs() << "\n\n\n\n\n";
+  // llvm::errs() << "\n\n\n\n\n";
 
   // delete the nextCircuit if it is now empty (starts with a return)
   auto firstReturnOp = dyn_cast<quir::ReturnOp>(&nextCircuitOp.front().front());
@@ -326,27 +325,27 @@ struct CallCircuitAndCallCircuitTopologicalPattern
       nextMeasureOp = nextMeasureOpt.value();
     }
 
-    llvm::errs() << "First Circuit: \n";
-    firstCircuit.dump();
+    // llvm::errs() << "First Circuit: \n";
+    // firstCircuit.dump();
 
-    llvm::errs() << "First Measure: \n";
-    firstMeasureOp.dump();
+    // llvm::errs() << "First Measure: \n";
+    // firstMeasureOp.dump();
 
-    llvm::errs() << "Operated Qubits = \n";
-    for (auto qubit : currMeasureQubits)
-      llvm::errs() << qubit << "\n";
+    // llvm::errs() << "Operated Qubits = \n";
+    // for (auto qubit : currMeasureQubits)
+    //   llvm::errs() << qubit << "\n";
 
-    llvm::errs() << "Second Circuit: \n";
-    secondCircuit.dump();
+    // llvm::errs() << "Second Circuit: \n";
+    // secondCircuit.dump();
 
-    llvm::errs() << "Next Measure: \n";
-    nextMeasureOp->dump();
+    // llvm::errs() << "Next Measure: \n";
+    // nextMeasureOp->dump();
 
-    llvm::errs() << "Observed Qubits = \n";
-    for (auto qubit : observedQubits)
-      llvm::errs() << qubit << "\n";
+    // llvm::errs() << "Observed Qubits = \n";
+    // for (auto qubit : observedQubits)
+    //   llvm::errs() << qubit << "\n";
 
-    llvm::errs() << "Found circuits to try an merge\n";
+    // llvm::errs() << "Found circuits to try an merge\n";
 
     // If any qubit along path touches the same qubits we cannot merge the next
     // measurement.
@@ -363,15 +362,15 @@ struct CallCircuitAndCallCircuitTopologicalPattern
                           std::inserter(mergeMeasureIntersection,
                                         mergeMeasureIntersection.begin()));
 
-    llvm::errs() << "Test Intersection = \n";
-    for (auto qubit : mergeMeasureIntersection)
-      llvm::errs() << qubit << "\n";
+    // llvm::errs() << "Test Intersection = \n";
+    // for (auto qubit : mergeMeasureIntersection)
+    //   llvm::errs() << qubit << "\n";
 
     if (!mergeMeasureIntersection.empty())
       return failure();
 
     // good to merge
-    llvm::errs() << "Good to Merge\n";
+    // llvm::errs() << "Good to Merge\n";
     mergeMeasurements(rewriter, callCircuitOp, *nextCallCircuitOp, firstCircuit,
                       secondCircuit, firstMeasureOp, nextMeasureOp,
                       *_symbolMap);

--- a/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
@@ -74,13 +74,18 @@ static void mergeMeasurements(PatternRewriter &rewriter,
   symbolMap[circuitOp.getSymName()] = oldCircuitOp;
 
   // merge circuit names with an additional m for the merge
-  std::string const newName1 =
+  std::string newName1 =
       (circuitOp.getSymName() + "_" + nextCircuitOp.getSymName()).str() + "+m";
+
+  std::string testName = newName1;
+  int cnt = 0;
+  while (symbolMap.contains(testName))
+    testName += std::to_string(cnt++);
 
   // rename first circuit to the new name
   circuitOp->setAttr(SymbolTable::getSymbolAttrName(),
-                     StringAttr::get(circuitOp->getContext(), newName1));
-  symbolMap[newName1] = circuitOp;
+                     StringAttr::get(circuitOp->getContext(), testName));
+  symbolMap[testName] = circuitOp;
 
   // copy nextCircuitOp in case there are multiple calls
   rewriter.setInsertionPoint(nextCircuitOp);
@@ -88,10 +93,15 @@ static void mergeMeasurements(PatternRewriter &rewriter,
   symbolMap[nextCircuitOp.getSymName()] = oldNexCircuitOp;
 
   // merge circuit names with an additional m for the merge
-  auto newName = nextCircuitOp.getSymName().str() + "-m";
+  auto newName2= nextCircuitOp.getSymName().str() + "-m";
+  testName = newName2;
+  cnt = 0;
+  while (symbolMap.contains(testName))
+    testName += std::to_string(cnt++);
+
   nextCircuitOp->setAttr(SymbolTable::getSymbolAttrName(),
-                         StringAttr::get(circuitOp->getContext(), newName));
-  symbolMap[newName] = nextCircuitOp;
+                         StringAttr::get(circuitOp->getContext(), testName));
+  symbolMap[testName] = nextCircuitOp;
 
   // merge measurements
   std::vector<Type> typeVec;

--- a/lib/Dialect/QUIR/Transforms/MergeCircuits.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuits.cpp
@@ -21,6 +21,7 @@
 
 #include "Dialect/QUIR/Transforms/MergeCircuits.h"
 
+#include "Dialect/QCS/IR/QCSOps.h"
 #include "Dialect/QUIR/IR/QUIRAttributes.h"
 #include "Dialect/QUIR/IR/QUIRInterfaces.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
@@ -121,10 +122,10 @@ struct CircuitAndCircuitPattern : public OpRewritePattern<CallCircuitOp> {
       moveList.clear();
       bool okToMoveUsers = false;
 
-      // check if curOp is parent of a user of callCircuitOp
-      for (auto *user : callCircuitOp->getUsers())
-        if (curOp->isAncestor(user))
-          return failure();
+      // do not attempt to merge circuits with a parallel control flow op in
+      // between
+      if (isa<qcs::ParallelControlFlowOp>(curOp))
+        return failure();
 
       if (std::find(callCircuitOp->user_begin(), callCircuitOp->user_end(),
                     curOp) != callCircuitOp->user_end())

--- a/lib/Dialect/QUIR/Transforms/MergeCircuits.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuits.cpp
@@ -122,7 +122,7 @@ struct CircuitAndCircuitPattern : public OpRewritePattern<CallCircuitOp> {
       bool okToMoveUsers = false;
 
       // check if curOp is parent of a user of callCircuitOp
-      for (auto user : callCircuitOp->getUsers())
+      for (auto *user : callCircuitOp->getUsers())
         if (curOp->isAncestor(user))
           return failure();
 

--- a/lib/Dialect/QUIR/Transforms/MergeCircuits.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuits.cpp
@@ -120,6 +120,12 @@ struct CircuitAndCircuitPattern : public OpRewritePattern<CallCircuitOp> {
     while (curOp != *secondOp) {
       moveList.clear();
       bool okToMoveUsers = false;
+
+      // check if curOp is parent of a user of callCircuitOp
+      for (auto user : callCircuitOp->getUsers())
+        if (curOp->isAncestor(user))
+          return failure();
+
       if (std::find(callCircuitOp->user_begin(), callCircuitOp->user_end(),
                     curOp) != callCircuitOp->user_end())
 

--- a/lib/Dialect/QUIR/Transforms/Passes.cpp
+++ b/lib/Dialect/QUIR/Transforms/Passes.cpp
@@ -25,6 +25,7 @@
 #include "Dialect/QUIR/Transforms/ConvertDurationUnits.h"
 #include "Dialect/QUIR/Transforms/FunctionArgumentSpecialization.h"
 #include "Dialect/QUIR/Transforms/LoadElimination.h"
+#include "Dialect/QUIR/Transforms/MergeCircuitMeasures.h"
 #include "Dialect/QUIR/Transforms/MergeCircuits.h"
 #include "Dialect/QUIR/Transforms/MergeMeasures.h"
 #include "Dialect/QUIR/Transforms/MergeParallelResets.h"
@@ -290,6 +291,7 @@ void registerQuirPasses() {
   PassRegistration<quir::ReorderMeasurementsPass>();
   PassRegistration<quir::ReorderCircuitsPass>();
   PassRegistration<quir::MergeCircuitsPass>();
+  PassRegistration<quir::MergeCircuitMeasuresTopologicalPass>();
   PassRegistration<quir::MergeMeasuresLexographicalPass>();
   PassRegistration<quir::MergeMeasuresTopologicalPass>();
   PassRegistration<quir::QUIRAngleConversionPass>();

--- a/lib/Dialect/QUIR/Transforms/Passes.cpp
+++ b/lib/Dialect/QUIR/Transforms/Passes.cpp
@@ -31,6 +31,7 @@
 #include "Dialect/QUIR/Transforms/MergeParallelResets.h"
 #include "Dialect/QUIR/Transforms/QuantumDecoration.h"
 #include "Dialect/QUIR/Transforms/RemoveQubitOperands.h"
+#include "Dialect/QUIR/Transforms/RemoveUnusedCircuits.h"
 #include "Dialect/QUIR/Transforms/ReorderCircuits.h"
 #include "Dialect/QUIR/Transforms/ReorderMeasurements.h"
 #include "Dialect/QUIR/Transforms/SubroutineCloning.h"
@@ -285,6 +286,7 @@ void registerQuirPasses() {
   PassRegistration<quir::MergeResetsTopologicalPass>();
   PassRegistration<quir::SubroutineCloningPass>();
   PassRegistration<quir::RemoveQubitOperandsPass>();
+  PassRegistration<quir::RemoveUnusedCircuitsPass>();
   PassRegistration<quir::UnusedVariablePass>();
   PassRegistration<quir::AddShotLoopPass>();
   PassRegistration<quir::QuantumDecorationPass>();

--- a/lib/Dialect/QUIR/Transforms/RemoveUnusedCircuits.cpp
+++ b/lib/Dialect/QUIR/Transforms/RemoveUnusedCircuits.cpp
@@ -1,0 +1,63 @@
+//===- RemoveUnusedCircuits.h - Remove Unused Circuits  ----------- C++ -*-===//
+//
+// (C) Copyright IBM 2024.
+//
+// This code is part of Qiskit.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+///
+///  This file implements the pass for removing unused circuits
+///
+//===----------------------------------------------------------------------===//
+
+#include "Dialect/QUIR/Transforms/RemoveUnusedCircuits.h"
+
+#include "Dialect/QUIR/IR/QUIROps.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSet.h"
+#include <mlir/IR/Operation.h>
+
+using namespace mlir;
+using namespace mlir::quir;
+
+void RemoveUnusedCircuitsPass::runOnOperation() {
+  Operation *moduleOperation = getOperation();
+
+  llvm::StringSet<> calledCircuits;
+
+  moduleOperation->walk([&](CallCircuitOp callCircuitOp) {
+    calledCircuits.insert(callCircuitOp.getCallee());
+  });
+
+  llvm::SmallVector<Operation *> eraseList;
+
+  moduleOperation->walk([&](CircuitOp circuitOp) {
+    auto search = calledCircuits.find(circuitOp.getSymName());
+    if (search == calledCircuits.end())
+      eraseList.push_back(circuitOp.getOperation());
+  });
+
+  for (auto *op : eraseList)
+    op->erase();
+} // runOnOperation
+
+llvm::StringRef RemoveUnusedCircuitsPass::getArgument() const {
+  return "remove-unused-circuits";
+}
+llvm::StringRef RemoveUnusedCircuitsPass::getDescription() const {
+  return "Remove unused circuits from a module";
+}
+
+llvm::StringRef RemoveUnusedCircuitsPass::getName() const {
+  return "Remove Unused Circuits Pass";
+}

--- a/releasenotes/notes/add-merge-circuit-measures-e2b80378bf659793.yaml
+++ b/releasenotes/notes/add-merge-circuit-measures-e2b80378bf659793.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Adds MergeCircuitMeasuresPass to replicate measurement merging performance
+    when using circuits.

--- a/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
+++ b/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
@@ -13,7 +13,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-// This test is based om merge-measures.mlir but uses circuits
+// This test is based on merge-measures.mlir but uses circuits
 
 module {
   oq3.declare_variable @c0 : !quir.cbit<1>

--- a/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
+++ b/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
@@ -1,4 +1,4 @@
-// RUN: qss-compiler -X=mlir --canonicalize --subroutine-cloning --quantum-decorate --merge-circuit-measures-topological %s | FileCheck %s
+// RUN: qss-compiler -X=mlir --canonicalize --subroutine-cloning --quantum-decorate --merge-circuit-measures-topological --remove-unused-circuits %s | FileCheck %s --dump-input always
 
 //
 // This code is part of Qiskit.
@@ -48,6 +48,11 @@ module {
     %0 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
     quir.return %0 : i1
   }
+  quir.circuit @circuit_6(%arg0: !quir.qubit<1> ) {
+    quir.call_gate @x(%arg0) : (!quir.qubit<1>) -> ()
+    quir.return
+  }
+  // func.func @main() -> i32  {
   func.func @main() -> i32  {
     %q0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
     %q1 = quir.declare_qubit {id = 1 : i32} : !quir.qubit<1>
@@ -57,14 +62,14 @@ module {
     %q5 = quir.declare_qubit {id = 5 : i32} : !quir.qubit<1>
 
     // one
-    // CHECK:  %{{.*}} = quir.call_circuit @circuit_0_q0(%{{.*}}) : (!quir.qubit<1>) -> i1
+    // CHECK:  %{{.*}} = quir.call_circuit @circuit_0_q0(%{{.}}) : (!quir.qubit<1>) -> i1
     %res = quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> (i1)
 
     // CHECK:  quir.barrier %0, %1, %2, %3, %4, %5
     quir.barrier %q0, %q1, %q2, %q3, %q4, %q5: (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> ()
 
     // two
-    // CHECK:  %{{.*}}:2 = quir.call_circuit @"circuit_0_q0_circuit_1_q1+m"(%{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
+    // CHECK:  %{{.*}}:2 = quir.call_circuit @"circuit_0_q0_circuit_1_q1+m"(%{{.}}, %{{.}}) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
     %res7_0 = quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> (i1)
     %cast7_0 = "oq3.cast"(%res7_0) : (i1) -> !quir.cbit<1>
     oq3.variable_assign @c0 : !quir.cbit<1> = %cast7_0
@@ -76,7 +81,7 @@ module {
     quir.barrier %q0, %q1, %q2, %q3, %q4, %q5: (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> ()
 
     // three
-    // CHECK:  %{{.*}}:3 = quir.call_circuit @"circuit_0_q0_circuit_1_q1_circuit_2_q2+m1+m"(%{{.*}}, %{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1)
+    // CHECK:  %{{.*}}:3 = quir.call_circuit @"circuit_0_q0_circuit_1_q1_circuit_2_q2+m1+m"(%{{.}}, %{{.}}, %{{.}}) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1)
     %res6_0 = quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> (i1)
     %cast6_0 = "oq3.cast"(%res6_0) : (i1) -> !quir.cbit<1>
     oq3.variable_assign @c0 : !quir.cbit<1> = %cast6_0
@@ -89,7 +94,7 @@ module {
     quir.barrier %q0, %q1, %q2, %q3, %q4, %q5: (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> ()
 
     // four
-    // CHECK:  %{{.*}}:4 = quir.call_circuit @"circuit_0_q0_circuit_1_q1_circuit_2_q2_circuit_3_q3+m0+m+m"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1, i1)
+    // CHECK:  %{{.*}}:4 = quir.call_circuit @"circuit_0_q0_circuit_1_q1_circuit_2_q2_circuit_3_q3+m0+m+m"(%{{.}}, %{{.}}, %{{.}}, %{{.}}) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1, i1)
     %res5_0 = quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> (i1)
     %cast5_0 = "oq3.cast"(%res5_0) : (i1) -> !quir.cbit<1>
     oq3.variable_assign @c0 : !quir.cbit<1> = %cast5_0
@@ -105,7 +110,7 @@ module {
     quir.barrier %q0, %q1, %q2, %q3, %q4, %q5: (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> ()
 
     // four_interrupted
-    // CHECK:  %{{.*}}:4 = quir.call_circuit @"circuit_0_q0_circuit_1_q1_circuit_2_q2_circuit_3_q3+m+m+m"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1, i1)
+    // CHECK:  %{{.*}}:4 = quir.call_circuit @"circuit_0_q0_circuit_1_q1_circuit_2_q2_circuit_3_q3+m+m+m"(%{{.}}, %{{.}}, %{{.}}, %{{.}}) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1, i1)
     %res4_0 = quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> (i1)
     %cast4_0 = "oq3.cast"(%res4_0) : (i1) -> !quir.cbit<1>
     oq3.variable_assign @c0 : !quir.cbit<1> = %cast4_0
@@ -113,8 +118,7 @@ module {
     %cast4_1 = "oq3.cast"(%res4_1) : (i1) -> !quir.cbit<1>
     oq3.variable_assign @c0 : !quir.cbit<1> = %cast4_1
 
-    // CHECK: quir.call_gate @x(%{{.*}}) : (!quir.qubit<1>) -> ()
-    quir.call_gate @x(%q4) : (!quir.qubit<1>) -> ()
+    quir.barrier %q5 : (!quir.qubit<1>) -> ()
 
     // CHECK-NOT:  %{{.*}} = quir.call_circuit @circuit_2
     %res4_2 = quir.call_circuit @circuit_2(%q2) : (!quir.qubit<1>) -> (i1)
@@ -126,7 +130,7 @@ module {
     quir.barrier %q0, %q1, %q2, %q3, %q4, %q5: (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> ()
 
     // inter_if
-    // CHECK: %{{.*}} = quir.call_circuit @circuit_0_q0(%0)
+    // CHECK:  %{{.*}} = quir.call_circuit @circuit_0_q0(%0)
     %res3_0 =  quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> i1
 
     %cond = arith.constant 1 : i1
@@ -135,7 +139,7 @@ module {
       quir.call_circuit @circuit_cx(%q2, %q3) : (!quir.qubit<1>, !quir.qubit<1>) -> ()
     }
 
-    // CHECK: %{{.*}}:2 = quir.call_circuit @"circuit_1_q1_circuit_2_q2+m0"(%{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
+    // CHECK:  %{{.*}}:2 = quir.call_circuit @"circuit_1_q1_circuit_2_q2+m0"(%{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
     %res3_1 = quir.call_circuit @circuit_1(%q1) : (!quir.qubit<1>) -> (i1)
     %res3_2 = quir.call_circuit @circuit_2(%q2) : (!quir.qubit<1>) -> (i1)
 
@@ -147,7 +151,7 @@ module {
     %res2_0 = quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> i1
     quir.barrier %q1, %q0 : (!quir.qubit<1>, !quir.qubit<1>) -> ()
 
-    // CHECK: %{{.*}}:2 = quir.call_circuit @"circuit_1_q1_circuit_2_q2+m"(%{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
+    // CHECK:  %{{.*}}:2 = quir.call_circuit @"circuit_1_q1_circuit_2_q2+m"(%{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
     %res2_1 = quir.call_circuit @circuit_1(%q1) : (!quir.qubit<1>) -> i1
 
     quir.barrier %q0, %q3: (!quir.qubit<1>, !quir.qubit<1>) -> ()
@@ -165,23 +169,26 @@ module {
     %flag = arith.constant 0 : i32
 
     quir.switch %flag {
-        quir.call_gate @x(%q1) : (!quir.qubit<1>) -> ()
+        // CHECK:  quir.call_circuit @circuit_6_q1(%{{.}}) : (!quir.qubit<1>) -> ()
+        quir.call_circuit @circuit_6(%q1) : (!quir.qubit<1>) -> ()
     } [
         0: {
-            quir.call_gate @x(%q2) : (!quir.qubit<1>) -> ()
+            // CHECK:  quir.call_circuit @circuit_6_q2(%{{.}}) : (!quir.qubit<1>) -> ()
+            quir.call_circuit @circuit_6(%q2) : (!quir.qubit<1>) -> ()
         }
         1: {
-            quir.call_gate @x(%q3) : (!quir.qubit<1>) -> ()
+            // CHECK:  quir.call_circuit @circuit_6_q3(%{{.}}) : (!quir.qubit<1>) -> ()
+            quir.call_circuit @circuit_6(%q3) : (!quir.qubit<1>) -> ()
         }
     ]
 
-    // CHECK:  %{{.*}}:4 = quir.call_circuit @"circuit_2_q2_circuit_3_q3_circuit_4_q4_circuit_5_q5+m+m+m"(%2, %3, %4, %5) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1, i1)
+    //  CHECK:  %{{.*}}:4 = quir.call_circuit @"circuit_2_q2_circuit_3_q3_circuit_4_q4_circuit_5_q5+m+m+m"(%2, %3, %4, %5) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1, i1)
     %res1_1 = quir.call_circuit @circuit_2(%q2) : (!quir.qubit<1>) -> i1
     %res1_2 = quir.call_circuit @circuit_3(%q3) : (!quir.qubit<1>) -> i1
 
     quir.switch %flag {} [
         0: {
-            quir.call_gate @x(%q0) : (!quir.qubit<1>) -> ()
+            quir.call_circuit @circuit_6(%q0) : (!quir.qubit<1>) -> ()
         }
     ]
 

--- a/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
+++ b/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
@@ -1,4 +1,4 @@
-// RUN: qss-compiler -X=mlir --canonicalize --subroutine-cloning --quantum-decorate --merge-circuit-measures-topological %s | FileCheck %s --dump-input always
+// RUN: qss-compiler -X=mlir --canonicalize --subroutine-cloning --quantum-decorate --merge-circuit-measures-topological %s | FileCheck %s
 
 //
 // This code is part of Qiskit.

--- a/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
+++ b/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
@@ -43,22 +43,6 @@
 //   return
 // }
 
-// func.func @four(%c : memref<1xi1>, %ind : index) {
-//   %q0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
-//   %q1 = quir.declare_qubit {id = 1 : i32} : !quir.qubit<1>
-//   %q2 = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
-//   %q3 = quir.declare_qubit {id = 3 : i32} : !quir.qubit<1>
-//   // TOP:  %{{.*}}:4 = quir.measure(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1, i1)
-//   %res0 = quir.measure(%q0) : (!quir.qubit<1>) -> (i1)
-//   memref.store %res0, %c[%ind] : memref<1xi1>
-//   %res1 = quir.measure(%q1) : (!quir.qubit<1>) -> (i1)
-//   memref.store %res1, %c[%ind] : memref<1xi1>
-//   %res2 = quir.measure(%q2) : (!quir.qubit<1>) -> (i1)
-//   memref.store %res2, %c[%ind] : memref<1xi1>
-//   %res3 = quir.measure(%q3) : (!quir.qubit<1>) -> (i1)
-//   return
-// }
-
 module {
   oq3.declare_variable @c0 : !quir.cbit<1>
   oq3.declare_variable @c1 : !quir.cbit<1>
@@ -100,6 +84,22 @@ module {
     %q4 = quir.declare_qubit {id = 4 : i32} : !quir.qubit<1>
     %q5 = quir.declare_qubit {id = 5 : i32} : !quir.qubit<1>
 
+    // four
+    // CHECK:  %{{.*}}:4 = quir.call_circuit @"circuit_0_q0_circuit_1_q1_circuit_2_q2_circuit_3_q3+m0+m+m"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1, i1)
+    %res5_0 = quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> (i1)
+    %cast5_0 = "oq3.cast"(%res5_0) : (i1) -> !quir.cbit<1>
+    oq3.variable_assign @c0 : !quir.cbit<1> = %cast5_0
+    %res5_1 = quir.call_circuit @circuit_1(%q1) : (!quir.qubit<1>) -> (i1)
+    %cast5_1 = "oq3.cast"(%res5_1) : (i1) -> !quir.cbit<1>
+    oq3.variable_assign @c0 : !quir.cbit<1> = %cast5_1
+    %res5_2 = quir.call_circuit @circuit_2(%q2) : (!quir.qubit<1>) -> (i1)
+    %cast5_2 = "oq3.cast"(%res5_2) : (i1) -> !quir.cbit<1>
+    oq3.variable_assign @c0 : !quir.cbit<1> = %cast5_2
+    %res3 = quir.call_circuit @circuit_3(%q3) : (!quir.qubit<1>) -> (i1)
+
+    // CHECK:  quir.barrier %0, %1, %2, %3, %4, %5
+    quir.barrier %q0, %q1, %q2, %q3, %q4, %q5: (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> ()
+
     // four_interrupted
     // CHECK:  %{{.*}}:4 = quir.call_circuit @"circuit_0_q0_circuit_1_q1_circuit_2_q2_circuit_3_q3+m+m+m"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1, i1)
     %res4_0 = quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> (i1)
@@ -131,7 +131,7 @@ module {
       quir.call_circuit @circuit_cx(%q2, %q3) : (!quir.qubit<1>, !quir.qubit<1>) -> ()
     }
 
-    // CHECK: %{{.*}}:2 = quir.call_circuit @"circuit_1_q1_circuit_2_q2+m"(%{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
+    // CHECK: %{{.*}}:2 = quir.call_circuit @"circuit_1_q1_circuit_2_q2+m0"(%{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
     %res3_1 = quir.call_circuit @circuit_1(%q1) : (!quir.qubit<1>) -> (i1)
     %res3_2 = quir.call_circuit @circuit_2(%q2) : (!quir.qubit<1>) -> (i1)
 

--- a/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
+++ b/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
@@ -1,0 +1,207 @@
+// RUN: qss-compiler -X=mlir --canonicalize --subroutine-cloning --quantum-decorate --merge-circuit-measures-topological %s | FileCheck %s
+
+//
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2024.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+// func.func @one() {
+//   %q = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
+//   // TOP:  %{{.*}} = quir.measure(%{{.*}}) : (!quir.qubit<1>) -> i1
+//   %res = quir.measure(%q) : (!quir.qubit<1>) -> (i1)
+//   return
+// }
+
+// func.func @two(%c : memref<1xi1>, %ind : index) {
+//   %q0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
+//   %q1 = quir.declare_qubit {id = 1 : i32} : !quir.qubit<1>
+//   // TOP:  %{{.*}}:2 = quir.measure(%{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
+//   %res0 = quir.measure(%q0) : (!quir.qubit<1>) -> (i1)
+//   memref.store %res0, %c[%ind] : memref<1xi1>
+//   %res1 = quir.measure(%q1) : (!quir.qubit<1>) -> (i1)
+//   return
+// }
+
+// func.func @three(%c : memref<1xi1>, %ind : index) {
+//   %q0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
+//   %q1 = quir.declare_qubit {id = 1 : i32} : !quir.qubit<1>
+//   %q2 = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
+//   // TOP:  %{{.*}}:3 = quir.measure(%{{.*}}, %{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1)
+//   %res0 = quir.measure(%q0) : (!quir.qubit<1>) -> (i1)
+//   memref.store %res0, %c[%ind] : memref<1xi1>
+//   %res1 = quir.measure(%q1) : (!quir.qubit<1>) -> (i1)
+//   memref.store %res1, %c[%ind] : memref<1xi1>
+//   %res2 = quir.measure(%q2) : (!quir.qubit<1>) -> (i1)
+//   return
+// }
+
+// func.func @four(%c : memref<1xi1>, %ind : index) {
+//   %q0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
+//   %q1 = quir.declare_qubit {id = 1 : i32} : !quir.qubit<1>
+//   %q2 = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
+//   %q3 = quir.declare_qubit {id = 3 : i32} : !quir.qubit<1>
+//   // TOP:  %{{.*}}:4 = quir.measure(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1, i1)
+//   %res0 = quir.measure(%q0) : (!quir.qubit<1>) -> (i1)
+//   memref.store %res0, %c[%ind] : memref<1xi1>
+//   %res1 = quir.measure(%q1) : (!quir.qubit<1>) -> (i1)
+//   memref.store %res1, %c[%ind] : memref<1xi1>
+//   %res2 = quir.measure(%q2) : (!quir.qubit<1>) -> (i1)
+//   memref.store %res2, %c[%ind] : memref<1xi1>
+//   %res3 = quir.measure(%q3) : (!quir.qubit<1>) -> (i1)
+//   return
+// }
+
+// func.func @four_interrupted(%c : memref<1xi1>, %ind : index) {
+//   %q0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
+//   %q1 = quir.declare_qubit {id = 1 : i32} : !quir.qubit<1>
+//   %q2 = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
+//   %q3 = quir.declare_qubit {id = 3 : i32} : !quir.qubit<1>
+//   %q4 = quir.declare_qubit {id = 4 : i32} : !quir.qubit<1>
+
+//   // TOP:  %{{.*}}:4 = quir.measure(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1, i1)
+//   %res0 = quir.measure(%q0) : (!quir.qubit<1>) -> (i1)
+//   memref.store %res0, %c[%ind] : memref<1xi1>
+//   %res1 = quir.measure(%q1) : (!quir.qubit<1>) -> (i1)
+//   memref.store %res1, %c[%ind] : memref<1xi1>
+
+//   // TOP: quir.call_gate @x(%{{.*}}) : (!quir.qubit<1>) -> ()
+//   quir.call_gate @x(%q4) : (!quir.qubit<1>) -> ()
+
+//   // TOP-NOT:  %{{.*}} = quir.measure(%{{.*}}) : (!quir.qubit<1>) -> (i1)
+//   %res2 = quir.measure(%q2) : (!quir.qubit<1>) -> (i1)
+//   memref.store %res2, %c[%ind] : memref<1xi1>
+//   %res3 = quir.measure(%q3) : (!quir.qubit<1>) -> (i1)
+//   return
+// }
+
+// func.func @inter_if(%c : memref<1xi1>, %ind : index, %cond : i1) {
+//   %q0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
+//   %q1 = quir.declare_qubit {id = 1 : i32} : !quir.qubit<1>
+//   %q2 = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
+//   %q3 = quir.declare_qubit {id = 3 : i32} : !quir.qubit<1>
+
+//   // TOP: %{{.*}} = quir.measure(%{{.*}}) : (!quir.qubit<1>) -> i1
+//   %res0 = quir.measure(%q0) : (!quir.qubit<1>) -> (i1)
+//   memref.store %res0, %c[%ind] : memref<1xi1>
+//   scf.if %cond {
+//     quir.call_gate @cx(%q2, %q3) : (!quir.qubit<1>, !quir.qubit<1>) -> ()
+//   }
+
+//   // TOP: %{{.*}}:2 = quir.measure(%{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
+//   %res1 = quir.measure(%q1) : (!quir.qubit<1>) -> (i1)
+//   %res2 = quir.measure(%q2) : (!quir.qubit<1>) -> (i1)
+//   memref.store %res1, %c[%ind] : memref<1xi1>
+//   return
+// }
+
+// func.func @barrier(%c : memref<1xi1>, %ind : index) {
+//   %q0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
+//   %q1 = quir.declare_qubit {id = 1 : i32} : !quir.qubit<1>
+//   %q2 = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
+//   %q3 = quir.declare_qubit {id = 3 : i32} : !quir.qubit<1>
+
+//   // TOP:  %{{.*}} = quir.measure(%{{.*}}) : (!quir.qubit<1>) -> i1
+//   %res0 = quir.measure(%q0) : (!quir.qubit<1>) -> (i1)
+//   quir.barrier %q1, %q0 : (!quir.qubit<1>, !quir.qubit<1>) -> ()
+
+//   // TOP: %{{.*}}:2 = quir.measure(%{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
+//   %res1 = quir.measure(%q1) : (!quir.qubit<1>) -> (i1)
+
+//   quir.barrier %q0, %q3: (!quir.qubit<1>, !quir.qubit<1>) -> ()
+
+//   // TOP-NOT:  %{{.*}} = quir.measure(%{{.*}}) : (!quir.qubit<1>) -> i1
+//   %res2 = quir.measure(%q2) : (!quir.qubit<1>) -> (i1)
+//   return
+// }
+
+module {
+  quir.circuit @circuit_0(%arg0: !quir.qubit<1> ) -> i1 {
+    quir.call_gate @x(%arg0) : (!quir.qubit<1>) -> ()
+    %0 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
+    quir.return %0 : i1
+  }
+  quir.circuit @circuit_1(%arg0: !quir.qubit<1> ) -> i1 {
+    %0 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
+    quir.return %0 : i1
+  }
+  quir.circuit @circuit_2(%arg0: !quir.qubit<1> ) -> i1 {
+    %0 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
+    quir.return %0 : i1
+  }
+  quir.circuit @circuit_3(%arg0: !quir.qubit<1> ) -> i1 {
+    %0 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
+    quir.return %0 : i1
+  }
+  quir.circuit @circuit_4(%arg0: !quir.qubit<1> ) -> i1 {
+    %0 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
+    quir.return %0 : i1
+  }
+  quir.circuit @circuit_5(%arg0: !quir.qubit<1> ) -> i1 {
+    %0 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
+    quir.return %0 : i1
+  }
+  func.func @main() -> i32  {
+    %q0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
+    %q1 = quir.declare_qubit {id = 1 : i32} : !quir.qubit<1>
+    %q2 = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
+    %q3 = quir.declare_qubit {id = 3 : i32} : !quir.qubit<1>
+    %q4 = quir.declare_qubit {id = 4 : i32} : !quir.qubit<1>
+    %q5 = quir.declare_qubit {id = 5 : i32} : !quir.qubit<1>
+
+
+    // CHECK:  %{{.*}} = quir.measure(%{{.*}}) : (!quir.qubit<1>) -> i1
+    %res2_0 = quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> i1
+    quir.barrier %q1, %q0 : (!quir.qubit<1>, !quir.qubit<1>) -> ()
+
+    // CHECK: %{{.*}}:2 = quir.measure(%{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
+    %res2_1 = quir.call_circuit @circuit_1(%q1) : (!quir.qubit<1>) -> i1
+
+    quir.barrier %q0, %q3: (!quir.qubit<1>, !quir.qubit<1>) -> ()
+
+    // CHECK-NOT:  %{{.*}} =  quir.call_circuit @circuit_2
+    %res2_2 = quir.call_circuit @circuit_2(%q2) : (!quir.qubit<1>) -> i1
+
+    quir.barrier %q0, %q1, %q2, %q3, %q4, %q5: (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> ()
+    
+    // CHECK:  %{{.*}} = quir.call_circuit @circuit_0_q0(%0) : (!quir.qubit<1>) -> i1
+    %res1_0 = quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> i1
+
+    %flag = arith.constant 0 : i32
+
+    quir.switch %flag {
+        quir.call_gate @x(%q1) : (!quir.qubit<1>) -> ()
+    } [
+        0: {
+            quir.call_gate @x(%q2) : (!quir.qubit<1>) -> ()
+        }
+        1: {
+            quir.call_gate @x(%q3) : (!quir.qubit<1>) -> ()
+        }
+    ]
+
+    // CHECK:  %{{.*}}:4 = quir.call_circuit @"circuit_2_q2_circuit_3_q3_circuit_4_q4_circuit_5_q5+m+m+m"(%2, %3, %4, %5) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1, i1)
+    %res1_1 = quir.call_circuit @circuit_2(%q2) : (!quir.qubit<1>) -> i1
+    %res1_2 = quir.call_circuit @circuit_3(%q3) : (!quir.qubit<1>) -> i1
+
+    quir.switch %flag {} [
+        0: {
+            quir.call_gate @x(%q0) : (!quir.qubit<1>) -> ()
+        }
+    ]
+
+    %res1_3 = quir.call_circuit @circuit_4(%q4) : (!quir.qubit<1>) -> (i1)
+    %res1_4 = quir.call_circuit @circuit_5(%q5) : (!quir.qubit<1>) -> (i1)
+
+    %c0_i32 = arith.constant 0 : i32
+    return %c0_i32 : i32
+  }
+}
+

--- a/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
+++ b/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
@@ -74,7 +74,7 @@ module {
     quir.barrier %q0, %q1, %q2, %q3, %q4, %q5: (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> ()
 
     // three
-    // CHECK:  %{{.*}}:3 = quir.call_circuit @"circuit_0_q0_circuit_1_q1_circuit_2_q2+m01+m"(%{{.*}}, %{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1)
+    // CHECK:  %{{.*}}:3 = quir.call_circuit @"circuit_0_q0_circuit_1_q1_circuit_2_q2+m1+m"(%{{.*}}, %{{.*}}, %{{.*}}) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> (i1, i1, i1)
     %res6_0 = quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> (i1)
     %cast6_0 = "oq3.cast"(%res6_0) : (i1) -> !quir.cbit<1>
     oq3.variable_assign @c0 : !quir.cbit<1> = %cast6_0

--- a/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
+++ b/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
@@ -13,7 +13,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-// This test is based om merge-measures.mlir but uses circuits 
+// This test is based om merge-measures.mlir but uses circuits
 
 module {
   oq3.declare_variable @c0 : !quir.cbit<1>
@@ -155,7 +155,7 @@ module {
 
     // CHECK:  quir.barrier %0, %1, %2, %3, %4, %5
     quir.barrier %q0, %q1, %q2, %q3, %q4, %q5: (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> ()
-    
+
     // inter_switch
     // CHECK:  %{{.*}} = quir.call_circuit @circuit_0_q0(%0) : (!quir.qubit<1>) -> i1
     %res1_0 = quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> i1
@@ -190,4 +190,3 @@ module {
     return %c0_i32 : i32
   }
 }
-

--- a/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
+++ b/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
@@ -69,6 +69,8 @@ module {
     %cast7_0 = "oq3.cast"(%res7_0) : (i1) -> !quir.cbit<1>
     oq3.variable_assign @c0 : !quir.cbit<1> = %cast7_0
     %res7_1 = quir.call_circuit @circuit_1(%q1) : (!quir.qubit<1>) -> (i1)
+    %cast7_1 = "oq3.cast"(%res7_0) : (i1) -> !quir.cbit<1>
+    oq3.variable_assign @c0 : !quir.cbit<1> = %cast7_1
 
     // CHECK:  quir.barrier %0, %1, %2, %3, %4, %5
     quir.barrier %q0, %q1, %q2, %q3, %q4, %q5: (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> ()

--- a/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
+++ b/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
@@ -1,4 +1,4 @@
-// RUN: qss-compiler -X=mlir --canonicalize --subroutine-cloning --quantum-decorate --merge-circuit-measures-topological %s | FileCheck %s
+// RUN: qss-compiler -X=mlir --canonicalize --subroutine-cloning --quantum-decorate --merge-circuit-measures-topological %s | FileCheck %s --dump-input always
 
 //
 // This code is part of Qiskit.

--- a/test/Dialect/QUIR/Transforms/remove-unused-circuits.mlir
+++ b/test/Dialect/QUIR/Transforms/remove-unused-circuits.mlir
@@ -1,0 +1,48 @@
+// RUN: qss-compiler -X=mlir --canonicalize --remove-unused-circuits %s | FileCheck %s --dump-input always
+//
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2024.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+module {
+  // CHECK: quir.circuit @circuit_0(%arg0: !quir.qubit<1>) -> i1 {
+  quir.circuit @circuit_0(%arg0: !quir.qubit<1> ) -> i1 {
+    quir.call_gate @x(%arg0) : (!quir.qubit<1>) -> ()
+    %0 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
+    quir.return %0 : i1
+  }
+  // CHECK: quir.circuit @circuit_1(%arg0: !quir.qubit<1>) -> i1 {
+  quir.circuit @circuit_1(%arg0: !quir.qubit<1> ) -> i1 {
+    %0 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
+    quir.return %0 : i1
+  }
+  // CHECK-NOT: quir.circuit @circuit_2(%arg0: !quir.qubit<1> ) -> i1 {
+  quir.circuit @circuit_2(%arg0: !quir.qubit<1> ) -> i1 {
+    %0 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
+    quir.return %0 : i1
+  }
+  // CHECK-NOT: quir.circuit @circuit_3(%arg0: !quir.qubit<1> ) -> i1 {
+  quir.circuit @circuit_3(%arg0: !quir.qubit<1> ) -> i1 {
+    %0 = quir.measure(%arg0) : (!quir.qubit<1>) -> i1
+    quir.return %0 : i1
+  }
+  func.func @main() -> i32  {
+    %q0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
+    %q1 = quir.declare_qubit {id = 1 : i32} : !quir.qubit<1>
+    
+    %res1 = quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> (i1)
+
+    %res2 = quir.call_circuit @circuit_1(%q1) : (!quir.qubit<1>) -> (i1)
+    
+    %c0_i32 = arith.constant 0 : i32
+    return %c0_i32 : i32
+  }
+}

--- a/test/Dialect/QUIR/Transforms/remove-unused-circuits.mlir
+++ b/test/Dialect/QUIR/Transforms/remove-unused-circuits.mlir
@@ -37,11 +37,11 @@ module {
   func.func @main() -> i32  {
     %q0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
     %q1 = quir.declare_qubit {id = 1 : i32} : !quir.qubit<1>
-    
+
     %res1 = quir.call_circuit @circuit_0(%q0) : (!quir.qubit<1>) -> (i1)
 
     %res2 = quir.call_circuit @circuit_1(%q1) : (!quir.qubit<1>) -> (i1)
-    
+
     %c0_i32 = arith.constant 0 : i32
     return %c0_i32 : i32
   }


### PR DESCRIPTION
Adds a `MergeCircuitMeasuresPass` to merge `quir.measure`s inside circuits. Based on `MergeMeasuresTopologicalPass`.

Adds pass and test. 

Updates `MergeCircuitsPass` so that a `ParallelControlFlowOp` will block a merge.

The PR restores performance of merging measurements when circuits are enabled. 