### PR TITLE
Enable python bindings for internal CI attempt 2

### DIFF
--- a/conan/llvm/conanfile.py
+++ b/conan/llvm/conanfile.py
@@ -60,6 +60,7 @@ class LLVMConan(ConanFile):
         "with_ffi": [True, False],
         "with_zlib": [True, False],
         "with_xml2": [True, False],
+        "with_python_bindings": [True, False],
     }
     default_options = {
         "shared": False,
@@ -79,6 +80,7 @@ class LLVMConan(ConanFile):
         "with_ffi": False,
         "with_zlib": True,
         "with_xml2": False,
+        "with_python_bindings": True,
     }
 
     generators = ["cmake"]
@@ -201,7 +203,9 @@ class LLVMConan(ConanFile):
 
         cmake.definitions["LLVM_PARALLEL_LINK_JOBS"] = 4
 
-        cmake.definitions["MLIR_ENABLE_BINDINGS_PYTHON"] = True
+        cmake.definitions["MLIR_ENABLE_BINDINGS_PYTHON"] = self.options.get_safe(
+            "with_python_bindings", False
+        )
         cmake.definitions["Python3_EXECUTABLE"] = sys.executable
 
         if self.settings.build_type == "Debug":


### PR DESCRIPTION
This PR is another attempt to update the conan cache so that the LLVM package builds with the python bindings enabled.