### PR TITLE
Fix incorrect # of replacement values assert for debug builds

### DIFF
--- a/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
@@ -262,6 +262,9 @@ static void mergeMeasurements(PatternRewriter &rewriter,
       measureOp.getLoc(), TypeRange(typeVec), ValueRange(valVec));
 
   auto originalNumResults = measureOp->getNumResults();
+  rewriter.replaceOp(measureOp,
+                     ResultRange(mergedOp.result_begin(),
+                                 mergedOp.result_begin() + originalNumResults));
 
   llvm::SmallVector<Type> outputTypes;
   llvm::SmallVector<Value> outputValues;
@@ -275,10 +278,6 @@ static void mergeMeasurements(PatternRewriter &rewriter,
 
   dropNextMeasure(rewriter, outputTypes, outputValues, nextCircuitOp,
                   nextMeasureOp);
-
-  for(uint resultNum = 0; resultNum < originalNumResults; resultNum++)
-    measureOp.getResult(resultNum).replaceAllUsesWith(mergedOp.getResult(resultNum));
-  rewriter.eraseOp(measureOp);
 
   // dice the output so we can specify which results to replace
   auto iterSep = newCallOp.result_begin() + callCircuitOp.getNumResults();

--- a/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
@@ -262,8 +262,6 @@ static void mergeMeasurements(PatternRewriter &rewriter,
       measureOp.getLoc(), TypeRange(typeVec), ValueRange(valVec));
 
   auto originalNumResults = measureOp->getNumResults();
-  rewriter.replaceOp(measureOp, ResultRange(mergedOp.getOuts().begin(),
-                                            mergedOp.getOuts().end()));
 
   llvm::SmallVector<Type> outputTypes;
   llvm::SmallVector<Value> outputValues;
@@ -277,6 +275,10 @@ static void mergeMeasurements(PatternRewriter &rewriter,
 
   dropNextMeasure(rewriter, outputTypes, outputValues, nextCircuitOp,
                   nextMeasureOp);
+
+  for(uint resultNum = 0; resultNum < originalNumResults; resultNum++)
+    measureOp.getResult(resultNum).replaceAllUsesWith(mergedOp.getResult(resultNum));
+  rewriter.eraseOp(measureOp);
 
   // dice the output so we can specify which results to replace
   auto iterSep = newCallOp.result_begin() + callCircuitOp.getNumResults();


### PR DESCRIPTION
Fixes `incorrect # of replacement values assert` when testing a debug build by correcting the number of values used when replacing an operation. 