### PR TITLE
Raise `OpenQASM3ParseFailure` instead of `QSSCompilerEOFFailure`

### DIFF
--- a/conan/qasm/conandata.yml
+++ b/conan/qasm/conandata.yml
@@ -1,5 +1,5 @@
 sources:
-  hash: "d59248cbb4cf8840c9720462f2569907b9506323"
+  hash: "f6d695fd9f18462e65f6290d05ccb4ccb371b288"
 requirements:
   - "gmp/6.2.1"
   - "mpfr/4.1.0"

--- a/conan/qasm/conanfile.py
+++ b/conan/qasm/conanfile.py
@@ -17,7 +17,7 @@ import subprocess
 
 class QasmConan(ConanFile):
     name = "qasm"
-    version = "0.3.0"
+    version = "0.3.2"
     url = "https://github.com/openqasm/qe-qasm.git"
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False], "examples": [True, False]}

--- a/conandata.yml
+++ b/conandata.yml
@@ -7,4 +7,4 @@ requirements:
   - pybind11/2.11.1
   - clang-tools-extra/17.0.5-0@
   - llvm/17.0.5-0@
-  - qasm/0.3.0@qss/stable
+  - qasm/0.3.2@qss/stable

--- a/test/python_lib/conftest.py
+++ b/test/python_lib/conftest.py
@@ -92,6 +92,19 @@ def example_warning_not_in_errors():
     rz(a) $0;
     """
 
+@pytest.fixture
+def example_incorrect_qasm3():
+    return """INCORRECT_QASM3_STR =
+    OPENQASM 3;
+    qubit $0;
+    gate sx q {}
+    gate rz(phi) q {}
+    sx $0;
+    rz("A") $0;
+    sx $0;
+    bit b;
+    b = measure $0;
+    """
 
 @pytest.fixture
 def example_unsupported_qasm3_tmpfile(tmp_path, example_unsupported_qasm3_str):

--- a/test/python_lib/conftest.py
+++ b/test/python_lib/conftest.py
@@ -94,8 +94,7 @@ def example_warning_not_in_errors():
 
 @pytest.fixture
 def example_incorrect_qasm3():
-    return """INCORRECT_QASM3_STR =
-    OPENQASM 3;
+    return """OPENQASM 3;
     qubit $0;
     gate sx q {}
     gate rz(phi) q {}

--- a/test/python_lib/conftest.py
+++ b/test/python_lib/conftest.py
@@ -92,6 +92,7 @@ def example_warning_not_in_errors():
     rz(a) $0;
     """
 
+
 @pytest.fixture
 def example_incorrect_qasm3():
     return """OPENQASM 3;
@@ -104,6 +105,7 @@ def example_incorrect_qasm3():
     bit b;
     b = measure $0;
     """
+
 
 @pytest.fixture
 def example_unsupported_qasm3_tmpfile(tmp_path, example_unsupported_qasm3_str):

--- a/test/python_lib/test_compile.py
+++ b/test/python_lib/test_compile.py
@@ -225,17 +225,11 @@ def test_incorrect_qasm3(example_incorrect_qasm3):
 
     diags = compfail.value.diagnostics
 
-    print("****************************************************************************")
-    print(diag.message for diag in diags)
-    print("****************************************************************************")
-
     assert any(
         diag.severity == Severity.Error
         and diag.category == ErrorCategory.OpenQASM3ParseFailure
         and "1 inconsistent parameters in the gate call for the corresponding gate definition"
         in diag.message
-        and "    gate rz(phi) q {}" in diag.message
-        and "              ^" in diag.message
         for diag in diags
     )
     assert any("OpenQASM 3 parse error" in str(diag) for diag in diags)
@@ -245,9 +239,6 @@ def test_incorrect_qasm3(example_incorrect_qasm3):
         "Error: OpenQASM 3 parse error" in str(compfail.value)
         and "1 inconsistent parameters in the gate call for the corresponding gate definition"
         in str(compfail.value)
-        and "error:" not in str(compfail.value)
-        and "    gate rz(phi) q {}" not in str(compfail.value)
-        and "              ^" not in str(compfail.value)
     )
 
 

