### PR TITLE
Replace few `QSSCompilationFailure` to `OpenQASM3ParseFailure`

### DIFF
--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -47,6 +47,7 @@ enum class ErrorCategory {
   QSSLinkArgumentNotFoundWarning,
   QSSLinkInvalidPatchTypeError,
   QSSControlSystemResourcesExceeded,
+  QSSIncorrectQASM3,
   UncategorizedError,
 };
 

--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -47,7 +47,6 @@ enum class ErrorCategory {
   QSSLinkArgumentNotFoundWarning,
   QSSLinkInvalidPatchTypeError,
   QSSControlSystemResourcesExceeded,
-  QSSIncorrectQASM3,
   UncategorizedError,
 };
 

--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -1,6 +1,6 @@
 //===- OpenQASM3Frontend.cpp ------------------------------------*- C++ -*-===//
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is part of Qiskit.
 //
@@ -195,14 +195,11 @@ llvm::Error qssc::frontend::openqasm3::parse(
         fileLoc << "File: " << File << ", Line: " << Loc.LineNo
                 << ", Col: " << Loc.ColNo;
 
-        llvm::errs() << level << " while parsing OpenQASM 3 input\n"
-                     << fileLoc.str() << " " << Msg << "\n"
-                     << sourceString << "\n";
-
         if (diagnosticCallback_) {
           qssc::Diagnostic const diag{
               diagLevel, qssc::ErrorCategory::OpenQASM3ParseFailure,
-              fileLoc.str() + "\n" + Msg + "\n" + sourceString};
+              level + " while parsing OpenQASM 3 input\n" + fileLoc.str() +
+                  " " + Msg + "\n" + sourceString + "\n"};
           (*diagnosticCallback_)(diag);
         }
 

--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -195,11 +195,17 @@ llvm::Error qssc::frontend::openqasm3::parse(
         fileLoc << "File: " << File << ", Line: " << Loc.LineNo
                 << ", Col: " << Loc.ColNo;
 
+        std::stringstream errMsg;
+        errMsg << fileLoc.str() << " " << Msg << "\n" << sourceString << "\n";
+
+        // This will show the error when trying to generate MLIR
+        llvm::errs() << level << " while parsing OpenQASM 3 input\n"
+                     << errMsg.str();
+
         if (diagnosticCallback_) {
           qssc::Diagnostic const diag{
               diagLevel, qssc::ErrorCategory::OpenQASM3ParseFailure,
-              level + " while parsing OpenQASM 3 input\n" + fileLoc.str() +
-                  " " + Msg + "\n" + sourceString + "\n"};
+              errMsg.str()};
           (*diagnosticCallback_)(diag);
         }
 

--- a/python_lib/qss_compiler/compile.py
+++ b/python_lib/qss_compiler/compile.py
@@ -304,6 +304,12 @@ class _CompilationManager:
                         diagnostics,
                         return_diagnostics=self.return_diagnostics,
                     )
