### PR TITLE
[Backport 3.8] Add ExtractCircuitsPass (#284)

### DIFF
--- a/include/Dialect/QUIR/Transforms/ExtractCircuits.h
+++ b/include/Dialect/QUIR/Transforms/ExtractCircuits.h
@@ -1,0 +1,70 @@
+//===- ExtractCircuits.h - Extract circuits ops -----------------*- C++ -*-===//
+//
+// (C) Copyright IBM 2024.
+//
+// This code is part of Qiskit.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+///
+///  This file declares the pass for extracting quantum ops into quir.circuits
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef QUIR_EXTRACT_CIRCUITS_H
+#define QUIR_EXTRACT_CIRCUITS_H
+
+#include "Dialect/QUIR/IR/QUIROps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+#include <unordered_map>
+
+namespace mlir::quir {
+
+struct ExtractCircuitsPass
+    : public PassWrapper<ExtractCircuitsPass, OperationPass<>> {
+  void runOnOperation() override;
+
+  llvm::StringRef getArgument() const override;
+  llvm::StringRef getDescription() const override;
+  llvm::StringRef getName() const override;
+
+private:
+  void processOps(mlir::Operation *currentOp, OpBuilder topLevelBuilder,
+                  OpBuilder circuitBuilder);
+  OpBuilder startCircuit(mlir::Location location, OpBuilder topLevelBuilder);
+  void endCircuit(mlir::Operation *firstOp, mlir::Operation *lastOp,
+                  OpBuilder topLevelBuilder, OpBuilder circuitBuilder,
+                  llvm::SmallVector<Operation *> &eraseList);
+  void addToCircuit(mlir::Operation *currentOp, OpBuilder circuitBuilder,
+                    llvm::SmallVector<Operation *> &eraseList);
+  uint64_t circuitCount;
+  llvm::StringMap<Operation *> circuitOpsMap;
+
+  mlir::quir::CircuitOp currentCircuitOp;
+  mlir::quir::CallCircuitOp newCallCircuitOp;
+
+  llvm::SmallVector<Type> inputTypes;
+  llvm::SmallVector<Value> inputValues;
+  llvm::SmallVector<Type> outputTypes;
+  llvm::SmallVector<Value> outputValues;
+  std::vector<int> phyiscalIds;
+
+  std::unordered_map<uint32_t, BlockArgument> circuitArguments;
+  std::unordered_map<Operation *, uint32_t> circuitOperands;
+  llvm::SmallVector<OpResult> originalResults;
+
+}; // struct ExtractCircuitsPass
+} // namespace mlir::quir
+#endif // QUIR_EXTRACT_CIRCUITS_H

--- a/include/Dialect/QUIR/Transforms/Passes.h
+++ b/include/Dialect/QUIR/Transforms/Passes.h
@@ -1,6 +1,6 @@
 //===- Passes.h - Quir Passes -----------------------------------*- C++ -*-===//
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is part of Qiskit.
 //
@@ -21,6 +21,7 @@
 #include "AngleConversion.h"
 #include "BreakReset.h"
 #include "ConvertDurationUnits.h"
+#include "ExtractCircuits.h"
 #include "FunctionArgumentSpecialization.h"
 #include "LoadElimination.h"
 #include "MergeCircuitMeasures.h"

--- a/lib/Dialect/QUIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/QUIR/Transforms/CMakeLists.txt
@@ -1,4 +1,4 @@
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2024.
 #
 # This code is part of Qiskit.
 #
@@ -16,6 +16,7 @@ add_mlir_dialect_library(MLIRQUIRTransforms
     AngleConversion.cpp
     BreakReset.cpp
     ConvertDurationUnits.cpp
+    ExtractCircuits.cpp
     FunctionArgumentSpecialization.cpp
     LoadElimination.cpp
     MergeCircuits.cpp

--- a/lib/Dialect/QUIR/Transforms/ExtractCircuits.cpp
+++ b/lib/Dialect/QUIR/Transforms/ExtractCircuits.cpp
@@ -1,0 +1,357 @@
+//===- ExtractCircuits.cpp - Extract quantum ops to circuits ----*- C++ -*-===//
+//
+// (C) Copyright IBM 2024.
+//
+// This code is part of Qiskit.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+///
+///  This file implements the pass for extracting quantum ops into quir.circuits
+///
+//===----------------------------------------------------------------------===//
+
+#include "Dialect/QUIR/Transforms/ExtractCircuits.h"
+
+#include "Dialect/OQ3/IR/OQ3Ops.h"
+#include "Dialect/QCS/IR/QCSOps.h"
+#include "Dialect/QUIR/IR/QUIRAttributes.h"
+#include "Dialect/QUIR/IR/QUIROps.h"
+#include "Dialect/QUIR/Utils/Utils.h"
+
+#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/TypeRange.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Support/LLVM.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+
+#include <algorithm>
+#include <cassert>
+#include <optional>
+#include <string>
+#include <sys/types.h>
+#include <vector>
+
+#define DEBUG_TYPE "ExtractCircuits"
+
+using namespace mlir;
+using namespace mlir::quir;
+
+llvm::cl::opt<bool>
+    enableCircuits("enable-circuits",
+                   llvm::cl::desc("enable extract quir circuits"),
+                   llvm::cl::init(false));
+
+// NOLINTNEXTLINE(misc-use-anonymous-namespace)
+static std::optional<Operation *> localNextQuantumOpOrNull(Operation *op) {
+  Operation *nextOp = op;
+  while (nextOp) {
+    if (isQuantumOp(nextOp) && nextOp != op)
+      return nextOp;
+    if (nextOp->hasTrait<::mlir::RegionBranchOpInterface::Trait>()) {
+      // control flow found, no next quantum op
+      return std::nullopt;
+    }
+    if (isa<qcs::ParallelControlFlowOp>(nextOp))
+      return std::nullopt;
+    if (isa<oq3::CBitInsertBitOp>(nextOp))
+      return std::nullopt;
+    if (isa<quir::SwitchOp>(nextOp))
+      return std::nullopt;
+    nextOp = nextOp->getNextNode();
+  }
+  return std::nullopt;
+} // localNextQuantumOpOrNull
+
+OpBuilder ExtractCircuitsPass::startCircuit(Location location,
+                                            OpBuilder topLevelBuilder) {
+
+  inputTypes.clear();
+  inputValues.clear();
+  outputTypes.clear();
+  outputValues.clear();
+  originalResults.clear();
+  circuitArguments.clear();
+  circuitOperands.clear();
+  phyiscalIds.clear();
+
+  std::string const circuitName = "circuit_";
+  std::string newName = circuitName + std::to_string(circuitCount++);
+  while (circuitOpsMap.find(newName) != circuitOpsMap.end())
+    newName = circuitName + std::to_string(circuitCount++);
+
+  currentCircuitOp =
+      topLevelBuilder.create<CircuitOp>(location, newName,
+                                        topLevelBuilder.getFunctionType(
+                                            /*inputs=*/ArrayRef<Type>(),
+                                            /*results=*/ArrayRef<Type>()));
+  currentCircuitOp.addEntryBlock();
+  circuitOpsMap[newName] = currentCircuitOp;
+
+  currentCircuitOp->setAttr(llvm::StringRef("quir.classicalOnly"),
+                            topLevelBuilder.getBoolAttr(false));
+
+  LLVM_DEBUG(llvm::dbgs() << "Start Circuit " << currentCircuitOp.sym_name()
+                          << "\n");
+
+  OpBuilder circuitBuilder =
+      OpBuilder::atBlockBegin(&currentCircuitOp.getBody().front());
+  return circuitBuilder;
+}
+
+void ExtractCircuitsPass::addToCircuit(
+    Operation *currentOp, OpBuilder circuitBuilder,
+    llvm::SmallVector<Operation *> &eraseList) {
+
+  BlockAndValueMapping mapper;
+  // add operands to circuit input list
+  for (auto operand : currentOp->getOperands()) {
+    auto *defOp = operand.getDefiningOp();
+    auto search = circuitOperands.find(defOp);
+    uint argumentIndex = 0;
+    if (search == circuitOperands.end()) {
+      argumentIndex = inputValues.size();
+      inputValues.push_back(operand);
+      circuitOperands[defOp] = argumentIndex;
+
+      currentCircuitOp.insertArgument(argumentIndex, operand.getType(), {},
+                                      currentOp->getLoc());
+      if (isa<quir::DeclareQubitOp>(defOp)) {
+        auto physicalId = defOp->getAttrOfType<IntegerAttr>("id");
+        phyiscalIds.push_back(physicalId.getInt());
+        currentCircuitOp.setArgAttrs(
+            argumentIndex,
+            ArrayRef({NamedAttribute(
+                StringAttr::get(&getContext(),
+                                mlir::quir::getPhysicalIdAttrName()),
+                physicalId)}));
+      }
+    } else {
+      argumentIndex = search->second;
+    }
+
+    mapper.map(operand, currentCircuitOp.getArgument(argumentIndex));
+  }
+  auto *newOp = circuitBuilder.clone(*currentOp, mapper);
+
+  outputTypes.append(newOp->getResultTypes().begin(),
+                     newOp->getResultTypes().end());
+  outputValues.append(newOp->getResults().begin(), newOp->getResults().end());
+  originalResults.append(currentOp->getResults().begin(),
+                         currentOp->getResults().end());
+
+  eraseList.push_back(currentOp);
+}
+
+void ExtractCircuitsPass::endCircuit(
+    Operation *firstOp, Operation *lastOp, OpBuilder topLevelBuilder,
+    OpBuilder circuitBuilder, llvm::SmallVector<Operation *> &eraseList) {
+
+  LLVM_DEBUG(llvm::dbgs() << "Ending circuit " << currentCircuitOp.sym_name()
+                          << "\n");
+
+  circuitBuilder.create<mlir::quir::ReturnOp>(lastOp->getLoc(), outputValues);
+
+  // change the input / output types for the quir.circuit
+  auto opType = currentCircuitOp.getType();
+  currentCircuitOp.setType(topLevelBuilder.getFunctionType(
+      /*inputs=*/opType.getInputs(),
+      /*results=*/ArrayRef<Type>(outputTypes)));
+
+  std::sort(phyiscalIds.begin(), phyiscalIds.end());
+  currentCircuitOp->setAttr(
+      mlir::quir::getPhysicalIdsAttrName(),
+      topLevelBuilder.getI32ArrayAttr(ArrayRef<int>(phyiscalIds)));
+
+  // insert call_circuit
+  // NOLINTNEXTLINE(misc-const-correctness)
+  OpBuilder builder(firstOp);
+  newCallCircuitOp = builder.create<mlir::quir::CallCircuitOp>(
+      currentCircuitOp->getLoc(), currentCircuitOp.sym_name(),
+      TypeRange(outputTypes), ValueRange(inputValues));
+
+  // remap uses
+  assert(originalResults.size() == newCallCircuitOp->getNumResults() &&
+         "number of results does not match");
+  for (uint cnt = 0; cnt < newCallCircuitOp->getNumResults(); cnt++) {
+    originalResults[cnt].replaceAllUsesWith(newCallCircuitOp->getResult(cnt));
+    assert(originalResults[cnt].use_empty() && "usage expected to be empty");
+  }
+
+  // erase operations
+  while (!eraseList.empty()) {
+    auto *op = eraseList.back();
+    eraseList.pop_back();
+    assert(op->use_empty() && "operation usage expected to be empty");
+    LLVM_DEBUG(llvm::dbgs() << "Erasing: ");
+    LLVM_DEBUG(op->dump());
+    op->erase();
+  }
+}
+
+void ExtractCircuitsPass::processOps(Operation *currentOp,
+                                     OpBuilder topLevelBuilder,
+                                     OpBuilder circuitBuilder) {
+
+  llvm::SmallVector<Operation *> eraseList;
+
+  Operation *firstQuantumOp = nullptr;
+
+  // Handle Shot Loop delay differently
+  if (isa<quir::DelayOp>(currentOp) &&
+      isa<qcs::ShotInitOp>(currentOp->getNextNode())) {
+    // skip past shot init
+    currentOp = currentOp->getNextNode()->getNextNode();
+  }
+
+  while (currentOp) {
+
+    // Walk through current block of operations and pull out quantum
+    // operations into quir.circuits:
+    //
+    // 1. Identify first quantum operation
+    // 2. Start new circuit and clone quantum operation into circuit
+    // 2.a. startCircuit will create a new unique quir.circuit
+    // 3. Walk forward node by node
+    // 4. If node is a quantum operation clone into circuit
+    // 5. If not quantum or if control flow - end circuit
+    // 5.a. endCircuit will finish circuit, adjust circuit input / output,
+    //      create call_circuit and erase original operations
+    // 6. If control flow - recursively call processOps for each region of
+    //    control flow
+
+    // do not assume first operation is quantum and find first quantum operation
+    if (!firstQuantumOp) {
+
+      if (isQuantumOp(currentOp)) {
+        firstQuantumOp = currentOp;
+      } else {
+        // walk forward for first quantum operation or control flow
+        auto firstOrNull = localNextQuantumOpOrNull(currentOp);
+        if (firstOrNull) {
+          currentOp = firstOrNull.value();
+          firstQuantumOp = currentOp;
+        }
+      }
+      if (firstQuantumOp)
+        circuitBuilder =
+            startCircuit(firstQuantumOp->getLoc(), topLevelBuilder);
+    }
+
+    // if operation is a quantum operation clone into circuit
+    if (isQuantumOp(currentOp))
+      addToCircuit(currentOp, circuitBuilder, eraseList);
+
+    // walk forward for next operation
+    auto nextOpOrNull = localNextQuantumOpOrNull(currentOp);
+    if (nextOpOrNull) {
+      currentOp = nextOpOrNull.value();
+      continue;
+    }
+
+    // next operation was not quantum so if there is a firstQuantumOp there is
+    // an in progress circuit to be ended.
+    if (firstQuantumOp) {
+      Operation *lastOp = currentOp;
+      // nextOpOrNull was null so advance one node
+      currentOp = currentOp->getNextNode();
+      endCircuit(firstQuantumOp, lastOp, topLevelBuilder, circuitBuilder,
+                 eraseList);
+    }
+    firstQuantumOp = nullptr;
+
+    if (!currentOp)
+      break;
+
+    // handle control flow -- and recursively call processOps for control flow
+    // regions
+
+    if (isa<scf::IfOp>(currentOp)) {
+      auto ifOp = static_cast<scf::IfOp>(currentOp);
+      if (!ifOp.getThenRegion().empty())
+        processOps(&ifOp.getThenRegion().front().front(), topLevelBuilder,
+                   circuitBuilder);
+      if (!ifOp.getElseRegion().empty())
+        processOps(&ifOp.getElseRegion().front().front(), topLevelBuilder,
+                   circuitBuilder);
+    } else if (isa<scf::ForOp>(currentOp)) {
+      auto forOp = static_cast<scf::ForOp>(currentOp);
+      processOps(&forOp.getBody()->front(), topLevelBuilder, circuitBuilder);
+    } else if (isa<scf::WhileOp>(currentOp)) {
+      auto whileOp = static_cast<scf::WhileOp>(currentOp);
+      if (!whileOp.getBefore().empty())
+        processOps(&whileOp.getBefore().front().front(), topLevelBuilder,
+                   circuitBuilder);
+      if (!whileOp.getAfter().empty())
+        processOps(&whileOp.getAfter().front().front(), topLevelBuilder,
+                   circuitBuilder);
+    } else if (isa<quir::SwitchOp>(currentOp)) {
+      // NOLINTNEXTLINE(llvm-qualified-auto)
+      auto switchOp = static_cast<quir::SwitchOp>(currentOp);
+      for (auto &region : switchOp.caseRegions())
+        processOps(&region.front().front(), topLevelBuilder, circuitBuilder);
+    } else if (isa<qcs::ParallelControlFlowOp>(currentOp)) {
+      // NOLINTNEXTLINE(llvm-qualified-auto)
+      auto parOp = static_cast<qcs::ParallelControlFlowOp>(currentOp);
+      processOps(&parOp.getBody()->front(), topLevelBuilder, circuitBuilder);
+    } else if (currentOp->hasTrait<::mlir::RegionBranchOpInterface::Trait>()) {
+      currentOp->dump();
+      assert(false && "Unhandled control flow");
+    }
+    currentOp = currentOp->getNextNode();
+  }
+}
+
+void ExtractCircuitsPass::runOnOperation() {
+  // do nothing if circuits is not enabled
+  if (!enableCircuits)
+    return;
+
+  circuitCount = 0;
+  currentCircuitOp = nullptr;
+
+  Operation *moduleOp = getOperation();
+
+  llvm::StringMap<Operation *> circuitOpsMap;
+
+  moduleOp->walk([&](CircuitOp circuitOp) {
+    circuitOpsMap[circuitOp.sym_name()] = circuitOp.getOperation();
+  });
+
+  mlir::FuncOp mainFunc =
+      dyn_cast<mlir::FuncOp>(quir::getMainFunction(moduleOp));
+  assert(mainFunc && "could not find the main func");
+
+  auto const builder = OpBuilder(mainFunc);
+  auto *firstOp = &mainFunc.getBody().front().front();
+  processOps(firstOp, builder, builder);
+} // runOnOperation
+
+llvm::StringRef ExtractCircuitsPass::getArgument() const {
+  return "extract-circuits";
+}
+llvm::StringRef ExtractCircuitsPass::getDescription() const {
+  return "Extract quantum operations to circuits ";
+}
+
+llvm::StringRef ExtractCircuitsPass::getName() const {
+  return "Extract Circuits Pass";
+}

--- a/lib/Dialect/QUIR/Transforms/Passes.cpp
+++ b/lib/Dialect/QUIR/Transforms/Passes.cpp
@@ -1,6 +1,6 @@
 //===- Passes.cpp - QUIR Passes ---------------------------------*- C++ -*-===//
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is part of Qiskit.
 //
@@ -263,6 +263,7 @@ void registerQuirPasses() {
   PassRegistration<quir::ReorderMeasurementsPass>();
   PassRegistration<quir::ReorderCircuitsPass>();
   PassRegistration<quir::MergeCircuitsPass>();
+  PassRegistration<quir::ExtractCircuitsPass>();
   PassRegistration<quir::MergeCircuitMeasuresTopologicalPass>();
   PassRegistration<quir::MergeMeasuresLexographicalPass>();
   PassRegistration<quir::MergeMeasuresTopologicalPass>();

--- a/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
@@ -1,6 +1,6 @@
 //===- QUIRGenQASM3Visitor.cpp ----------------------------------*- C++ -*-===//
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is part of Qiskit.
 //
@@ -89,7 +89,7 @@ static llvm::cl::opt<bool>
                      llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
-    enableCircuits("enable-circuits", llvm::cl::desc("enable quir circuits"),
+    enableCircuits("enable-circuits-from-qasm", llvm::cl::desc("enable quir circuits"),
                    llvm::cl::init(false));
 
 static llvm::cl::opt<bool> debugCircuits("debug-circuits",
@@ -190,15 +190,6 @@ void QUIRGenQASM3Visitor::initialize(
     const mlir::quir::TimeUnits &shotDelayUnits) {
   Location initialLocation =
       mlir::FileLineColLoc::get(topLevelBuilder.getContext(), filename, 0, 0);
-
-  // validate command line options
-  if (enableParameters && !enableCircuits) {
-    hasFailed = true;
-    DiagnosticEngine &engine = builder.getContext()->getDiagEngine();
-    engine.emit(initialLocation, mlir::DiagnosticSeverity::Error)
-        << "the --enable-parameters circuit requires --enable-circuits";
-    return;
-  }
 
   // create the "main" function
   auto func = topLevelBuilder.create<FuncOp>(

--- a/releasenotes/notes/add-extract-circuits-pass-72576158242077c6.yaml
+++ b/releasenotes/notes/add-extract-circuits-pass-72576158242077c6.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Add new ExtractCircuitsPass. This pass will walk the main func and extract
+    quantum operations into quir.circuits. It is intended to be run after all
+    reordering and merging has been completed. The pass currently requires
+    --enable-circuits=true in order to have effect.
+deprecations:
+  - |
+    Circuit formation during QUIRGen has been deprecated. This form of circuit
+    generation is now controlled by the --enable-circuits-from-qasm command
+    line option.

--- a/targets/systems/mock/test/static/integration/openqasm3/bell-v0.qasm
+++ b/targets/systems/mock/test/static/integration/openqasm3/bell-v0.qasm
@@ -1,7 +1,7 @@
 OPENQASM 3.0;
-// RUN: qss-compiler %s --target mock --config %TEST_CFG --emit=qem --plaintext-payload --enable-circuits=false | FileCheck %s
+// RUN: qss-compiler %s --target mock --config %TEST_CFG --emit=qem --plaintext-payload --enable-circuits-from-qasm=false | FileCheck %s
 
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is part of Qiskit.
 //

--- a/targets/systems/mock/test/static/integration/openqasm3/example.qasm
+++ b/targets/systems/mock/test/static/integration/openqasm3/example.qasm
@@ -1,8 +1,8 @@
 OPENQASM 3.0;
-// RUN: qss-compiler %s --target mock --config %TEST_CFG --emit=qem --plaintext-payload --enable-circuits=false| FileCheck %s
-// RUN: qss-compiler "`cat %s`" --include-source --direct --target mock --config %TEST_CFG --emit=qem --plaintext-payload --enable-circuits=false| FileCheck %s --match-full-lines --check-prefix CHECK-SOURCE
+// RUN: qss-compiler %s --target mock --config %TEST_CFG --emit=qem --plaintext-payload --enable-circuits-from-qasm=false| FileCheck %s
+// RUN: qss-compiler "`cat %s`" --include-source --direct --target mock --config %TEST_CFG --emit=qem --plaintext-payload --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefix CHECK-SOURCE
 
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is part of Qiskit.
 //

--- a/test/Dialect/QUIR/Transforms/extract-circuits.mlir
+++ b/test/Dialect/QUIR/Transforms/extract-circuits.mlir
@@ -1,0 +1,95 @@
+// RUN: qss-compiler -X=mlir --enable-circuits=true --extract-circuits %s | FileCheck %s
+//
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2023, 2024.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+module {
+  oq3.declare_variable @obs : !quir.cbit<4>
+  func @x(%arg0: !quir.qubit<1>) attributes {quir.classicalOnly = false} {
+    return
+  }
+  // CHECK: quir.circuit @circuit_0
+  // CHECK: quir.delay %arg0, (%arg1)
+  // CHECK: %0:2 = quir.measure(%arg2, %arg3)
+  // CHECK: quir.return %0#0, %0#1 : i1, i1
+  // CHECK: quir.circuit @circuit_1
+  // CHECK: quir.call_gate @x(%arg0)
+  // CHECK: quir.return
+  // CHECK: func @main()
+  func @main() -> i32 attributes {quir.classicalOnly = false} {
+    %c0_i1 = arith.constant 0 : i1
+    %c0_i32 = arith.constant 0 : i32
+    %c0_i4 = arith.constant 0 : i4
+    %dur = quir.constant #quir.duration<1.000000e+00 : <ms>>
+    %c1 = arith.constant 1 : index
+    %c1000 = arith.constant 1000 : index
+    %c0 = arith.constant 0 : index
+    %dur_0 = quir.constant #quir.duration<2.800000e+03 : <dt>>
+    qcs.init
+    scf.for %arg0 = %c0 to %c1000 step %c1 {
+      quir.delay %dur, () : !quir.duration<ms>, () -> ()
+      qcs.shot_init {qcs.num_shots = 1000 : i32}
+      %0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
+      %1 = quir.declare_qubit {id = 1 : i32} : !quir.qubit<1>
+      %2 = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
+      %3 = "oq3.cast"(%c0_i4) : (i4) -> !quir.cbit<4>
+      oq3.variable_assign @obs : !quir.cbit<4> = %3
+      quir.delay %dur_0, (%1) : !quir.duration<dt>, (!quir.qubit<1>) -> ()
+      %4:2 = quir.measure(%0, %2) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
+      // CHECK-NOT: quir.delay %dur_0, (%1) : !quir.duration<dt>, (!quir.qubit<1>) -> ()
+      // CHECK-NOT: %4:2 = quir.measure(%0, %2) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
+      // CHECK: %4:2 = quir.call_circuit @circuit_0(%dur_0, %1, %0, %2)
+      qcs.parallel_control_flow {
+      // CHECK: qcs.parallel_control_flow
+      scf.if %4#0 {
+      // scf.if
+        quir.call_gate @x(%0) : (!quir.qubit<1>) -> ()
+        // CHECK-NOT:  quir.call_gate @x(%0) : (!quir.qubit<1>) -> ()
+        // CHECK: quir.call_circuit @circuit_1(%0) : (!quir.qubit<1>) -> ()
+      } {quir.classicalOnly = false, quir.physicalIds = [0 : i32]}
+      oq3.cbit_assign_bit @obs<4> [0] : i1 = %4#1
+      } {quir.maxDelayCycles = 100 : i64, quir.physicalIds = [0 : i32]}
+      quir.switch %c0_i32 {
+      // CHECK: quir.switch
+        } [
+            1: {
+                quir.call_gate @x(%1) : (!quir.qubit<1>) -> ()
+                // CHECK-NOT:  quir.call_gate @x(%1) : (!quir.qubit<1>) -> ()
+                // CHECK: quir.call_circuit @circuit_2(%1) : (!quir.qubit<1>) -> ()
+            }
+            2: {
+                quir.call_gate @x(%2) : (!quir.qubit<1>) -> ()
+                // CHECK-NOT:  quir.call_gate @x(%2) : (!quir.qubit<1>) -> ()
+                // CHECK: quir.call_circuit @circuit_3(%2) : (!quir.qubit<1>) -> ()
+            }
+            3: {
+            }
+        ]
+      scf.while : () -> () {
+      // CHECK: scf.while
+        quir.call_gate @x(%1) : (!quir.qubit<1>) -> ()
+        // CHECK-NOT:  quir.call_gate @x(%1) : (!quir.qubit<1>) -> ()
+        // CHECK: quir.call_circuit @circuit_4(%1) : (!quir.qubit<1>) -> ()
+        scf.condition(%c0_i1)
+        // CHECK: scf.condition
+      } do {
+        quir.call_gate @x(%2) : (!quir.qubit<1>) -> ()
+        // CHECK-NOT:  quir.call_gate @x(%2) : (!quir.qubit<1>) -> ()
+        // CHECK: quir.call_circuit @circuit_5(%2) : (!quir.qubit<1>) -> ()
+        scf.yield
+        // CHECK: scf.yield
+      }
+    } {qcs.shot_loop, quir.classicalOnly = false, quir.physicalIds = [0 : i32, 1 : i32, 2 : i32]}
+    qcs.finalize
+    return %c0_i32 : i32
+  }
+}

--- a/test/Frontend/OpenQASM3/bell-v0.qasm
+++ b/test/Frontend/OpenQASM3/bell-v0.qasm
@@ -1,13 +1,13 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast %s | FileCheck %s --check-prefix AST
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/bell-v1.qasm
+++ b/test/Frontend/OpenQASM3/bell-v1.qasm
@@ -1,13 +1,13 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast %s | FileCheck %s --check-prefix AST
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false | FileCheck %s --match-full-lines  --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false | FileCheck %s --match-full-lines  --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/bitindices.qasm
+++ b/test/Frontend/OpenQASM3/bitindices.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false | FileCheck %s --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --check-prefixes MLIR,MLIR-CIRCUITS 
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false | FileCheck %s --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --check-prefixes MLIR,MLIR-CIRCUITS 
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/booleans.qasm
+++ b/test/Frontend/OpenQASM3/booleans.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/cbit.qasm
+++ b/test/Frontend/OpenQASM3/cbit.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/conditionals.qasm
+++ b/test/Frontend/OpenQASM3/conditionals.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/delay-inside-controlflow.qasm
+++ b/test/Frontend/OpenQASM3/delay-inside-controlflow.qasm
@@ -1,6 +1,19 @@
 OPENQASM 3.0;
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+
+//
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2023, 2024.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
 
 gate x q {}
 qubit $0;

--- a/test/Frontend/OpenQASM3/delay.qasm
+++ b/test/Frontend/OpenQASM3/delay.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt
@@ -75,7 +75,7 @@ delay[a] $0, $1;
 // MLIR-CIRCUITS: {{.*}} = quir.constant #quir.duration<4.000000e+01 : <dt>>
 // MLIR-CIRCUITS: {{.*}} = quir.constant #quir.duration<1.000000e+01 : <ns>>
 // MLIR-CIRCUITS: quir.call_circuit @circuit_0({{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}) : (!quir.{{.*}}, !quir.{{.*}}, !quir.{{.*}}, !quir.{{.*}}, !quir.{{.*}}, !quir.{{.*}}, !quir.{{.*}}, !quir.{{.*}}) -> ()
-// TODO: Two oq3.declare_stretch statements are generated independent of --enable-circuits
+// TODO: Two oq3.declare_stretch statements are generated independent of --enable-circuits-from-qasm
 //       This does no harm but might potentially be fixed at some point
 //MLIR-CIRCUITS: %3 = oq3.declare_stretch : !quir.stretch
 //MLIR-CIRCUITS: quir.call_circuit @circuit_1({{.*}}, {{.*}},{{.*}}) : (!quir.{{.*}}, !quir.{{.*}}, !quir.{{.*}}) -> ()

--- a/test/Frontend/OpenQASM3/for-loop.qasm
+++ b/test/Frontend/OpenQASM3/for-loop.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/gate.qasm
+++ b/test/Frontend/OpenQASM3/gate.qasm
@@ -1,11 +1,11 @@
 OPENQASM 3.0;
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/gates-issue-655-2.qasm
+++ b/test/Frontend/OpenQASM3/gates-issue-655-2.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false | FileCheck %s --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false | FileCheck %s --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/gates-issue-655.qasm
+++ b/test/Frontend/OpenQASM3/gates-issue-655.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --check-prefixes MLIR
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --check-prefixes MLIR
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/input-output-variables.qasm
+++ b/test/Frontend/OpenQASM3/input-output-variables.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
 // RUN: qss-compiler -X=qasm --emit=mlir %s --enable-parameters=false | FileCheck %s --match-full-lines --check-prefix MLIR
-// RUN: (! qss-compiler -X=qasm --emit=mlir --enable-parameters --enable-circuits %s 2>&1 ) | FileCheck %s --check-prefix CIRCUITS
+// RUN: (! qss-compiler -X=qasm --emit=mlir --enable-parameters --enable-circuits-from-qasm %s 2>&1 ) | FileCheck %s --check-prefix CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/input-parameters-errors.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters-errors.qasm
@@ -1,11 +1,11 @@
 OPENQASM 3;
-// RUN: (! qss-compiler -X=qasm --emit=mlir --enable-parameters %s 2>&1 ) | FileCheck %s --check-prefixes NO-CIRCUITS,CIRCUITS
-// RUN: (! qss-compiler -X=qasm --emit=mlir --enable-parameters --enable-circuits %s 2>&1 ) | FileCheck %s --check-prefix CIRCUITS 
+// RUN: (! qss-compiler -X=qasm --emit=mlir --enable-parameters %s 2>&1 ) | FileCheck %s --check-prefixes CIRCUITS
+// RUN: (! qss-compiler -X=qasm --emit=mlir --enable-parameters --enable-circuits-from-qasm %s 2>&1 ) | FileCheck %s --check-prefix CIRCUITS 
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt
@@ -28,7 +28,6 @@ input uint badUInt;
 input float[32] badFloat32;
 input float badFloat;
 
-// NO-CIRCUITS: loc("-":0:0): error: the --enable-parameters circuit requires --enable-circuits
 // CIRCUITS-NOT: error: Input parameter theta type error. Input parameters must be angle or float[64].
 // CIRCUITS-NOT: error: Input parameter theta2 type error. Input parameters must be angle or float[64].
 // CIRCUITS: error: Input parameter badComplex type error. Input parameters must be angle or float[64].

--- a/test/Frontend/OpenQASM3/input-parameters-if.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters-if.qasm
@@ -1,10 +1,10 @@
 OPENQASM 3.0;
-// RUN: qss-compiler -X=qasm --emit=mlir --enable-parameters --enable-circuits %s | FileCheck %s
+// RUN: qss-compiler -X=qasm --emit=mlir --enable-parameters --enable-circuits-from-qasm %s | FileCheck %s
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/input-parameters-while.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters-while.qasm
@@ -1,10 +1,10 @@
 OPENQASM 3.0;
-// RUN: qss-compiler -X=qasm --enable-parameters --enable-circuits %s | FileCheck %s
+// RUN: qss-compiler -X=qasm --enable-parameters --enable-circuits-from-qasm %s | FileCheck %s
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/input-parameters.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters.qasm
@@ -1,10 +1,10 @@
 OPENQASM 3;
-// RUN: qss-compiler -X=qasm --emit=mlir --enable-parameters --enable-circuits %s | FileCheck %s --check-prefixes=CHECK,CHECK-XX
+// RUN: qss-compiler -X=qasm --emit=mlir --enable-parameters --enable-circuits-from-qasm %s | FileCheck %s --check-prefixes=CHECK,CHECK-XX
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/measure-multi-clregs.qasm
+++ b/test/Frontend/OpenQASM3/measure-multi-clregs.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/measure.qasm
+++ b/test/Frontend/OpenQASM3/measure.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s  --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s  --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/multi-param-gatedef.qasm
+++ b/test/Frontend/OpenQASM3/multi-param-gatedef.qasm
@@ -1,11 +1,11 @@
 OPENQASM 3.0;
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/multi-qubit-gatedef.qasm
+++ b/test/Frontend/OpenQASM3/multi-qubit-gatedef.qasm
@@ -1,11 +1,11 @@
 OPENQASM 3.0;
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/nested-gatecalls.qasm
+++ b/test/Frontend/OpenQASM3/nested-gatecalls.qasm
@@ -1,11 +1,11 @@
 OPENQASM 3.0;
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/nested-if.qasm
+++ b/test/Frontend/OpenQASM3/nested-if.qasm
@@ -1,11 +1,11 @@
 OPENQASM 3.0;
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/reset-v0.qasm
+++ b/test/Frontend/OpenQASM3/reset-v0.qasm
@@ -1,13 +1,13 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast %s | FileCheck %s --check-prefix AST
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/reset-v1.qasm
+++ b/test/Frontend/OpenQASM3/reset-v1.qasm
@@ -1,13 +1,13 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast %s | FileCheck %s --check-prefix AST
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/rz-issue-655.qasm
+++ b/test/Frontend/OpenQASM3/rz-issue-655.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s  --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s  --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/switch-1.qasm
+++ b/test/Frontend/OpenQASM3/switch-1.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/switch-2.qasm
+++ b/test/Frontend/OpenQASM3/switch-2.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/switch-no-default.qasm
+++ b/test/Frontend/OpenQASM3/switch-no-default.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/teleport.qasm
+++ b/test/Frontend/OpenQASM3/teleport.qasm
@@ -1,15 +1,15 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast %s | FileCheck %s --check-prefix AST
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false | grep -v OK | qss-compiler -X=mlir --enable-circuits=false - | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s  --enable-circuits | grep -v OK | qss-compiler -X=mlir --enable-circuits - | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false | grep -v OK | qss-compiler -X=mlir --enable-circuits-from-qasm=false - | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s  --enable-circuits-from-qasm | grep -v OK | qss-compiler -X=mlir --enable-circuits-from-qasm - | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/while-1.qasm
+++ b/test/Frontend/OpenQASM3/while-1.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/while-2.qasm
+++ b/test/Frontend/OpenQASM3/while-2.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt

--- a/test/Frontend/OpenQASM3/while-3.qasm
+++ b/test/Frontend/OpenQASM3/while-3.qasm
@@ -1,12 +1,12 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-NO-CIRCUITS
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR,MLIR-CIRCUITS
 
 //
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2023.
+// (C) Copyright IBM 2023, 2024.
 //
 // This code is licensed under the Apache License, Version 2.0 with LLVM
 // Exceptions. You may obtain a copy of this license in the LICENSE.txt


### PR DESCRIPTION
This PR adds a new ExtractCircuitsPass. This pass will walk the main function and extract quantum operations into `quir.circuit`s. It is intended to be run after all reordering and merging has been completed. The pass currently requires  --enable-circuits=true in order to have effect.

Circuit formation during QUIRGen has been deprecated. This form of circuit generation is now controlled by the --enable-circuits-from-qasm command line option.

---------