### PR TITLE
[Backport v3.8] Replace few `QSSCompilationFailure` to `OpenQASM3ParseFailure`

### DIFF
--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -1,6 +1,6 @@
 //===- OpenQASM3Frontend.cpp ------------------------------------*- C++ -*-===//
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is part of Qiskit.
 //
@@ -172,14 +172,17 @@ llvm::Error qssc::frontend::openqasm3::parse(
         fileLoc << "File: " << File << ", Line: " << Loc.LineNo
                 << ", Col: " << Loc.ColNo;
 
+        std::stringstream errMsg;
+        errMsg << fileLoc.str() << " " << Msg << "\n" << sourceString << "\n";
+
+        // This will show the error when trying to generate MLIR
         llvm::errs() << level << " while parsing OpenQASM 3 input\n"
-                     << fileLoc.str() << " " << Msg << "\n"
-                     << sourceString << "\n";
+                     << errMsg.str();
 
         if (diagnosticCallback_) {
           qssc::Diagnostic diag{
               diagLevel, qssc::ErrorCategory::OpenQASM3ParseFailure,
-              fileLoc.str() + "\n" + Msg + "\n" + sourceString};
+              errMsg.str()};
           (*diagnosticCallback_)(diag);
         }
 

--- a/python_lib/qss_compiler/compile.py
+++ b/python_lib/qss_compiler/compile.py
@@ -1,4 +1,4 @@
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2024.
 #
 # This code is part of Qiskit.
 #
@@ -61,7 +61,7 @@ from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 from . import exceptions
-from .py_qssc import _compile_with_args, Diagnostic
+from .py_qssc import _compile_with_args, Diagnostic, ErrorCategory
 
 # use the forkserver context to create a server process
 # for forking new compiler processes
@@ -296,6 +296,14 @@ def _do_compile(
                 diagnostics,
                 return_diagnostics=return_diagnostics,
             )
+        
+        for diag in diagnostics:
+            if diag.category == ErrorCategory.OpenQASM3ParseFailure:
+                raise exceptions.OpenQASM3ParseFailure(
+                    diag.message,
+                    diagnostics,
+                    return_diagnostics=return_diagnostics,
+                )
 
         if not success:
             raise exceptions.QSSCompilationFailure(
@@ -339,7 +347,7 @@ def compile_file(
     **kwargs,
 ) -> Union[bytes, str, None]:
     """! Compile a file to the specified output type using the given target.
-
+ 
     Produces output in a file (if parameter output_file is provided) or returns
     the compiler output as byte sequence or string, depending on the requested
     output format.

--- a/python_lib/qss_compiler/compile.py
+++ b/python_lib/qss_compiler/compile.py
@@ -347,7 +347,7 @@ def compile_file(
     **kwargs,
 ) -> Union[bytes, str, None]:
     """! Compile a file to the specified output type using the given target.
- 
+
     Produces output in a file (if parameter output_file is provided) or returns
     the compiler output as byte sequence or string, depending on the requested
     output format.

--- a/python_lib/qss_compiler/exceptions.py
+++ b/python_lib/qss_compiler/exceptions.py
@@ -1,4 +1,4 @@
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2024.
 #
 # This code is part of Qiskit.
 #
@@ -107,3 +107,7 @@ class QSSLinkInvalidPatchTypeError(QSSLinkingFailure):
 
 class QSSLinkInvalidArgumentError(QSSLinkingFailure):
     """Raised when argument is invalid"""
+
+
+class OpenQASM3ParseFailure(QSSCompilerError):
+    """Raised when a parser failure is received"""

--- a/releasenotes/notes/soo-ER-raise-OpenQASM3ParseFailure-7db973ddd38ece7e.yaml
+++ b/releasenotes/notes/soo-ER-raise-OpenQASM3ParseFailure-7db973ddd38ece7e.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Few of the failing test cases that raise the generic ``QSSCompilationFailure``
+    will now raise ``OpenQASM3ParseFailure`` when the parse returns an Error
+    diagnostic.

--- a/test/python_lib/test_compile.py
+++ b/test/python_lib/test_compile.py
@@ -1,4 +1,4 @@
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2024.
 #
 # This code is part of Qiskit.
 #
@@ -23,7 +23,7 @@ from qss_compiler import (
     OutputType,
     Severity,
 )
-from qss_compiler.exceptions import QSSCompilationFailure
+from qss_compiler import exceptions
 
 
 def check_mlir_string(mlir):
@@ -98,7 +98,7 @@ def test_compile_invalid_file(example_invalid_qasm3_tmpfile):
     """Test that we can attempt to compile invalid OpenQASM 3 and receive an
     error"""
 
-    with pytest.raises(QSSCompilationFailure):
+    with pytest.raises(exceptions.OpenQASM3ParseFailure):
         compile_file(
             example_invalid_qasm3_tmpfile,
             return_diagnostics=True,  # For testing purposes
@@ -112,7 +112,7 @@ def test_compile_invalid_str(example_invalid_qasm3_str):
     """Test that we can attempt to compile invalid OpenQASM 3 and receive an
     error"""
 
-    with pytest.raises(QSSCompilationFailure) as compfail:
+    with pytest.raises(exceptions.OpenQASM3ParseFailure) as compfail:
         compile_str(
             example_invalid_qasm3_str,
             return_diagnostics=True,  # For testing purposes


### PR DESCRIPTION
Backport changes made in https://github.com/openqasm/qe-compiler/pull/277

waiting on other back ports to merge.