### PR TITLE
Optimize greedy rewrite passes

### DIFF
--- a/lib/Dialect/QUIR/IR/QUIRInterfaces.cpp
+++ b/lib/Dialect/QUIR/IR/QUIRInterfaces.cpp
@@ -115,7 +115,7 @@ std::set<uint32_t>
 interfaces_impl::getQubitsBetweenOperations(mlir::Operation *first,
                                             mlir::Operation *second) {
   std::set<uint32_t> operatedQubits;
-  if (!first->isBeforeInBlock(second))
+  if (first->getBlock()->isOpOrderValid() && !first->isBeforeInBlock(second))
     return operatedQubits;
 
   Operation *curOp = first->getNextNode();

--- a/lib/Dialect/QUIR/IR/QUIRInterfaces.cpp
+++ b/lib/Dialect/QUIR/IR/QUIRInterfaces.cpp
@@ -115,6 +115,8 @@ std::set<uint32_t>
 interfaces_impl::getQubitsBetweenOperations(mlir::Operation *first,
                                             mlir::Operation *second) {
   std::set<uint32_t> operatedQubits;
+  // Don't use isBeforeInBlock if the op order is invalid as
+  // this is O(n) in the worst case.
   if (first->getBlock()->isOpOrderValid() && !first->isBeforeInBlock(second))
     return operatedQubits;
 

--- a/lib/Dialect/QUIR/Transforms/AngleConversion.cpp
+++ b/lib/Dialect/QUIR/Transforms/AngleConversion.cpp
@@ -101,6 +101,9 @@ void QUIRAngleConversionPass::runOnOperation() {
   mlir::GreedyRewriteConfig config;
   // Disable to improve performance
   config.enableRegionSimplification = false;
+  config.strictMode = mlir::GreedyRewriteStrictness::ExistingOps;
+  // Each operation can only be modified once so limit
+  config.maxIterations = 1;
 
   if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
                                           config))) {

--- a/releasenotes/notes/optimize-greedy-rewrites-b042d4e824642f9a.yaml
+++ b/releasenotes/notes/optimize-greedy-rewrites-b042d4e824642f9a.yaml
@@ -3,3 +3,6 @@ features:
   - |
     The performance of the QUIRAngleConversionPass has been improved by a factor of
     ~8-10x by optimizing the greedy rewrite behaviour.
+  - |
+    Parallelize control flow improves by ~8-10x due to a quadratic scaling factor
+    that was uncovered.

--- a/releasenotes/notes/optimize-greedy-rewrites-b042d4e824642f9a.yaml
+++ b/releasenotes/notes/optimize-greedy-rewrites-b042d4e824642f9a.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The performance of the QUIRAngleConversionPass has been improved by a factor of
+    ~8-10x by optimizing the greedy rewrite behaviour.


### PR DESCRIPTION
Optimize a number of greedy rewrite passes. 
- QUIRAngleConversionPass: Goes from about ~7.5s for 100x100 to 0.9s on my machine