### PR TITLE
Add toleration for modules that do not have a quir.nodeType attribute.

### DIFF
--- a/lib/HAL/TargetSystem.cpp
+++ b/lib/HAL/TargetSystem.cpp
@@ -80,6 +80,10 @@ llvm::Expected<mlir::ModuleOp>
 TargetInstrument::getModule(mlir::ModuleOp parentModuleOp) {
   for (auto childModuleOp :
        parentModuleOp.getBody()->getOps<mlir::ModuleOp>()) {
+    // Check for a QUIR module. If no quir.nodeType, skip this module.
+    if (!childModuleOp->hasAttrOfType<mlir::StringAttr>("quir.nodeType"))
+      continue;
+
     auto moduleNodeType =
         childModuleOp->getAttrOfType<mlir::StringAttr>("quir.nodeType");
     auto moduleNodeId = mlir::quir::getNodeId(childModuleOp);

--- a/lib/HAL/TargetSystem.cpp
+++ b/lib/HAL/TargetSystem.cpp
@@ -81,6 +81,7 @@ TargetInstrument::getModule(mlir::ModuleOp parentModuleOp) {
   for (auto childModuleOp :
        parentModuleOp.getBody()->getOps<mlir::ModuleOp>()) {
     // Check for a QUIR module. If no quir.nodeType, skip this module.
+    // This likely indicates it is the `main` module
     if (!childModuleOp->hasAttrOfType<mlir::StringAttr>("quir.nodeType"))
       continue;
 


### PR DESCRIPTION
This allows modules that do not have a `quir.nodeType` attribute to exist and not cause compilation failures. 