### PR TITLE
[Backport 3.8] Fix incorrect # of replacement values assert for debug builds (#283)

### DIFF
--- a/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
@@ -260,8 +260,9 @@ static void mergeMeasurements(PatternRewriter &rewriter,
       measureOp.getLoc(), TypeRange(typeVec), ValueRange(valVec));
 
   auto originalNumResults = measureOp->getNumResults();
-  rewriter.replaceOp(
-      measureOp, ResultRange(mergedOp.outs().begin(), mergedOp.outs().end()));
+  rewriter.replaceOp(measureOp,
+                     ResultRange(mergedOp.result_begin(),
+                                 mergedOp.result_begin() + originalNumResults));
 
   llvm::SmallVector<Type> outputTypes;
   llvm::SmallVector<Value> outputValues;


### PR DESCRIPTION
Fixes `incorrect # of replacement values assert` when testing a debug build by correcting the number of values used when replacing an operation.