### PR TITLE
Add control system resources exceeded error

### DIFF
--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -46,6 +46,7 @@ enum class ErrorCategory {
   QSSLinkSignatureNotFound,
   QSSLinkArgumentNotFoundWarning,
   QSSLinkInvalidPatchTypeError,
+  QSSControlSystemResourcesExceeded,
   UncategorizedError,
 };
 

--- a/include/HAL/TargetSystem.h
+++ b/include/HAL/TargetSystem.h
@@ -150,7 +150,7 @@ public:
   }
   /// @brief Construct a diagnostic and add to this target
   void addDiagnostic(Severity severity, ErrorCategory category,
-                     std::string message) {
+                     const std::string &message) {
     const std::lock_guard<std::mutex> lock(diagnosticsMutex_);
     diagnostics_.emplace_back(severity, category, message);
   }

--- a/include/HAL/TargetSystem.h
+++ b/include/HAL/TargetSystem.h
@@ -148,6 +148,12 @@ public:
     const std::lock_guard<std::mutex> lock(diagnosticsMutex_);
     diagnostics_.emplace_back(diag);
   }
+  /// @brief Construct a diagnostic and add to this target
+  void addDiagnostic(Severity severity, ErrorCategory category,
+                     std::string message) {
+    const std::lock_guard<std::mutex> lock(diagnosticsMutex_);
+    diagnostics_.emplace_back(severity, category, message);
+  }
   /// @brief Return the diagnostics from this target and its sub-targets.
   ///        Take and clear the diagnostic lists of the targets.
   qssc::DiagList takeDiagnostics() {

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -79,6 +79,9 @@ std::string_view getErrorCategoryAsString(qssc::ErrorCategory category) {
   case ErrorCategory::QSSLinkInvalidPatchTypeError:
     return "Invalid patch point type";
 
+  case ErrorCategory::QSSControlSystemResourcesExceeded:
+    return "Control system resources exceeded";
+
   case ErrorCategory::UncategorizedError:
     return "Compilation failure";
   }

--- a/python_lib/qss_compiler/compile.py
+++ b/python_lib/qss_compiler/compile.py
@@ -297,6 +297,12 @@ class _CompilationManager:
                         diagnostics,
                         return_diagnostics=self.return_diagnostics,
                     )
+                if diag.category == ErrorCategory.QSSControlSystemResourcesExceeded:
+                    raise exceptions.QSSControlSystemResourcesExceeded(
+                        diag.message,
+                        diagnostics,
+                        return_diagnostics=self.return_diagnostics,
+                    )
 
             if not success:
                 raise exceptions.QSSCompilationFailure(

--- a/python_lib/qss_compiler/exceptions.py
+++ b/python_lib/qss_compiler/exceptions.py
@@ -111,3 +111,7 @@ class QSSLinkInvalidPatchTypeError(QSSLinkingFailure):
 
 class QSSLinkInvalidArgumentError(QSSLinkingFailure):
     """Raised when argument is invalid"""
+
+
+class QSSControlSystemResourcesExceeded(QSSCompilerError):
+    """Raised when control system resources (such as instruction memory) are exceeded."""

--- a/python_lib/qss_compiler/lib_enums.cpp
+++ b/python_lib/qss_compiler/lib_enums.cpp
@@ -41,6 +41,8 @@ void addErrorCategory(py::module &m) {
              qssc::ErrorCategory::QSSLinkArgumentNotFoundWarning)
       .value("QSSLinkInvalidPatchTypeError",
              qssc::ErrorCategory::QSSLinkInvalidPatchTypeError)
+      .value("QSSControlSystemResourcesExceeded",
+             qssc::ErrorCategory::QSSControlSystemResourcesExceeded)
       .value("UncategorizedError", qssc::ErrorCategory::UncategorizedError)
       .export_values();
 }

--- a/releasenotes/notes/control-system-resources-exceeded-error-d2a2c15c52fa02dd.yaml
+++ b/releasenotes/notes/control-system-resources-exceeded-error-d2a2c15c52fa02dd.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    A new QSSControlSystemResourcesExceeded error has been added as an error
+    category. This can be raised as an error whenever the compiler detects that
+    an input circuit will exceed the capabilities of the control system.


### PR DESCRIPTION
This PR adds a new QSSControlSystemResourcesExceeded error category. This can be raised as an error whenever the compiler detects that an input circuit will exceed the resources of the control system, such as instruction or waveform memory.

I've also added a new `addDiagnostic()` method to the target system that prevents unnecessary copies of diagnostic objects from being made.