### PR TITLE
Revert "[Backport 3.8] Control systems resources exceeded (#281)"

### DIFF
--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -44,7 +44,6 @@ enum class ErrorCategory {
   QSSLinkSignatureNotFound,
   QSSLinkArgumentNotFoundWarning,
   QSSLinkInvalidPatchTypeError,
-  QSSControlSystemResourcesExceeded,
   UncategorizedError,
 };
 

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -71,9 +71,6 @@ static std::string_view getErrorCategoryAsString(ErrorCategory category) {
   case ErrorCategory::QSSLinkInvalidPatchTypeError:
     return "Invalid patch point type";
 
-  case ErrorCategory::QSSControlSystemResourcesExceeded:
-    return "Control system resources exceeded";
-
   case ErrorCategory::UncategorizedError:
     return "Compilation failure";
   }

--- a/python_lib/qss_compiler/compile.py
+++ b/python_lib/qss_compiler/compile.py
@@ -305,14 +305,6 @@ def _do_compile(
                     return_diagnostics=return_diagnostics,
                 )
 
-        for diag in diagnostics:
-            if diag.category == ErrorCategory.QSSControlSystemResourcesExceeded:
-                raise exceptions.QSSControlSystemResourcesExceeded(
-                    diag.message,
-                    diagnostics,
-                    return_diagnostics=self.return_diagnostics,
-                )
-
         if not success:
             raise exceptions.QSSCompilationFailure(
                 "Failure during compilation",

--- a/python_lib/qss_compiler/exceptions.py
+++ b/python_lib/qss_compiler/exceptions.py
@@ -109,9 +109,5 @@ class QSSLinkInvalidArgumentError(QSSLinkingFailure):
     """Raised when argument is invalid"""
 
 
-class QSSControlSystemResourcesExceeded(QSSCompilerError):
-    """Raised when control system resources (such as instruction memory) are exceeded."""
-
-
 class OpenQASM3ParseFailure(QSSCompilerError):
     """Raised when a parser failure is received"""

--- a/python_lib/qss_compiler/lib_enums.cpp
+++ b/python_lib/qss_compiler/lib_enums.cpp
@@ -4,37 +4,24 @@
 namespace py = pybind11;
 
 void addErrorCategory(py::module &m) {
-  py::enum_<qssc::ErrorCategory>(m, "ErrorCategory", py::arithmetic())
-      .value("OpenQASM3ParseFailure",
-             qssc::ErrorCategory::OpenQASM3ParseFailure)
-      .value("QSSCompilerError", qssc::ErrorCategory::QSSCompilerError)
-      .value("QSSCompilerNoInputError",
-             qssc::ErrorCategory::QSSCompilerNoInputError)
-      .value("QSSCompilerCommunicationFailure",
-             qssc::ErrorCategory::QSSCompilerCommunicationFailure)
-      .value("QSSCompilerEOFFailure",
-             qssc::ErrorCategory::QSSCompilerEOFFailure)
-      .value("QSSCompilerNonZeroStatus",
-             qssc::ErrorCategory::QSSCompilerNonZeroStatus)
-      .value("QSSCompilationFailure",
-             qssc::ErrorCategory::QSSCompilationFailure)
-      .value("QSSLinkerNotImplemented",
-             qssc::ErrorCategory::QSSLinkerNotImplemented)
-      .value("QSSLinkSignatureWarning",
-             qssc::ErrorCategory::QSSLinkSignatureWarning)
-      .value("QSSLinkSignatureError",
-             qssc::ErrorCategory::QSSLinkSignatureError)
-      .value("QSSLinkAddressError", qssc::ErrorCategory::QSSLinkAddressError)
-      .value("QSSLinkSignatureNotFound",
-             qssc::ErrorCategory::QSSLinkSignatureNotFound)
-      .value("QSSLinkArgumentNotFoundWarning",
-             qssc::ErrorCategory::QSSLinkArgumentNotFoundWarning)
-      .value("QSSLinkInvalidPatchTypeError",
-             qssc::ErrorCategory::QSSLinkInvalidPatchTypeError)
-      .value("QSSControlSystemResourcesExceeded",
-             qssc::ErrorCategory::QSSControlSystemResourcesExceeded)
-      .value("UncategorizedError", qssc::ErrorCategory::UncategorizedError)
-      .export_values();
+    py::enum_<qssc::ErrorCategory>(m, "ErrorCategory", py::arithmetic())
+        .value("OpenQASM3ParseFailure",
+                qssc::ErrorCategory::OpenQASM3ParseFailure)
+        .value("QSSCompilerError", qssc::ErrorCategory::QSSCompilerError)
+        .value("QSSCompilerNoInputError", qssc::ErrorCategory::QSSCompilerNoInputError)
+        .value("QSSCompilerCommunicationFailure", qssc::ErrorCategory::QSSCompilerCommunicationFailure)
+        .value("QSSCompilerEOFFailure", qssc::ErrorCategory::QSSCompilerEOFFailure)
+        .value("QSSCompilerNonZeroStatus", qssc::ErrorCategory::QSSCompilerNonZeroStatus)
+        .value("QSSCompilationFailure", qssc::ErrorCategory::QSSCompilationFailure)
+        .value("QSSLinkerNotImplemented", qssc::ErrorCategory::QSSLinkerNotImplemented)
+        .value("QSSLinkSignatureWarning", qssc::ErrorCategory::QSSLinkSignatureWarning)
+        .value("QSSLinkSignatureError", qssc::ErrorCategory::QSSLinkSignatureError)
+        .value("QSSLinkAddressError", qssc::ErrorCategory::QSSLinkAddressError)
+        .value("QSSLinkSignatureNotFound", qssc::ErrorCategory::QSSLinkSignatureNotFound)
+        .value("QSSLinkArgumentNotFoundWarning", qssc::ErrorCategory::QSSLinkArgumentNotFoundWarning)
+        .value("QSSLinkInvalidPatchTypeError", qssc::ErrorCategory::QSSLinkInvalidPatchTypeError)
+        .value("UncategorizedError", qssc::ErrorCategory::UncategorizedError)
+        .export_values();
 }
 
 void addSeverity(py::module &m) {

--- a/releasenotes/notes/control-system-resources-exceeded-error-d2a2c15c52fa02dd.yaml
+++ b/releasenotes/notes/control-system-resources-exceeded-error-d2a2c15c52fa02dd.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    A new QSSControlSystemResourcesExceeded error has been added as an error
-    category. This can be raised as an error whenever the compiler detects that
-    an input circuit will exceed the capabilities of the control system.


### PR DESCRIPTION
This reverts commit e99ff5c863a310262adc4c6ddff18e43172e7682.

This reverts the addition of the `QSSControlSystemResourcesExceeded` error class as the code to actually emit that type of error has not been back ported to release_v3.8.

After discussions with the author @mbhealy it is our recommendation to not back port the code to emit the error as it was developed after the LLVM 17 update and associated refactors making the back port difficult.  