### PR TITLE
remove unnecessary  --dump-input

### DIFF
--- a/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
+++ b/test/Dialect/QUIR/Transforms/merge-circuit-measures.mlir
@@ -1,4 +1,4 @@
-// RUN: qss-compiler -X=mlir --canonicalize --subroutine-cloning --quantum-decorate --merge-circuit-measures-topological --remove-unused-circuits %s | FileCheck %s --dump-input always
+// RUN: qss-compiler -X=mlir --canonicalize --subroutine-cloning --quantum-decorate --merge-circuit-measures-topological --remove-unused-circuits %s | FileCheck %s
 
 //
 // This code is part of Qiskit.

--- a/test/Dialect/QUIR/Transforms/remove-unused-circuits.mlir
+++ b/test/Dialect/QUIR/Transforms/remove-unused-circuits.mlir
@@ -1,4 +1,4 @@
-// RUN: qss-compiler -X=mlir --canonicalize --remove-unused-circuits %s | FileCheck %s --dump-input always
+// RUN: qss-compiler -X=mlir --canonicalize --remove-unused-circuits %s | FileCheck %s
 //
 // This code is part of Qiskit.
 //


### PR DESCRIPTION
Removes unnecessary  `--dump-input always` from FileChecks left over from debugging. 