### PR TITLE
fix: support ~ operation, close #278

### DIFF
--- a/conan/qasm/conandata.yml
+++ b/conan/qasm/conandata.yml
@@ -1,5 +1,5 @@
 sources:
-  hash: "d42bca2c2b7a8e2543462cceea178240709b6fa2"
+  hash: "2a7cb619d28fc45b9b91460468f42f47e905573b"
 requirements:
   - "gmp/6.2.1"
   - "mpfr/4.1.0"

--- a/conan/qasm/conandata.yml
+++ b/conan/qasm/conandata.yml
@@ -1,5 +1,5 @@
 sources:
-  hash: "2a7cb619d28fc45b9b91460468f42f47e905573b"
+  hash: "a9cf9fa3599b2045941d154dc91aba5a45beabb7"
 requirements:
   - "gmp/6.2.1"
   - "mpfr/4.1.0"

--- a/conan/qasm/conandata.yml
+++ b/conan/qasm/conandata.yml
@@ -1,5 +1,5 @@
 sources:
-  hash: "d59248cbb4cf8840c9720462f2569907b9506323"
+  hash: "d42bca2c2b7a8e2543462cceea178240709b6fa2"
 requirements:
   - "gmp/6.2.1"
   - "mpfr/4.1.0"

--- a/conan/qasm/conanfile.py
+++ b/conan/qasm/conanfile.py
@@ -17,7 +17,7 @@ import subprocess
 
 class QasmConan(ConanFile):
     name = "qasm"
-    version = "0.3.0"
+    version = "0.3.1"
     url = "https://github.com/openqasm/qe-qasm.git"
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False], "examples": [True, False]}

--- a/conandata.yml
+++ b/conandata.yml
@@ -7,4 +7,4 @@ requirements:
   - pybind11/2.11.1
   - clang-tools-extra/17.0.5-0@
   - llvm/17.0.5-0@
-  - qasm/0.3.0@qss/stable
+  - qasm/0.3.1@qss/stable

