### PR TITLE
Fix for when to add `OpenQASM3ParseFailure` to diagnostic

### DIFF
--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -202,7 +202,7 @@ llvm::Error qssc::frontend::openqasm3::parse(
         llvm::errs() << level << " while parsing OpenQASM 3 input\n"
                      << errMsg.str();
 
-        if (diagnosticCallback_) {
+        if (diagnosticCallback_ and diagLevel == qssc::Severity::Error) {
           qssc::Diagnostic const diag{
               diagLevel, qssc::ErrorCategory::OpenQASM3ParseFailure,
               errMsg.str()};

--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -203,7 +203,7 @@ llvm::Error qssc::frontend::openqasm3::parse(
                      << errMsg.str();
 
         if (diagnosticCallback_ and (diagLevel == qssc::Severity::Error or
-                                     diagLevel == qssc::Severity::ICE)) {
+                                     diagLevel == qssc::Severity::Fatal)) {
           qssc::Diagnostic const diag{
               diagLevel, qssc::ErrorCategory::OpenQASM3ParseFailure,
               errMsg.str()};

--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -202,7 +202,8 @@ llvm::Error qssc::frontend::openqasm3::parse(
         llvm::errs() << level << " while parsing OpenQASM 3 input\n"
                      << errMsg.str();
 
-        if (diagnosticCallback_ and diagLevel == qssc::Severity::Error) {
+        if (diagnosticCallback_ and (diagLevel == qssc::Severity::Error or
+                                     diagLevel == qssc::Severity::ICE)) {
           qssc::Diagnostic const diag{
               diagLevel, qssc::ErrorCategory::OpenQASM3ParseFailure,
               errMsg.str()};

--- a/test/python_lib/conftest.py
+++ b/test/python_lib/conftest.py
@@ -84,5 +84,15 @@ def example_unsupported_qasm3_str():
 
 
 @pytest.fixture
+def example_warning_not_in_errors():
+    return """OPENQASM 3.0;
+    gate rz(theta) q {}
+    qubit $0;
+    rz(7.35196807786455) $0;
+    rz(a) $0;
+    """
+
+
+@pytest.fixture
 def example_unsupported_qasm3_tmpfile(tmp_path, example_unsupported_qasm3_str):
     return __create_tmpfile(tmp_path, example_unsupported_qasm3_str)

--- a/test/python_lib/test_compile.py
+++ b/test/python_lib/test_compile.py
@@ -177,8 +177,7 @@ def test_compile_invalid_str(example_invalid_qasm3_str):
 
 
 def test_warning_not_in_errors(example_warning_not_in_errors):
-    """Test that we can attempt to compile invalid OpenQASM 3 and receive an
-    error"""
+    """Test that warnings are not included in error."""
 
     with pytest.raises(exceptions.OpenQASM3ParseFailure) as compfail:
         compile_str(


### PR DESCRIPTION
## Summary

Without the change made in this PR, a list of diagnostics with all kinds of `diagLevel`s are added to category `OpenQASM3ParseFailure`. This PR changes this behavior to just having `Error` and `Fatal` severity `diagLevel` in the  `OpenQASM3ParseFailure` category.