### PR TITLE
[Backport v3.8] Fix for when to add `OpenQASM3ParseFailure` to diagnostic

### DIFF
--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -179,10 +179,11 @@ llvm::Error qssc::frontend::openqasm3::parse(
         llvm::errs() << level << " while parsing OpenQASM 3 input\n"
                      << errMsg.str();
 
-        if (diagnosticCallback_) {
-          qssc::Diagnostic diag{diagLevel,
-                                qssc::ErrorCategory::OpenQASM3ParseFailure,
-                                errMsg.str()};
+        if (diagnosticCallback_ and (diagLevel == qssc::Severity::Error or
+                                     diagLevel == qssc::Severity::Fatal)) {
+          qssc::Diagnostic const diag{
+              diagLevel, qssc::ErrorCategory::OpenQASM3ParseFailure,
+              errMsg.str()};
           (*diagnosticCallback_)(diag);
         }
 

--- a/test/python_lib/conftest.py
+++ b/test/python_lib/conftest.py
@@ -75,5 +75,15 @@ def example_unsupported_qasm3_str():
 
 
 @pytest.fixture
+def example_warning_not_in_errors():
+    return """OPENQASM 3.0;
+    gate rz(theta) q {}
+    qubit $0;
+    rz(7.35196807786455) $0;
+    rz(a) $0;
+    """
+
+
+@pytest.fixture
 def example_unsupported_qasm3_tmpfile(tmp_path, example_unsupported_qasm3_str):
     return __create_tmpfile(tmp_path, example_unsupported_qasm3_str)

--- a/test/python_lib/test_compile.py
+++ b/test/python_lib/test_compile.py
@@ -137,3 +137,36 @@ def test_compile_invalid_str(example_invalid_qasm3_str):
     # check string representation of the exception to contain diagnostic messages
     assert "OpenQASM 3 parse error" in str(compfail.value)
     assert "unknown version number" in str(compfail.value)
+
+
+def test_warning_not_in_errors(example_warning_not_in_errors):
+    """Test that warnings are not included in error."""
+
+    with pytest.raises(exceptions.OpenQASM3ParseFailure) as compfail:
+        compile_str(
+            example_warning_not_in_errors,
+            return_diagnostics=True,
+            input_type=InputType.QASM3,
+            output_type=OutputType.MLIR,
+            output_file=None,
+        )
+
+    assert hasattr(compfail.value, "diagnostics")
+
+    diags = compfail.value.diagnostics
+
+    assert any(
+        diag.severity == Severity.Error
+        and diag.category == ErrorCategory.OpenQASM3ParseFailure
+        and "Non-existent angle a passed as angle argument to Gate Call." in diag.message
+        and "^" in diag.message
+        for diag in diags
+    )
+    assert any("OpenQASM 3 parse error" in str(diag) for diag in diags)
+
+    # check string representation of the exception to contain diagnostic messages
+    assert (
+        "Error: OpenQASM 3 parse error" in str(compfail.value)
+        and "Non-existent angle a passed as angle argument to Gate Call." in str(compfail.value)
+        and "Angle value exceeds 2pi." not in str(compfail.value)
+    )


### PR DESCRIPTION
Backport https://github.com/openqasm/qe-compiler/pull/296