### PR TITLE
[3.8] Fix tidy on 3.8

### DIFF
--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -180,9 +180,9 @@ llvm::Error qssc::frontend::openqasm3::parse(
                      << errMsg.str();
 
         if (diagnosticCallback_) {
-          qssc::Diagnostic diag{
-              diagLevel, qssc::ErrorCategory::OpenQASM3ParseFailure,
-              errMsg.str()};
+          qssc::Diagnostic diag{diagLevel,
+                                qssc::ErrorCategory::OpenQASM3ParseFailure,
+                                errMsg.str()};
           (*diagnosticCallback_)(diag);
         }
 

--- a/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
@@ -89,7 +89,8 @@ static llvm::cl::opt<bool>
                      llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
-    enableCircuits("enable-circuits-from-qasm", llvm::cl::desc("enable quir circuits"),
+    enableCircuits("enable-circuits-from-qasm",
+                   llvm::cl::desc("enable quir circuits"),
                    llvm::cl::init(false));
 
 static llvm::cl::opt<bool> debugCircuits("debug-circuits",


### PR DESCRIPTION
Re-applies clang-tidy to release_v3.8