--- a/test/python_lib/test_compile.py
+++ b/test/python_lib/test_compile.py
@@ -209,6 +209,46 @@ def test_warning_not_in_errors(example_warning_not_in_errors):
     )
 
 
+def test_incorrect_qasm3(example_incorrect_qasm3):
+    """Test incorrect qasm3 raises error."""
+
+    with pytest.raises(exceptions.OpenQASM3ParseFailure) as compfail:
+        compile_str(
+            example_incorrect_qasm3,
+            return_diagnostics=True,
+            input_type=InputType.QASM3,
+            output_type=OutputType.MLIR,
+            output_file=None,
+        )
+
+    assert hasattr(compfail.value, "diagnostics")
+
+    diags = compfail.value.diagnostics
+
+    print("****************************************************************************")
+    print(diag.message for diag in diags)
+    print("****************************************************************************")
+
+    assert any(
+        diag.severity == Severity.Error
+        and diag.category == ErrorCategory.OpenQASM3ParseFailure
+        and "1 inconsistent parameters in the gate call for the corresponding gate definition" in diag.message
+        and "    gate rz(phi) q {}" in diag.message
+        and "              ^" in diag.message
+        for diag in diags
+    )
+    assert any("OpenQASM 3 parse error" in str(diag) for diag in diags)
+
+    # check string representation of the exception to contain diagnostic messages
+    assert (
+        "Error: OpenQASM 3 parse error" in str(compfail.value)
+        and "1 inconsistent parameters in the gate call for the corresponding gate definition" in str(compfail.value)
+        and "error:" not in str(compfail.value)
+        and "    gate rz(phi) q {}" not in str(compfail.value)
+        and "              ^" not in str(compfail.value)
+    )
+
+
 def test_failure_no_hang():
     """Test no hang on malformed inputs."""
     with pytest.raises(exceptions.QSSCompilerEOFFailure):

--- a/test/python_lib/test_compile.py
+++ b/test/python_lib/test_compile.py
@@ -232,7 +232,8 @@ def test_incorrect_qasm3(example_incorrect_qasm3):
     assert any(
         diag.severity == Severity.Error
         and diag.category == ErrorCategory.OpenQASM3ParseFailure
-        and "1 inconsistent parameters in the gate call for the corresponding gate definition" in diag.message
+        and "1 inconsistent parameters in the gate call for the corresponding gate definition"
+        in diag.message
         and "    gate rz(phi) q {}" in diag.message
         and "              ^" in diag.message
         for diag in diags
@@ -242,7 +243,8 @@ def test_incorrect_qasm3(example_incorrect_qasm3):
     # check string representation of the exception to contain diagnostic messages
     assert (
         "Error: OpenQASM 3 parse error" in str(compfail.value)
-        and "1 inconsistent parameters in the gate call for the corresponding gate definition" in str(compfail.value)
+        and "1 inconsistent parameters in the gate call for the corresponding gate definition"
+        in str(compfail.value)
         and "error:" not in str(compfail.value)
         and "    gate rz(phi) q {}" not in str(compfail.value)
         and "              ^" not in str(compfail.value)

--- a/test/python_lib/test_compile.py
+++ b/test/python_lib/test_compile.py
@@ -235,10 +235,10 @@ def test_incorrect_qasm3(example_incorrect_qasm3):
     assert any("OpenQASM 3 parse error" in str(diag) for diag in diags)
 
     # check string representation of the exception to contain diagnostic messages
-    assert (
-        "Error: OpenQASM 3 parse error" in str(compfail.value)
-        and "1 inconsistent parameters in the gate call for the corresponding gate definition"
-        in str(compfail.value)
+    assert "Error: OpenQASM 3 parse error" in str(
+        compfail.value
+    ) and "1 inconsistent parameters in the gate call for the corresponding gate definition" in str(
+        compfail.value
     )
 
 


### PR DESCRIPTION
## Summary

This PR adds tests for the updates made in https://github.com/openqasm/qe-qasm/pull/34. This update is made so that the compiler doesn't fail assertion, but instead raises appropriate errors