+                if diag.category == ErrorCategory.OpenQASM3ParseFailure:
+                    raise exceptions.OpenQASM3ParseFailure(
+                        diag.message,
+                        diagnostics,
+                        return_diagnostics=self.return_diagnostics,
+                    )
 
             if not success:
                 raise exceptions.QSSCompilationFailure(

--- a/python_lib/qss_compiler/compile.py
+++ b/python_lib/qss_compiler/compile.py
@@ -1,4 +1,4 @@
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2024.
 #
 # This code is part of Qiskit.
 #

--- a/python_lib/qss_compiler/exceptions.py
+++ b/python_lib/qss_compiler/exceptions.py
@@ -115,3 +115,7 @@ class QSSLinkInvalidArgumentError(QSSLinkingFailure):
 
 class QSSControlSystemResourcesExceeded(QSSCompilerError):
     """Raised when control system resources (such as instruction memory) are exceeded."""
+
+
+class OpenQASM3ParseFailure(QSSCompilerError):
+    """Raised when a parser failure is received"""

--- a/python_lib/qss_compiler/exceptions.py
+++ b/python_lib/qss_compiler/exceptions.py
@@ -1,4 +1,4 @@
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2024.
 #
 # This code is part of Qiskit.
 #

--- a/releasenotes/notes/soo-ER-raise-OpenQASM3ParseFailure-7db973ddd38ece7e.yaml
+++ b/releasenotes/notes/soo-ER-raise-OpenQASM3ParseFailure-7db973ddd38ece7e.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    One of the failing test cases that raise the generic ``QSSCompilationFailure``
+    will now raise ``OpenQASM3ParseFailure`` when the parse returns an Error 
+    diagnostic.

--- a/releasenotes/notes/soo-ER-raise-OpenQASM3ParseFailure-7db973ddd38ece7e.yaml
+++ b/releasenotes/notes/soo-ER-raise-OpenQASM3ParseFailure-7db973ddd38ece7e.yaml
@@ -2,5 +2,5 @@
 features:
   - |
     Few of the failing test cases that raise the generic ``QSSCompilationFailure``
-    will now raise ``OpenQASM3ParseFailure`` when the parse returns an Error 
+    will now raise ``OpenQASM3ParseFailure`` when the parse returns an Error
     diagnostic.

--- a/releasenotes/notes/soo-ER-raise-OpenQASM3ParseFailure-7db973ddd38ece7e.yaml
+++ b/releasenotes/notes/soo-ER-raise-OpenQASM3ParseFailure-7db973ddd38ece7e.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    One of the failing test cases that raise the generic ``QSSCompilationFailure``
+    Few of the failing test cases that raise the generic ``QSSCompilationFailure``
     will now raise ``OpenQASM3ParseFailure`` when the parse returns an Error 
     diagnostic.

--- a/test/python_lib/test_compile.py
+++ b/test/python_lib/test_compile.py
@@ -1,4 +1,4 @@
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2024.
 #
 # This code is part of Qiskit.
 #

--- a/test/python_lib/test_compile.py
+++ b/test/python_lib/test_compile.py
@@ -23,7 +23,7 @@ from qss_compiler import (
     OutputType,
     Severity,
 )
-from qss_compiler.exceptions import QSSCompilationFailure, QSSCompilerEOFFailure
+from qss_compiler import exceptions
 
 
 def check_mlir_string(mlir):
@@ -135,7 +135,7 @@ def test_compile_invalid_file(example_invalid_qasm3_tmpfile):
     """Test that we can attempt to compile invalid OpenQASM 3 and receive an
     error"""
 
-    with pytest.raises(QSSCompilationFailure):
+    with pytest.raises(exceptions.OpenQASM3ParseFailure):
         compile_file(
             example_invalid_qasm3_tmpfile,
             return_diagnostics=True,  # For testing purposes
@@ -149,7 +149,7 @@ def test_compile_invalid_str(example_invalid_qasm3_str):
     """Test that we can attempt to compile invalid OpenQASM 3 and receive an
     error"""
 
-    with pytest.raises(QSSCompilationFailure) as compfail:
+    with pytest.raises(exceptions.OpenQASM3ParseFailure) as compfail:
         compile_str(
             example_invalid_qasm3_str,
             return_diagnostics=True,  # For testing purposes
@@ -178,7 +178,7 @@ def test_compile_invalid_str(example_invalid_qasm3_str):
 
 def test_failure_no_hang():
     """Test no hang on malformed inputs."""
-    with pytest.raises(QSSCompilerEOFFailure):
+    with pytest.raises(exceptions.QSSCompilerEOFFailure):
         _ = compile_str(
             "",
             input_type=InputType.QASM3,


### PR DESCRIPTION
## Summary

`QSSCompilationFailure` error category is a generic error category and one of the test case which raises Error diagnostic in the parser will now raise `OpenQASM3ParseFailure`