--- a/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
@@ -1847,6 +1847,7 @@ ExpressionValueType QUIRGenQASM3Visitor::visit_(const ASTUnaryOpNode *node) {
   }
 
   switch (node->GetOpType()) {
+  case ASTOpTypeBitNot:
   case ASTOpTypeLogicalNot: {
     const auto boolType = builder.getI1Type();
 

--- a/releasenotes/notes/add-bitnot-support-7ad288e5a87b7302.yaml
+++ b/releasenotes/notes/add-bitnot-support-7ad288e5a87b7302.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes failure to parse expressions with bitnop operation. Refer to
+    `#278 <https://github.com/openqasm/qe-compiler/issues/278>` for more
+    details.

--- a/releasenotes/notes/add-bitnot-support-7ad288e5a87b7302.yaml
+++ b/releasenotes/notes/add-bitnot-support-7ad288e5a87b7302.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Fixes failure to parse expressions with bitnop operation. Refer to
+    Fixes failure to parse expressions with bitnot operation. Refer to
     `#278 <https://github.com/openqasm/qe-compiler/issues/278>` for more
     details.

--- a/test/Frontend/OpenQASM3/bitops.qasm
+++ b/test/Frontend/OpenQASM3/bitops.qasm
@@ -107,5 +107,11 @@ f = e | d;
 // MLIR: [[NOT_CBIT:%.*]] = "oq3.cast"([[NOT]]) : (i1) -> !quir.cbit<1>
 // MLIR: oq3.variable_assign @f : !quir.cbit<1> = [[NOT_CBIT]]
 f = !f;
-// equivalent to "!"
+
+// MLIR: [[F:%.*]] = oq3.variable_load @f : !quir.cbit<1>
+// MLIR: [[BOOL_F:%.*]] = "oq3.cast"([[F]]) : (!quir.cbit<1>) -> i1
+// MLIR: [[TRUE:%.*]] = arith.constant true
+// MLIR: [[NOT:%.*]] = arith.cmpi ne, [[BOOL_F]], [[TRUE]] : i1
+// MLIR: [[NOT_CBIT:%.*]] = "oq3.cast"([[NOT]]) : (i1) -> !quir.cbit<1>
+// MLIR: oq3.variable_assign @f : !quir.cbit<1> = [[NOT_CBIT]]
 f = ~f;

--- a/test/Frontend/OpenQASM3/bitops.qasm
+++ b/test/Frontend/OpenQASM3/bitops.qasm
@@ -107,3 +107,5 @@ f = e | d;
 // MLIR: [[NOT_CBIT:%.*]] = "oq3.cast"([[NOT]]) : (i1) -> !quir.cbit<1>
 // MLIR: oq3.variable_assign @f : !quir.cbit<1> = [[NOT_CBIT]]
 f = !f;
+// equivalent to "!"
+f = ~f;


### PR DESCRIPTION
Hi Team,

I've added rules to parse "~" symbol in qe-qasm: https://github.com/openqasm/qe-qasm/pull/29, at the side of qe-compiler, we need to generate a MLIR op for `ASTOpTypeBitNot` in `lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp`.

After searching, I find that MLIR does not have arith operations directly related to "BitNot". In the context of OQ3, I believe "~cbit" and "!cbit" are equivalent in a "if" condition? So I just simply reused the processing logic of `ASTOpTypeLogicalNot`, which checks whether the target is a `I1Type` and also works for `ASTOpTypeBitNot` operation. It will also create an `CmpIPredicate::ne` operation.

Willing to update my pr if you have better solutions

Thanks,
Yilun


## Changes
1. Update the commit id of qe-qasm project
2. Reuse the processing logic of `ASTOpTypeLogicalNot` for `ASTOpTypeBitNot`.

## Sample

Given the following source file

```bash
OPENQASM 3.0;

qubit $0;

gate x q {}

bit[4] qc0_c0;

if ((qc0_c0[0] & qc0_c0[1] | qc0_c0[0] & qc0_c0[2] | qc0_c0[1] & qc0_c0[2]) & ~(qc0_c0[0] & qc0_c0[1] & qc0_c0[2])) {
    x $0;
}
qc0_c0[3] = measure $0;
```

The compiler generates following MLIR

````bash
module {
  oq3.declare_variable @qc0_c0 : !quir.cbit<4>
  func.func @x(%arg0: !quir.qubit<1>) {
    return
  }
  func.func @main() -> i32 {
    qcs.init
    %c0 = arith.constant 0 : index
    %c1000 = arith.constant 1000 : index
    %c1 = arith.constant 1 : index
    scf.for %arg0 = %c0 to %c1000 step %c1 {
      %dur = quir.constant #quir.duration<1.000000e+00> : !quir.duration<ms>
      quir.delay %dur, () : !quir.duration<ms>, () -> ()
      qcs.shot_init {qcs.num_shots = 1000 : i32}
      %0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
      %c0_i4 = arith.constant 0 : i4
      %1 = "oq3.cast"(%c0_i4) : (i4) -> !quir.cbit<4>
      oq3.variable_assign @qc0_c0 : !quir.cbit<4> = %1
      %2 = oq3.variable_load @qc0_c0 : !quir.cbit<4>
      %3 = oq3.cbit_extractbit(%2 : !quir.cbit<4>) [0] : i1
      %4 = oq3.variable_load @qc0_c0 : !quir.cbit<4>
      %5 = oq3.cbit_extractbit(%4 : !quir.cbit<4>) [1] : i1
      %6 = oq3.cbit_and %3, %5 : i1
      %7 = oq3.variable_load @qc0_c0 : !quir.cbit<4>
      %8 = oq3.cbit_extractbit(%7 : !quir.cbit<4>) [0] : i1
      %9 = oq3.variable_load @qc0_c0 : !quir.cbit<4>
      %10 = oq3.cbit_extractbit(%9 : !quir.cbit<4>) [2] : i1
      %11 = oq3.cbit_and %8, %10 : i1
      %12 = oq3.cbit_or %6, %11 : i1
      %13 = oq3.variable_load @qc0_c0 : !quir.cbit<4>
      %14 = oq3.cbit_extractbit(%13 : !quir.cbit<4>) [1] : i1
      %15 = oq3.variable_load @qc0_c0 : !quir.cbit<4>
      %16 = oq3.cbit_extractbit(%15 : !quir.cbit<4>) [2] : i1
      %17 = oq3.cbit_and %14, %16 : i1
      %18 = oq3.cbit_or %12, %17 : i1
      %19 = oq3.variable_load @qc0_c0 : !quir.cbit<4>
      %20 = oq3.cbit_extractbit(%19 : !quir.cbit<4>) [0] : i1
      %21 = oq3.variable_load @qc0_c0 : !quir.cbit<4>
      %22 = oq3.cbit_extractbit(%21 : !quir.cbit<4>) [1] : i1
      %23 = oq3.cbit_and %20, %22 : i1
      %24 = oq3.variable_load @qc0_c0 : !quir.cbit<4>
      %25 = oq3.cbit_extractbit(%24 : !quir.cbit<4>) [2] : i1
      %26 = oq3.cbit_and %23, %25 : i1
      %true = arith.constant true
      %27 = arith.cmpi ne, %26, %true : i1
      %28 = oq3.cbit_and %18, %27 : i1
      scf.if %28 {
        quir.call_gate @x(%0) : (!quir.qubit<1>) -> ()
        %false = arith.constant false
      }
      %29 = quir.measure(%0) : (!quir.qubit<1>) -> i1
      oq3.cbit_assign_bit @qc0_c0<4> [3] : i1 = %29
    } {qcs.shot_loop}
    qcs.finalize
    %c0_i32 = arith.constant 0 : i32
    return %c0_i32 : i32
  }
}
```