### PR TITLE
Update getPhaseValue to return an mlir::Value.

### DIFF
--- a/include/Dialect/Pulse/Utils/Utils.h
+++ b/include/Dialect/Pulse/Utils/Utils.h
@@ -42,9 +42,13 @@ Waveform_CreateOp getWaveformOp(PlayOp pulsePlayOp,
 Waveform_CreateOp getWaveformOp(PlayOp pulsePlayOp,
                                 CallSequenceStack_t &callSequenceOpStack);
 
+#if 0
 double getPhaseValue(ShiftPhaseOp shiftPhaseOp,
                      CallSequenceStack_t &callSequenceOpStack);
-
+#else
+mlir::Value getPhaseValue(ShiftPhaseOp shiftPhaseOp,
+                          CallSequenceStack_t &callSequenceOpStack);
+#endif
 /// this function goes over all the blocks of the input pulse sequence, and for
 /// each block, it sorts the pulse ops within the block according to their
 /// timepoints.

--- a/include/Dialect/Pulse/Utils/Utils.h
+++ b/include/Dialect/Pulse/Utils/Utils.h
@@ -41,14 +41,9 @@ Waveform_CreateOp getWaveformOp(PlayOp pulsePlayOp,
 
 Waveform_CreateOp getWaveformOp(PlayOp pulsePlayOp,
                                 CallSequenceStack_t &callSequenceOpStack);
-
-#if 0
-double getPhaseValue(ShiftPhaseOp shiftPhaseOp,
-                     CallSequenceStack_t &callSequenceOpStack);
-#else
 mlir::Value getPhaseValue(ShiftPhaseOp shiftPhaseOp,
                           CallSequenceStack_t &callSequenceOpStack);
-#endif
+
 /// this function goes over all the blocks of the input pulse sequence, and for
 /// each block, it sorts the pulse ops within the block according to their
 /// timepoints.

--- a/lib/Dialect/Pulse/Utils/Utils.cpp
+++ b/lib/Dialect/Pulse/Utils/Utils.cpp
@@ -20,6 +20,7 @@
 
 #include "Dialect/Pulse/Utils/Utils.h"
 
+#include "Dialect/OQ3/IR/OQ3Ops.h"
 #include "Dialect/Pulse/IR/PulseInterfaces.h"
 #include "Dialect/Pulse/IR/PulseOps.h"
 #include "Dialect/Pulse/IR/PulseTraits.h"
@@ -64,6 +65,12 @@ Waveform_CreateOp getWaveformOp(PlayOp pulsePlayOp,
   return waveformOp;
 }
 
+double angleValToDouble(mlir::Value &value) {
+  llvm::dbgs() << "KIT: DUMMY -- NOT IMPLEMENTED\n";
+  return 0.0;
+}
+
+#if 0
 double getPhaseValue(ShiftPhaseOp shiftPhaseOp,
                      CallSequenceStack_t &callSequenceOpStack) {
   auto phaseOffsetIndex = 0;
@@ -84,6 +91,43 @@ double getPhaseValue(ShiftPhaseOp shiftPhaseOp,
     phaseOffsetOp->emitError() << "Phase offset is not a ConstantFloatOp.";
   return phaseOffsetOp.value().convertToDouble();
 }
+#else
+mlir::Value getPhaseValue(ShiftPhaseOp shiftPhaseOp,
+                          CallSequenceStack_t &callSequenceOpStack) {
+  auto phaseOffsetIndex = 0;
+  mlir::Value phaseOffset = shiftPhaseOp.getPhaseOffset();
+
+  for (auto it = callSequenceOpStack.rbegin(); it != callSequenceOpStack.rend();
+       ++it) {
+    if (phaseOffset.isa<BlockArgument>()) {
+      phaseOffsetIndex = phaseOffset.dyn_cast<BlockArgument>().getArgNumber();
+      phaseOffset = it->getOperand(phaseOffsetIndex);
+    } else
+      break;
+  }
+
+  return phaseOffset;
+#if 0
+  if (auto castOp =
+          dyn_cast<mlir::arith::ConstantFloatOp>(phaseOffset.getDefiningOp())) {
+    return castOp.value().convertToDouble();
+  }
+  if (auto castOp = dyn_cast<mlir::oq3::CastOp>(phaseOffset.getDefiningOp())) {
+    assert(castOp->getNumOperands() == 1 &&
+           "Expecting OQ3::CastOp to have 1 operand!");
+    mlir::Value castFromVal = castOp->getOperand(0);
+    // Check type of operand
+    if (castFromVal.getType().isa<mlir::quir::AngleType>())
+      return angleValToDouble(castFromVal);
+
+    assert(0 && "Unhandled type");
+  } else {
+    shiftPhaseOp->emitError() << "Phase offset is not a ConstantFloatOp.";
+  }
+  return 0.0;
+#endif
+}
+#endif
 
 void sortOpsByTimepoint(SequenceOp &sequenceOp) {
   // sort ops by timepoint


### PR DESCRIPTION
This PR changes the return value of the Pulse utility method `getPhaseValue()` to return an `mlir::Value` instead of a `double`. 
This is necessary when using parameters, as the phase offset can be specified as a parameter value in addition to a compile time constant. By returning the `mlir::Value`, the caller of `phaseOffset` has the ability to differentiate between the two scenarios and act accordingly. 