### PR TITLE
Disable LLVM_ENABLE_WARNINGS 

### DIFF
--- a/conan/clang-tools-extra/conanfile.py
+++ b/conan/clang-tools-extra/conanfile.py
@@ -92,7 +92,7 @@ class ClangToolsExtraConan(ConanFile):
         cmake.definitions["LLVM_ENABLE_PIC"] = self.options.get_safe("fPIC", default=False)
 
         cmake.definitions["LLVM_ABI_BREAKING_CHECKS"] = "WITH_ASSERTS"
-        cmake.definitions["LLVM_ENABLE_WARNINGS"] = True
+        cmake.definitions["LLVM_ENABLE_WARNINGS"] = False
         cmake.definitions["LLVM_ENABLE_PEDANTIC"] = True
         cmake.definitions["LLVM_ENABLE_WERROR"] = False
 

--- a/conan/llvm/conanfile.py
+++ b/conan/llvm/conanfile.py
@@ -145,7 +145,7 @@ class LLVMConan(ConanFile):
         cmake.definitions["LLVM_ENABLE_PIC"] = self.options.get_safe("fPIC", default=False)
 
         cmake.definitions["LLVM_ABI_BREAKING_CHECKS"] = "WITH_ASSERTS"
-        cmake.definitions["LLVM_ENABLE_WARNINGS"] = True
+        cmake.definitions["LLVM_ENABLE_WARNINGS"] = False
         cmake.definitions["LLVM_ENABLE_PEDANTIC"] = True
         cmake.definitions["LLVM_ENABLE_WERROR"] = False
 


### PR DESCRIPTION
This PR disables LLVM_ENABLE_WARNINGS to reflect our internal environment. Some of the checks enabled by this flag will be added back in a separate PR.