### PR TITLE
Fix cmake warning

### DIFF
--- a/cmake/AddWarnings.cmake
+++ b/cmake/AddWarnings.cmake
@@ -146,4 +146,4 @@ if (QSSC_ENABLE_WARNINGS AND NOT LLVM_ENABLE_WARNINGS)
 
   # Enable -Wctad-maybe-unsupported to catch unintended use of CTAD.
   add_flag_if_supported("-Wctad-maybe-unsupported" CTAD_MAYBE_UNSPPORTED_FLAG)
-endif (QSSC_ENABLE_WARNINGS)
+endif (QSSC_ENABLE_WARNINGS AND NOT LLVM_ENABLE_WARNINGS)


### PR DESCRIPTION
Fixes cmake warning:

```
CMake Warning (dev) in qss-compiler/cmake/AddWarnings.cmake:
  A logical block opening on the line

    qss-compiler/cmake/AddWarnings.cmake:26 (if)

  closes on the line

    qss-compiler/cmake/AddWarnings.cmake:149 (endif)

  with mis-matching arguments.
Call Stack (most recent call first):
  qss-compiler/CMakeLists.txt:96 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```