### PR TITLE
Add qasm3 generation error handling

### DIFF
--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -32,6 +32,7 @@ namespace qssc {
 
 enum class ErrorCategory {
   OpenQASM3ParseFailure,
+  OpenQASM3UnsupportedInput,
   QSSCompilerError,
   QSSCompilerNoInputError,
   QSSCompilerCommunicationFailure,

--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -159,7 +159,6 @@ private:
   mlir::Diagnostic filterQSSCDiagnostic(mlir::Diagnostic &diagnostic);
 
   const OptDiagnosticCallback &diagnosticCb;
-
 };
 
 } // namespace qssc

--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -144,18 +144,18 @@ mlir::InFlightDiagnostic emitWarning(mlir::Operation *op,
 /// Diagnostic handler for the QSSC compiler which will emit MLIR diagnostics
 /// through the compiler's diagnostic interface as well as through MLIR's
 /// source manager handler.
-class QSSCMLIRDiagnosticHandler : public mlir::ScopedDiagnosticHandler {
+class QSSCMLIRDiagnosticHandler : mlir::SourceMgrDiagnosticHandler {
 public:
   QSSCMLIRDiagnosticHandler(llvm::SourceMgr &mgr, mlir::MLIRContext *ctx,
                             const OptDiagnosticCallback &diagnosticCb);
 
+  /// Emit a diagnostic through the source manager dianostic handler
+  /// removing any fields that are related to the qscc error category.
+  void emitDiagnostic(mlir::Diagnostic &diagnostic);
+
 private:
   const OptDiagnosticCallback &diagnosticCb;
-  // Must be initialized after the QSSC emitDiagnostic callback
-  // to ensure processed after.
-  mlir::SourceMgrDiagnosticHandler sourceMgrDiagnosticHandler;
 
-  void emitDiagnostic(mlir::Diagnostic &diagnostic);
 };
 
 } // namespace qssc

--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -21,6 +21,8 @@
 #ifndef QSS_COMPILER_ERROR_H
 #define QSS_COMPILER_ERROR_H
 
+#include "mlir/IR/Diagnostics.h"
+
 #include "llvm/Support/Error.h"
 
 #include <functional>
@@ -70,6 +72,22 @@ public:
 
   std::string toString() const;
 };
+
+/// MLIR diagnostic that contains a QSSC diagnostic and will
+/// automatically be deduced by the qss-compiler and its
+/// diagnostic APIs when used in conjunction with MLIR's
+/// in-flight diagnostic APIs.
+class MLIRQSSCDiagnostic : public mlir::Diagnostic {
+  public:
+    MLIRQSSCDiagnostic(mlir::Location loc, mlir::DiagnosticSeverity severity, ErrorCategory qsscErrorCategory)
+       : mlir::Diagnostic(loc, severity), qsscErrorCategory(qsscErrorCategory) {}
+    ErrorCategory getQSSCErrorCategory() { return qsscErrorCategory; }
+
+    private:
+      ErrorCategory qsscErrorCategory;
+
+};
+
 
 using DiagList = std::list<Diagnostic>;
 using DiagRefList = std::list<std::reference_wrapper<const Diagnostic>>;

--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -50,8 +50,8 @@ enum class ErrorCategory {
   QSSLinkArgumentNotFoundWarning,
   QSSLinkInvalidPatchTypeError,
   QSSControlSystemResourcesExceeded,
-  OpenQASM3UnsupportedInput,
   QSSTargetUnsupportedOperation,
+  OpenQASM3UnsupportedInput,
   UncategorizedError,
 };
 

--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -113,12 +113,6 @@ void encodeQSSCError(mlir::MLIRContext *context,
 void encodeQSSCError(mlir::MLIRContext *context, mlir::Diagnostic *diagnostic,
                      ErrorCategory category);
 
-/// Decode the MLIR diagnostic into a QSSC Diagnostic (if necessary). If the
-/// diagnostic has a QSSC diagnostic encoded through encodeQSSCError the emitted
-/// diagnostic will contain this information. If std::nullopt is returned no
-/// QSSC diagnostic should be generated.
-std::optional<Diagnostic> decodeQSSCDiagnostic(mlir::Diagnostic &diagnostic);
-
 /// Emit a QSSC encoded MLIR error on an operation. Reporting up to any
 /// diagnostic handlers that may be listening.
 mlir::InFlightDiagnostic emitError(mlir::Operation *op, ErrorCategory category,
@@ -153,12 +147,23 @@ public:
   /// removing any fields that are related to the qscc error category.
   void emitDiagnostic(mlir::Diagnostic &diagnostic);
 
+  /// Decode the MLIR diagnostic into a QSSC Diagnostic (if necessary). If the
+  /// diagnostic has a QSSC diagnostic encoded through encodeQSSCError the
+  /// emitted diagnostic will contain this information. If std::nullopt is
+  /// returned no QSSC diagnostic should be generated.
+  std::optional<Diagnostic> decodeQSSCDiagnostic(mlir::Diagnostic &diagnostic);
+
 private:
   /// Create a new diagnostic which contains all information
   /// except the QSSC diagnostic category information.
   mlir::Diagnostic filterQSSCDiagnostic(mlir::Diagnostic &diagnostic);
 
   const OptDiagnosticCallback &diagnosticCb;
+  // Store captured output
+  std::string capturedString;
+  // Output stream for source manager
+  llvm::raw_string_ostream capturedOutputStream =
+      llvm::raw_string_ostream(capturedString);
 };
 
 } // namespace qssc

--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -150,9 +150,9 @@ public:
 
 private:
   const OptDiagnosticCallback &diagnosticCb;
-  // Must be pointer as we need to initialize after this class to avoid
-  // registering handle with MLIR context before this class.
-  std::unique_ptr<mlir::SourceMgrDiagnosticHandler> sourceMgrDiagnosticHandler;
+  // Must be initialized after the QSSC emitDiagnostic callback
+  // to ensure processed after.
+  mlir::SourceMgrDiagnosticHandler sourceMgrDiagnosticHandler;
 
   void emitDiagnostic(mlir::Diagnostic &diagnostic);
 };

--- a/include/API/errors.h
+++ b/include/API/errors.h
@@ -154,6 +154,10 @@ public:
   void emitDiagnostic(mlir::Diagnostic &diagnostic);
 
 private:
+  /// Create a new diagnostic which contains all information
+  /// except the QSSC diagnostic category information.
+  mlir::Diagnostic filterQSSCDiagnostic(mlir::Diagnostic &diagnostic);
+
   const OptDiagnosticCallback &diagnosticCb;
 
 };

--- a/include/Frontend/OpenQASM3/OpenQASM3Frontend.h
+++ b/include/Frontend/OpenQASM3/OpenQASM3Frontend.h
@@ -36,18 +36,17 @@ namespace qssc::frontend::openqasm3 {
 
 /// @brief Parse an OpenQASM 3 source file and emit high-level IR in the
 /// OpenQASM 3 dialect or dump the AST
+/// @param context The context to parse the module into
 /// @param sourceMgr Input source manager for the qasm3 source to be parsed
 /// @param emitRawAST whether the raw AST should be dumped
 /// @param emitPrettyAST whether a pretty-printed AST should be dumped
 /// @param emitMLIR whether high-level IR should be emitted
 /// @param newModule ModuleOp container for emitting MLIR into
-/// @param diagnosticCb a callback that will receive emitted diagnostics
 /// @return an llvm::Error in case of failure, or llvm::Error::success()
 /// otherwise
-llvm::Error parse(llvm::SourceMgr &sourceMgr, bool emitRawAST,
-                  bool emitPrettyAST, bool emitMLIR, mlir::ModuleOp newModule,
-                  OptDiagnosticCallback diagnosticCb,
-                  mlir::TimingScope &timing);
+llvm::Error parse(mlir::MLIRContext *context, llvm::SourceMgr &sourceMgr,
+                  bool emitRawAST, bool emitPrettyAST, bool emitMLIR,
+                  mlir::ModuleOp newModule, mlir::TimingScope &timing);
 
 }; // namespace qssc::frontend::openqasm3
 

--- a/include/Frontend/OpenQASM3/QUIRGenQASM3Visitor.h
+++ b/include/Frontend/OpenQASM3/QUIRGenQASM3Visitor.h
@@ -17,6 +17,8 @@
 #ifndef VISITOR_QUIR_GEN_VISITOR_H
 #define VISITOR_QUIR_GEN_VISITOR_H
 
+#include "API/errors.h"
+
 #include "Dialect/QUIR/IR/QUIRDialect.h"
 #include "Dialect/QUIR/IR/QUIREnums.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
@@ -97,7 +99,8 @@ private:
   ///
   /// \returns an in-flight diagnostic that allows adding messages and notes.
   mlir::InFlightDiagnostic reportError(QASM::ASTBase const *location,
-                                       mlir::DiagnosticSeverity severity);
+                                       mlir::DiagnosticSeverity severity,
+                                       qssc::ErrorCategory category = qssc::ErrorCategory::OpenQASM3UnsupportedInput);
 
   template <class MLIROp>
   ExpressionValueType buildUnaryOp(llvm::StringRef name,

--- a/include/Frontend/OpenQASM3/QUIRGenQASM3Visitor.h
+++ b/include/Frontend/OpenQASM3/QUIRGenQASM3Visitor.h
@@ -98,9 +98,10 @@ private:
   /// \param severity severity of the diagnostic
   ///
   /// \returns an in-flight diagnostic that allows adding messages and notes.
-  mlir::InFlightDiagnostic reportError(QASM::ASTBase const *location,
-                                       mlir::DiagnosticSeverity severity,
-                                       qssc::ErrorCategory category = qssc::ErrorCategory::OpenQASM3UnsupportedInput);
+  mlir::InFlightDiagnostic
+  reportError(QASM::ASTBase const *location, mlir::DiagnosticSeverity severity,
+              qssc::ErrorCategory category =
+                  qssc::ErrorCategory::OpenQASM3UnsupportedInput);
 
   template <class MLIROp>
   ExpressionValueType buildUnaryOp(llvm::StringRef name,

--- a/include/Frontend/OpenQASM3/QUIRGenQASM3Visitor.h
+++ b/include/Frontend/OpenQASM3/QUIRGenQASM3Visitor.h
@@ -47,10 +47,11 @@ private:
   mlir::OpBuilder circuitParentBuilder;
   mlir::ModuleOp newModule;
   mlir::quir::CircuitOp currentCircuitOp;
-  std::string filename;
   bool hasFailed{false};
   bool buildingInCircuit{false};
   uint circuitCount{0};
+  std::string fileName;
+  bool requiresParserLocationFix;
 
   mlir::Location getLocation(const QASM::ASTBase *);
   bool assign(mlir::Value &, const std::string &);
@@ -117,17 +118,23 @@ private:
 
 public:
   QUIRGenQASM3Visitor(QASM::ASTStatementList *sList, mlir::OpBuilder b,
-                      mlir::ModuleOp newModule, std::string f)
+                      mlir::ModuleOp newModule, std::string fileName,
+                      bool requiresParserLocationFix = false)
       : BaseQASM3Visitor(sList), builder(b), topLevelBuilder(b),
-        circuitParentBuilder(b), newModule(newModule), filename(std::move(f)),
+        circuitParentBuilder(b), newModule(newModule),
+        fileName(std::move(fileName)),
+        requiresParserLocationFix(requiresParserLocationFix),
         expression(llvm::createStringError(llvm::inconvertibleErrorCode(),
                                            "Testing error")),
         varHandler(builder) {}
 
   QUIRGenQASM3Visitor(mlir::OpBuilder b, mlir::ModuleOp newModule,
-                      std::string filename)
+                      std::string fileName,
+                      bool requiresParserLocationFix = false)
       : builder(b), topLevelBuilder(b), circuitParentBuilder(b),
-        newModule(newModule), filename(std::move(filename)),
+        fileName(std::move(fileName)),
+        requiresParserLocationFix(requiresParserLocationFix),
+        newModule(newModule),
         expression(llvm::createStringError(llvm::inconvertibleErrorCode(),
                                            "Testing error")),
         varHandler(builder) {}

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -491,7 +491,8 @@ llvm::Error performCompileActions(llvm::raw_ostream &outputStream,
     if (config.getEmitAction() >= EmitAction::MLIR) {
       auto bufferIdentifier = sourceBuffer->getBufferIdentifier();
 
-      LocationAttr sourceLoc = mlir::FileLineColLoc::get(&context, bufferIdentifier, 0, 0);
+      LocationAttr sourceLoc =
+          mlir::FileLineColLoc::get(&context, bufferIdentifier, 0, 0);
 
       moduleOp = mlir::ModuleOp::create(sourceLoc);
     }

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -497,9 +497,9 @@ llvm::Error performCompileActions(llvm::raw_ostream &outputStream,
       moduleOp = mlir::ModuleOp::create(sourceLoc);
     }
     if (auto frontendError = qssc::frontend::openqasm3::parse(
-            *sourceMgr, config.getEmitAction() == EmitAction::AST,
+            &context, *sourceMgr, config.getEmitAction() == EmitAction::AST,
             config.getEmitAction() == EmitAction::ASTPretty,
-            config.getEmitAction() >= EmitAction::MLIR, moduleOp, diagnosticCb,
+            config.getEmitAction() >= EmitAction::MLIR, moduleOp,
             loadQASM3Timing))
       return frontendError;
     if (config.getEmitAction() < EmitAction::MLIR)

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -491,11 +491,7 @@ llvm::Error performCompileActions(llvm::raw_ostream &outputStream,
     if (config.getEmitAction() >= EmitAction::MLIR) {
       auto bufferIdentifier = sourceBuffer->getBufferIdentifier();
 
-      LocationAttr sourceLoc;
-      if ((bufferIdentifier == "" || bufferIdentifier == "<stdin>"))
-        sourceLoc = UnknownLoc::get(&context);
-      else
-        sourceLoc = mlir::FileLineColLoc::get(&context, bufferIdentifier, 0, 0);
+      LocationAttr sourceLoc = mlir::FileLineColLoc::get(&context, bufferIdentifier, 0, 0);
 
       moduleOp = mlir::ModuleOp::create(sourceLoc);
     }

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -491,7 +491,7 @@ llvm::Error performCompileActions(llvm::raw_ostream &outputStream,
     if (config.getEmitAction() >= EmitAction::MLIR) {
       auto bufferIdentifier = sourceBuffer->getBufferIdentifier();
 
-      const LocationAttr sourceLoc =
+      LocationAttr const sourceLoc =
           mlir::FileLineColLoc::get(&context, bufferIdentifier, 0, 0);
 
       moduleOp = mlir::ModuleOp::create(sourceLoc);

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -491,7 +491,7 @@ llvm::Error performCompileActions(llvm::raw_ostream &outputStream,
     if (config.getEmitAction() >= EmitAction::MLIR) {
       auto bufferIdentifier = sourceBuffer->getBufferIdentifier();
 
-      LocationAttr sourceLoc =
+      const LocationAttr sourceLoc =
           mlir::FileLineColLoc::get(&context, bufferIdentifier, 0, 0);
 
       moduleOp = mlir::ModuleOp::create(sourceLoc);

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -263,13 +263,7 @@ mlir::InFlightDiagnostic emitWarning(mlir::Operation *op,
 QSSCMLIRDiagnosticHandler::QSSCMLIRDiagnosticHandler(
     llvm::SourceMgr &mgr, mlir::MLIRContext *ctx,
     const OptDiagnosticCallback &diagnosticCb)
-    : mlir::ScopedDiagnosticHandler(ctx), diagnosticCb(diagnosticCb) {
-  // Register handlier for QSSC diagnostic
-  setHandler([this](mlir::Diagnostic &diag) { this->emitDiagnostic(diag); });
-  // Then register standard source mgr handler to ensure emitted to stdout
-  sourceMgrDiagnosticHandler =
-      std::make_unique<mlir::SourceMgrDiagnosticHandler>(mgr, ctx);
-}
+    : mlir::ScopedDiagnosticHandler(ctx, [this](mlir::Diagnostic &diag) { this->emitDiagnostic(diag); }), diagnosticCb(diagnosticCb), sourceMgrDiagnosticHandler(mlir::SourceMgrDiagnosticHandler(mgr, ctx)) {}
 
 void QSSCMLIRDiagnosticHandler::emitDiagnostic(mlir::Diagnostic &diagnostic) {
   // emit diagnostic cast to void to discard result as it is not needed here

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -279,6 +279,7 @@ void QSSCMLIRDiagnosticHandler::emitDiagnostic(mlir::Diagnostic &diagnostic) {
   if (auto decoded = decodeQSSCDiagnostic(diagnostic)) {
     (void)qssc::emitDiagnostic(diagnosticCb, decoded.value());
     llvm::errs() << decoded.value().message;
+    return;
   }
 
   // If no diagnostic

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -161,10 +161,8 @@ getQSSCDiagnosticCategory(mlir::DiagnosticArgument &arg) {
             arg.getAsAttribute().dyn_cast_or_null<mlir::DictionaryAttr>()) {
       if (auto namedAttr = dictAttr.getNamed(ErrorCategoryAttrName)) {
         if (auto catInt =
-                namedAttr.value().getValue().dyn_cast<mlir::IntegerAttr>()) {
-          auto cat = static_cast<ErrorCategory>((uint32_t)catInt.getInt());
-          return cat;
-        }
+                namedAttr.value().getValue().dyn_cast<mlir::IntegerAttr>())
+          return static_cast<ErrorCategory>((uint32_t)catInt.getInt());
 
         llvm_unreachable("Invalid attribute type for error category. Must "
                          "be an integer.");

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -229,7 +229,7 @@ void encodeQSSCError(mlir::MLIRContext *context, mlir::Diagnostic *diagnostic,
                      ErrorCategory category) {
   auto builder = mlir::OpBuilder(context);
   const mlir::StringAttr key = builder.getStringAttr(ErrorCategoryAttrName);
-  const mlir::IntegerAttr value =
+  mlir::IntegerAttr const value =
       builder.getI32IntegerAttr(static_cast<int32_t>(category));
   auto attr = builder.getDictionaryAttr(builder.getNamedAttr(key, value));
   diagnostic->attachNote().append(attr);

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -20,10 +20,19 @@
 
 #include "API/errors.h"
 
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Operation.h"
+
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -36,6 +45,9 @@ std::string_view getErrorCategoryAsString(qssc::ErrorCategory category) {
   switch (category) {
   case ErrorCategory::OpenQASM3ParseFailure:
     return "OpenQASM 3 parse error";
+
+  case ErrorCategory::OpenQASM3UnsupportedInput:
+    return "OpenQASM 3 semantics are unsupported";
 
   case ErrorCategory::QSSCompilerError:
     return "Unknown compiler error";
@@ -133,6 +145,119 @@ llvm::Error emitDiagnostic(const OptDiagnosticCallback &onDiagnostic,
                            std::string message, std::error_code ec) {
   qssc::Diagnostic const diag{severity, category, std::move(message)};
   return emitDiagnostic(onDiagnostic, diag, ec);
+}
+
+namespace {
+std::string ErrorCategoryAttrName = "QSSCErrorCategory";
+
+// We decode the QSSC ErrorCategory as an attribute argument that a dictionary
+// attribute containing a named attribute that is an integer encoding the error
+// category enum value.
+std::optional<ErrorCategory> lookupErrorCategory(mlir::Diagnostic &diagnostic) {
+  for (const auto &note : diagnostic.getNotes()) {
+    for (const auto &arg : note.getArguments()) {
+      if (arg.getKind() ==
+          mlir::DiagnosticArgument::DiagnosticArgumentKind::Attribute) {
+        if (auto dictAttr =
+                arg.getAsAttribute().dyn_cast_or_null<mlir::DictionaryAttr>()) {
+          if (auto namedAttr = dictAttr.getNamed(ErrorCategoryAttrName)) {
+            if (auto catInt = namedAttr.value()
+                                  .getValue()
+                                  .dyn_cast<mlir::IntegerAttr>()) {
+              auto cat = static_cast<ErrorCategory>((uint32_t)catInt.getInt());
+              return cat;
+            }
+
+            llvm_unreachable("Invalid attribute type for error category. Must "
+                             "be an integer.");
+          }
+        }
+      }
+    }
+  }
+  // Not found
+  return std::nullopt;
+}
+
+} // anonymous namespace
+
+// We encode the QSSC ErrorCategory as an attribute argument that a dictionary
+// attribute containing a named attribute that is an integer encoding the error
+// category enum value.
+void encodeQSSCError(mlir::MLIRContext *context,
+                     mlir::InFlightDiagnostic &diagnostic,
+                     ErrorCategory category) {
+  return encodeQSSCError(context, diagnostic.getUnderlyingDiagnostic(),
+                         category);
+}
+
+void encodeQSSCError(mlir::MLIRContext *context, mlir::Diagnostic *diagnostic,
+                     ErrorCategory category) {
+  auto builder = mlir::OpBuilder(context);
+  mlir::StringAttr key = builder.getStringAttr(ErrorCategoryAttrName);
+  mlir::IntegerAttr value =
+      builder.getI32IntegerAttr(static_cast<int32_t>(category));
+  auto attr = builder.getDictionaryAttr(builder.getNamedAttr(key, value));
+  diagnostic->attachNote().append(attr);
+}
+
+std::optional<Diagnostic> decodeQSSCDiagnostic(mlir::Diagnostic &diagnostic) {
+  // map diagnostic severity to qssc severity
+  auto severity = diagnostic.getSeverity();
+  qssc::Severity qsscSeverity = qssc::Severity::Error;
+  switch (severity) {
+  case mlir::DiagnosticSeverity::Error:
+    qsscSeverity = qssc::Severity::Error;
+    break;
+  case mlir::DiagnosticSeverity::Warning:
+    qsscSeverity = qssc::Severity::Warning;
+    break;
+  case mlir::DiagnosticSeverity::Note:
+  case mlir::DiagnosticSeverity::Remark:
+    qsscSeverity = qssc::Severity::Info;
+  }
+
+  auto errorCategory = lookupErrorCategory(diagnostic);
+  if (errorCategory.has_value())
+    return Diagnostic(qsscSeverity, errorCategory.value(), diagnostic.str());
+
+  // Default error category for unspecified MLIR error diagnostics of Error
+  // severity.
+  if (qsscSeverity == qssc::Severity::Error)
+    return Diagnostic(qsscSeverity, ErrorCategory::QSSCompilationFailure,
+                      diagnostic.str());
+
+  return std::nullopt;
+}
+
+mlir::InFlightDiagnostic emitError(mlir::Operation *op, ErrorCategory category,
+                                   const llvm::Twine &message) {
+  auto diagnostic = op->emitError(message);
+  encodeQSSCError(op->getContext(), diagnostic, category);
+  return diagnostic;
+}
+
+mlir::InFlightDiagnostic emitOpError(mlir::Operation *op,
+                                     ErrorCategory category,
+                                     const llvm::Twine &message) {
+  auto diagnostic = op->emitOpError(message);
+  encodeQSSCError(op->getContext(), diagnostic, category);
+  return diagnostic;
+}
+
+mlir::InFlightDiagnostic emitRemark(mlir::Operation *op, ErrorCategory category,
+                                    const llvm::Twine &message) {
+  auto diagnostic = op->emitRemark(message);
+  encodeQSSCError(op->getContext(), diagnostic, category);
+  return diagnostic;
+}
+
+mlir::InFlightDiagnostic emitWarning(mlir::Operation *op,
+                                     ErrorCategory category,
+                                     const llvm::Twine &message) {
+  auto diagnostic = op->emitWarning(message);
+  encodeQSSCError(op->getContext(), diagnostic, category);
+  return diagnostic;
 }
 
 } // namespace qssc

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -228,7 +228,7 @@ void encodeQSSCError(mlir::MLIRContext *context,
 void encodeQSSCError(mlir::MLIRContext *context, mlir::Diagnostic *diagnostic,
                      ErrorCategory category) {
   auto builder = mlir::OpBuilder(context);
-  const mlir::StringAttr key = builder.getStringAttr(ErrorCategoryAttrName);
+  mlir::StringAttr const key = builder.getStringAttr(ErrorCategoryAttrName);
   mlir::IntegerAttr const value =
       builder.getI32IntegerAttr(static_cast<int32_t>(category));
   auto attr = builder.getDictionaryAttr(builder.getNamedAttr(key, value));

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -150,10 +150,9 @@ llvm::Error emitDiagnostic(const OptDiagnosticCallback &onDiagnostic,
   return emitDiagnostic(onDiagnostic, diag, ec);
 }
 
-namespace {
 std::string ErrorCategoryAttrName = "QSSCErrorCategory";
 
-std::optional<ErrorCategory>
+static std::optional<ErrorCategory>
 getQSSCDiagnosticCategory(mlir::DiagnosticArgument &arg) {
   if (arg.getKind() ==
       mlir::DiagnosticArgument::DiagnosticArgumentKind::Attribute) {
@@ -175,7 +174,7 @@ getQSSCDiagnosticCategory(mlir::DiagnosticArgument &arg) {
 // We decode the QSSC ErrorCategory as an attribute argument that a dictionary
 // attribute containing a named attribute that is an integer encoding the error
 // category enum value.
-std::optional<ErrorCategory> lookupErrorCategory(mlir::Diagnostic &diagnostic) {
+static std::optional<ErrorCategory> lookupErrorCategory(mlir::Diagnostic &diagnostic) {
   for (auto &note : diagnostic.getNotes()) {
     for (auto &arg : note.getArguments())
       if (auto cat = getQSSCDiagnosticCategory(arg))
@@ -187,7 +186,7 @@ std::optional<ErrorCategory> lookupErrorCategory(mlir::Diagnostic &diagnostic) {
 
 // Recursively populate diagnostic (including notes except those that are for
 // the QSSC error category)
-void populateDiagnosticIgnoringQSSC(mlir::Diagnostic &from,
+static void populateDiagnosticIgnoringQSSC(mlir::Diagnostic &from,
                                     mlir::Diagnostic &to) {
   for (auto &arg : from.getArguments()) {
     // Do not copy diagnostic category
@@ -210,8 +209,6 @@ void populateDiagnosticIgnoringQSSC(mlir::Diagnostic &from,
     }
   }
 }
-
-} // anonymous namespace
 
 // We encode the QSSC ErrorCategory as an attribute argument that a dictionary
 // attribute containing a named attribute that is an integer encoding the error

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -228,8 +228,8 @@ void encodeQSSCError(mlir::MLIRContext *context,
 void encodeQSSCError(mlir::MLIRContext *context, mlir::Diagnostic *diagnostic,
                      ErrorCategory category) {
   auto builder = mlir::OpBuilder(context);
-  mlir::StringAttr key = builder.getStringAttr(ErrorCategoryAttrName);
-  mlir::IntegerAttr value =
+  const mlir::StringAttr key = builder.getStringAttr(ErrorCategoryAttrName);
+  const mlir::IntegerAttr value =
       builder.getI32IntegerAttr(static_cast<int32_t>(category));
   auto attr = builder.getDictionaryAttr(builder.getNamedAttr(key, value));
   diagnostic->attachNote().append(attr);

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -174,7 +174,8 @@ getQSSCDiagnosticCategory(mlir::DiagnosticArgument &arg) {
 // We decode the QSSC ErrorCategory as an attribute argument that a dictionary
 // attribute containing a named attribute that is an integer encoding the error
 // category enum value.
-static std::optional<ErrorCategory> lookupErrorCategory(mlir::Diagnostic &diagnostic) {
+static std::optional<ErrorCategory>
+lookupErrorCategory(mlir::Diagnostic &diagnostic) {
   for (auto &note : diagnostic.getNotes()) {
     for (auto &arg : note.getArguments())
       if (auto cat = getQSSCDiagnosticCategory(arg))
@@ -187,7 +188,7 @@ static std::optional<ErrorCategory> lookupErrorCategory(mlir::Diagnostic &diagno
 // Recursively populate diagnostic (including notes except those that are for
 // the QSSC error category)
 static void populateDiagnosticIgnoringQSSC(mlir::Diagnostic &from,
-                                    mlir::Diagnostic &to) {
+                                           mlir::Diagnostic &to) {
   for (auto &arg : from.getArguments()) {
     // Do not copy diagnostic category
     if (!getQSSCDiagnosticCategory(arg).has_value())

--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -190,9 +190,14 @@ llvm::Error qssc::frontend::openqasm3::parse(mlir::MLIRContext *context,
 
         auto &diagEngine = MLIRContext_->getDiagEngine();
         auto inflightDiag = diagEngine.emit(sourceLoc, diagLevel);
-        encodeQSSCError(MLIRContext_, inflightDiag,
-                        qssc::ErrorCategory::OpenQASM3ParseFailure);
-        inflightDiag << "While parsing OpenQASM3 input: " << msg;
+
+        // Currently we only report QSSC diagnostics for errors
+        // as the parser emits too much noise at warning level.
+        // TODO: Remove warning noise and return all diagnostics.
+        if (diagLevel == mlir::DiagnosticSeverity::Error)
+          encodeQSSCError(MLIRContext_, inflightDiag,
+                          qssc::ErrorCategory::OpenQASM3ParseFailure);
+        inflightDiag << msg;
         inflightDiag.report();
 
         if (qasmDiagLevel == QASM::QasmDiagnosticEmitter::DiagLevel::Error ||

--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -30,6 +30,9 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/LogicalResult.h"
@@ -39,11 +42,9 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Support/SMLoc.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include <cassert>
 #include <exception>
 #include <iostream>
 #include <memory>

--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -183,15 +183,16 @@ llvm::Error qssc::frontend::openqasm3::parse(
 
         std::string errMsg;
         llvm::raw_string_ostream ostream(errMsg);
-        sourceMgr.PrintMessage(ostream, loc, sourceMgrDiagKind, "While parsing OpenQASM3 input: \n" + Msg + "\n");
+        sourceMgr.PrintMessage(ostream, loc, sourceMgrDiagKind,
+                               "While parsing OpenQASM3 input: \n" + Msg +
+                                   "\n");
 
         llvm::errs() << errMsg << "\n";
 
         if (diagnosticCallback_ and (diagLevel == qssc::Severity::Error or
                                      diagLevel == qssc::Severity::Fatal)) {
           qssc::Diagnostic const diag{
-              diagLevel, qssc::ErrorCategory::OpenQASM3ParseFailure,
-              errMsg};
+              diagLevel, qssc::ErrorCategory::OpenQASM3ParseFailure, errMsg};
           (*diagnosticCallback_)(diag);
         }
 

--- a/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
+++ b/lib/Frontend/OpenQASM3/OpenQASM3Frontend.cpp
@@ -56,7 +56,6 @@
 #include <qasm/Frontend/QasmParser.h>
 #include <qasm/QPP/QasmPP.h>
 #include <regex>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <sys/types.h>

--- a/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
@@ -39,7 +39,7 @@
 
 #include "Frontend/OpenQASM3/QUIRGenQASM3Visitor.h"
 
-#include "Api/errors.h"
+#include "API/errors.h"
 #include "Dialect/OQ3/IR/OQ3Ops.h"
 #include "Dialect/QCS/IR/QCSAttributes.h"
 #include "Dialect/QCS/IR/QCSOps.h"

--- a/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
@@ -335,13 +335,17 @@ mlir::LogicalResult QUIRGenQASM3Visitor::walkAST() {
 
 mlir::InFlightDiagnostic
 QUIRGenQASM3Visitor::reportError(ASTBase const *location,
-                                 mlir::DiagnosticSeverity severity) {
+                                 mlir::DiagnosticSeverity severity, qssc::ErrorCategory qsscErrorCategory) {
 
   DiagnosticEngine &engine = builder.getContext()->getDiagEngine();
 
   if (severity == mlir::DiagnosticSeverity::Error)
     hasFailed = true;
-  return engine.emit(getLocation(location), severity);
+
+  // Create a MLIRQSSCDiagnostic such that the diagnostic will be properly reported by the
+  // compilers diagnostic handling APIs.
+  auto diagnostic = qssc::MLIRQSSCDiagnostic(getLocation(location), severity, qsscErrorCategory);
+  return engine.emit(std::move(diagnostic));
 }
 
 void QUIRGenQASM3Visitor::visit(const ASTForStatementNode *node) {

--- a/python_lib/qss_compiler/compile.py
+++ b/python_lib/qss_compiler/compile.py
@@ -61,7 +61,7 @@ from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 from . import exceptions
-from .py_qssc import _compile_bytes, _compile_file, Diagnostic, ErrorCategory
+from .py_qssc import _compile_bytes, _compile_file, Diagnostic
 
 # use the forkserver context to create a server process
 # for forking new compiler processes
@@ -289,27 +289,8 @@ class _CompilationManager:
                     return_diagnostics=self.return_diagnostics,
                 )
 
-            # Place all higher-level diagnostics related to user input here
-            # TODO: Best way to deal with multiple diagnostics?
-            for diag in diagnostics:
-                if diag.category == ErrorCategory.QSSCompilerSequenceTooLong:
-                    raise exceptions.QSSCompilerSequenceTooLong(
-                        diag.message,
-                        diagnostics,
-                        return_diagnostics=self.return_diagnostics,
-                    )
-                if diag.category == ErrorCategory.QSSControlSystemResourcesExceeded:
-                    raise exceptions.QSSControlSystemResourcesExceeded(
-                        diag.message,
-                        diagnostics,
-                        return_diagnostics=self.return_diagnostics,
-                    )
-                if diag.category == ErrorCategory.OpenQASM3ParseFailure:
-                    raise exceptions.OpenQASM3ParseFailure(
-                        diag.message,
-                        diagnostics,
-                        return_diagnostics=self.return_diagnostics,
-                    )
+            # Convert diagnostics to Python exceptions if necessary
+            exceptions.raise_diagnostics(diagnostics, return_diagnostics=self.return_diagnostics)
 
             if not success:
                 raise exceptions.QSSCompilationFailure(

--- a/python_lib/qss_compiler/examples/parse.py
+++ b/python_lib/qss_compiler/examples/parse.py
@@ -22,7 +22,6 @@ from qss_compiler.mlir.ir import Context, Module
 from qss_compiler.mlir.dialects import pulse, quir
 
 with Context() as ctx:
-
     pulse.pulse.register_dialect()
     quir.quir.register_dialect()
 

--- a/python_lib/qss_compiler/examples/pulse.py
+++ b/python_lib/qss_compiler/examples/pulse.py
@@ -34,7 +34,6 @@ samples_2d[:, 1] = np.imag(samples)
 
 
 with Context() as ctx:
-
     pulse.pulse.register_dialect()
     quir.quir.register_dialect()
 
@@ -55,7 +54,6 @@ with Context() as ctx:
             mainFunc.add_entry_block()
 
         with InsertionPoint(module.body):
-
             seq1 = pulse.SequenceOp("seq_1", [wf, wf, mf, mf], [i1])
             seq1.add_entry_block()
 

--- a/python_lib/qss_compiler/exceptions.py
+++ b/python_lib/qss_compiler/exceptions.py
@@ -129,6 +129,15 @@ class OpenQASM3UnsupportedInput(QSSCompilerError):
     compiler."""
 
 
+# Map diagnostic categories to compiler exceptions
+category_exception_map = {
+    ErrorCategory.QSSCompilerSequenceTooLong: QSSCompilerSequenceTooLong,
+    ErrorCategory.QSSControlSystemResourcesExceeded: QSSControlSystemResourcesExceeded,
+    ErrorCategory.OpenQASM3ParseFailure: OpenQASM3ParseFailure,
+    ErrorCategory.OpenQASM3UnsupportedInput: OpenQASM3UnsupportedInput,
+}
+
+
 def convert_diagnostics_to_exception(
     diagnostics: Iterable[Diagnostic], return_diagnostics: bool = False
 ) -> QSSCompilerError:
@@ -146,20 +155,9 @@ def convert_diagnostics_to_exception(
         # Do not double print diagnostic message
         msg = "" if return_diagnostics else diag.message
 
-        if diag.category == QSSCompilerSequenceTooLong:
-            return QSSCompilerSequenceTooLong(
-                msg,
-                diagnostics,
-                return_diagnostics=return_diagnostics,
-            )
-        if diag.category == ErrorCategory.QSSControlSystemResourcesExceeded:
-            return QSSControlSystemResourcesExceeded(
-                msg,
-                diagnostics,
-                return_diagnostics=return_diagnostics,
-            )
-        if diag.category == ErrorCategory.OpenQASM3ParseFailure:
-            return OpenQASM3ParseFailure(
+        exception_class = category_exception_map.get(diag.category, None)
+        if exception_class:
+            return exception_class(
                 msg,
                 diagnostics,
                 return_diagnostics=return_diagnostics,

--- a/python_lib/qss_compiler/exceptions.py
+++ b/python_lib/qss_compiler/exceptions.py
@@ -119,3 +119,7 @@ class QSSControlSystemResourcesExceeded(QSSCompilerError):
 
 class OpenQASM3ParseFailure(QSSCompilerError):
     """Raised when a parser failure is received"""
+
+
+class OpenQASM3UnsupportedInput(QSSCompilerError):
+    """Raised when provided Openqasm 3 input has semantics that are not supported by the compiler."""

--- a/python_lib/qss_compiler/lib.cpp
+++ b/python_lib/qss_compiler/lib.cpp
@@ -196,8 +196,10 @@ py::tuple py_compile_bytes(const std::string &bytes,
                            qssc::DiagnosticCallback onDiagnostic) {
 
   // Set up the input file.
+  // <stdin> is treated specially for diagnostic handling
+  // so assign buffer identifier.
   std::unique_ptr<llvm::MemoryBuffer> input =
-      llvm::MemoryBuffer::getMemBuffer(bytes);
+      llvm::MemoryBuffer::getMemBuffer(bytes, "<stdin>");
 
   return compileOptionalOutput(outputFile, std::move(input), args,
                                std::move(onDiagnostic));

--- a/python_lib/qss_compiler/lib_enums.cpp
+++ b/python_lib/qss_compiler/lib_enums.cpp
@@ -15,7 +15,6 @@ void addErrorCategory(py::module &m) {
   py::enum_<qssc::ErrorCategory>(m, "ErrorCategory", py::arithmetic())
       .value("OpenQASM3ParseFailure",
              qssc::ErrorCategory::OpenQASM3ParseFailure)
-      .value("OpenQASM3UnsupportedInput", qssc::ErrorCategory::OpenQASM3UnsupportedInput)
       .value("QSSCompilerError", qssc::ErrorCategory::QSSCompilerError)
       .value("QSSCompilerNoInputError",
              qssc::ErrorCategory::QSSCompilerNoInputError)
@@ -44,6 +43,8 @@ void addErrorCategory(py::module &m) {
              qssc::ErrorCategory::QSSLinkInvalidPatchTypeError)
       .value("QSSControlSystemResourcesExceeded",
              qssc::ErrorCategory::QSSControlSystemResourcesExceeded)
+      .value("OpenQASM3UnsupportedInput",
+             qssc::ErrorCategory::OpenQASM3UnsupportedInput)
       .value("UncategorizedError", qssc::ErrorCategory::UncategorizedError)
       .export_values();
 }

--- a/python_lib/qss_compiler/lib_enums.cpp
+++ b/python_lib/qss_compiler/lib_enums.cpp
@@ -45,7 +45,7 @@ void addErrorCategory(py::module &m) {
              qssc::ErrorCategory::QSSControlSystemResourcesExceeded)
       .value("QSSTargetUnsupportedOperation",
              qssc::ErrorCategory::QSSTargetUnsupportedOperation)
-       .value("OpenQASM3UnsupportedInput",
+      .value("OpenQASM3UnsupportedInput",
              qssc::ErrorCategory::OpenQASM3UnsupportedInput)
       .value("UncategorizedError", qssc::ErrorCategory::UncategorizedError)
       .export_values();

--- a/python_lib/qss_compiler/lib_enums.cpp
+++ b/python_lib/qss_compiler/lib_enums.cpp
@@ -15,6 +15,7 @@ void addErrorCategory(py::module &m) {
   py::enum_<qssc::ErrorCategory>(m, "ErrorCategory", py::arithmetic())
       .value("OpenQASM3ParseFailure",
              qssc::ErrorCategory::OpenQASM3ParseFailure)
+      .value("OpenQASM3UnsupportedInput", qssc::ErrorCategory::OpenQASM3UnsupportedInput)
       .value("QSSCompilerError", qssc::ErrorCategory::QSSCompilerError)
       .value("QSSCompilerNoInputError",
              qssc::ErrorCategory::QSSCompilerNoInputError)

--- a/python_lib/qss_compiler/link.py
+++ b/python_lib/qss_compiler/link.py
@@ -135,7 +135,6 @@ def link_file(
             link_options.on_diagnostic,
         )
         if not success:
-
             exception_mapping = {
                 ErrorCategory.QSSLinkerNotImplemented: exceptions.QSSLinkerNotImplemented,
                 ErrorCategory.QSSLinkSignatureWarning: exceptions.QSSLinkSignatureWarning,

--- a/releasenotes/notes/add-qssc-error-reporting-mechanisms-82fa32e30d30ccce.yaml
+++ b/releasenotes/notes/add-qssc-error-reporting-mechanisms-82fa32e30d30ccce.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    Added the ability to easily return QSSC diagnostics from the standard MLIR diagnostic mechanisms
+    and callback handlers through easy to use helper methods. It is now possible to write code like:
+
+    .. code-block:: cpp
+
+        qssc::emitError(op, qssc::ErrorCategory::OpenQASM3UnsupportedInput) << "Error message \n";
+
+    The diagnostic will be treated like a normal MLIR diagnostic but will also encode the QSSC
+    information to be decoded by the compiler's diagnostic handlers.
+

--- a/releasenotes/notes/add-qssc-error-reporting-mechanisms-82fa32e30d30ccce.yaml
+++ b/releasenotes/notes/add-qssc-error-reporting-mechanisms-82fa32e30d30ccce.yaml
@@ -10,4 +10,3 @@ features:
 
     The diagnostic will be treated like a normal MLIR diagnostic but will also encode the QSSC
     information to be decoded by the compiler's diagnostic handlers.
-

--- a/releasenotes/notes/add-unsupported-openqasm3-input-a584bb990cd9c9ff.yaml
+++ b/releasenotes/notes/add-unsupported-openqasm3-input-a584bb990cd9c9ff.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    A new diagnostic has been added for unsupported OpenQASM 3 semantics - ``OpenQASM3UnsupportedInput``.
+    This should be raised when the input OpenQASM 3 semantics are not valid for the compiler.
+

--- a/releasenotes/notes/add-unsupported-openqasm3-input-a584bb990cd9c9ff.yaml
+++ b/releasenotes/notes/add-unsupported-openqasm3-input-a584bb990cd9c9ff.yaml
@@ -3,4 +3,3 @@ features:
   - |
     A new diagnostic has been added for unsupported OpenQASM 3 semantics - ``OpenQASM3UnsupportedInput``.
     This should be raised when the input OpenQASM 3 semantics are not valid for the compiler.
-

--- a/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.cpp
+++ b/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.cpp
@@ -45,13 +45,14 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/DialectRegistry.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <cstdint>
 #include <utility>
@@ -220,7 +221,7 @@ void conversion::MockQUIRToStdPass::getDependentDialects(
 }
 
 void MockQUIRToStdPass::runOnOperation(MockSystem &system) {
-  ModuleOp moduleOp = getOperation();
+  const ModuleOp moduleOp = getOperation();
 
   // First remove all arguments from synchronization ops
   moduleOp->walk([](qcs::SynchronizeOp synchOp) {

--- a/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.cpp
+++ b/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.cpp
@@ -189,29 +189,29 @@ struct CommOpConversionPat : public OpConversionPattern<CommOp> {
 // Remaining operation conversion pattern
 class RemainingOpConversionPat : public ConversionPattern {
 
-  public:
-    RemainingOpConversionPat(MLIRContext *ctx, QuirTypeConverter &typeConverter)
-        : ConversionPattern(RewritePattern::MatchAnyOpTypeTag(), /*benefit=*/1, ctx) {}
+public:
+  RemainingOpConversionPat(MLIRContext *ctx, QuirTypeConverter &typeConverter)
+      : ConversionPattern(RewritePattern::MatchAnyOpTypeTag(), /*benefit=*/1,
+                          ctx) {}
 
-    LogicalResult
-    matchAndRewrite(Operation *op, ArrayRef<Value> operands, ConversionPatternRewriter &rewriter) const override {
-      if (llvm::isa<oq3::OQ3Dialect>(op->getDialect()) ||
-            llvm::isa<quir::QUIRDialect>(op->getDialect()) ||
-            llvm::isa<qcs::QCSDialect>(op->getDialect())) {
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (llvm::isa<oq3::OQ3Dialect>(op->getDialect()) ||
+        llvm::isa<quir::QUIRDialect>(op->getDialect()) ||
+        llvm::isa<qcs::QCSDialect>(op->getDialect())) {
 
-          for (auto *user : op->getUsers()) {
-            rewriter.eraseOp(user);
-          }
+      for (auto *user : op->getUsers())
+        rewriter.eraseOp(user);
 
-          rewriter.eraseOp(op);
-          return success();
-      }
+      rewriter.eraseOp(op);
+      return success();
+    }
 
-      // attribute type is not handled (for now)
-      return failure();
-    } // matchAndRewrite
+    // attribute type is not handled (for now)
+    return failure();
+  } // matchAndRewrite
 };  // struct RemainingOpConversionPat
-
 
 void conversion::MockQUIRToStdPass::getDependentDialects(
     DialectRegistry &registry) const {

--- a/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.cpp
+++ b/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.cpp
@@ -186,6 +186,33 @@ struct CommOpConversionPat : public OpConversionPattern<CommOp> {
   } // matchAndRewrite
 };  // struct CommOpConversionPat
 
+// Remaining operation conversion pattern
+class RemainingOpConversionPat : public ConversionPattern {
+
+  public:
+    RemainingOpConversionPat(MLIRContext *ctx, QuirTypeConverter &typeConverter)
+        : ConversionPattern(RewritePattern::MatchAnyOpTypeTag(), /*benefit=*/1, ctx) {}
+
+    LogicalResult
+    matchAndRewrite(Operation *op, ArrayRef<Value> operands, ConversionPatternRewriter &rewriter) const override {
+      if (llvm::isa<oq3::OQ3Dialect>(op->getDialect()) ||
+            llvm::isa<quir::QUIRDialect>(op->getDialect()) ||
+            llvm::isa<qcs::QCSDialect>(op->getDialect())) {
+
+          for (auto *user : op->getUsers()) {
+            rewriter.eraseOp(user);
+          }
+
+          rewriter.eraseOp(op);
+          return success();
+      }
+
+      // attribute type is not handled (for now)
+      return failure();
+    } // matchAndRewrite
+};  // struct RemainingOpConversionPat
+
+
 void conversion::MockQUIRToStdPass::getDependentDialects(
     DialectRegistry &registry) const {
   registry.insert<LLVM::LLVMDialect, mlir::memref::MemRefDialect,
@@ -251,7 +278,8 @@ void MockQUIRToStdPass::runOnOperation(MockSystem &system) {
                AngleBinOpConversionPat<oq3::AngleAddOp, mlir::arith::AddIOp>,
                AngleBinOpConversionPat<oq3::AngleSubOp, mlir::arith::SubIOp>,
                AngleBinOpConversionPat<oq3::AngleMulOp, mlir::arith::MulIOp>,
-               AngleBinOpConversionPat<oq3::AngleDivOp, mlir::arith::DivSIOp>>(
+               AngleBinOpConversionPat<oq3::AngleDivOp, mlir::arith::DivSIOp>,
+               RemainingOpConversionPat>(
       context, typeConverter);
   // clang-format on
 
@@ -261,19 +289,7 @@ void MockQUIRToStdPass::runOnOperation(MockSystem &system) {
   // With the target and rewrite patterns defined, we can now attempt the
   // conversion. The conversion will signal failure if any of our `illegal`
   // operations were not converted successfully.
-  if (failed(applyPartialConversion(moduleOp, target, std::move(patterns)))) {
-    // If we fail conversion remove remaining ops for the Mock target.
-    moduleOp.walk([&](Operation *op) {
-      if (llvm::isa<oq3::OQ3Dialect>(op->getDialect()) ||
-          llvm::isa<quir::QUIRDialect>(op->getDialect()) ||
-          llvm::isa<qcs::QCSDialect>(op->getDialect())) {
-        llvm::outs() << "Removing unsupported " << op->getName() << " \n";
-        op->dropAllReferences();
-        op->dropAllDefinedValueUses();
-        op->erase();
-      }
-    });
-  }
+  applyPartialConversion(moduleOp, target, std::move(patterns));
 } // QUIRToStdPass::runOnOperation()
 
 llvm::StringRef MockQUIRToStdPass::getArgument() const {

--- a/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.cpp
+++ b/targets/systems/mock/Conversion/QUIRToStandard/QUIRToStandard.cpp
@@ -47,10 +47,10 @@
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/ValueRange.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
 
-#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
 

--- a/targets/systems/mock/Transforms/QubitLocalization.cpp
+++ b/targets/systems/mock/Transforms/QubitLocalization.cpp
@@ -42,6 +42,7 @@
 #include "mlir/IR/TypeRange.h"
 #include "mlir/IR/Types.h"
 #include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/LLVM.h"
 
@@ -197,7 +198,7 @@ auto mock::MockQubitLocalizationPass::addMainFunction(
   if (addReturn) {
     OpBuilder mainBuilder(funcOp.getBody());
     auto intAttr = mainBuilder.getI32IntegerAttr(0);
-    mlir::Value intConstVal = mainBuilder.create<mlir::arith::ConstantOp>(
+    const mlir::Value intConstVal = mainBuilder.create<mlir::arith::ConstantOp>(
         loc, mainBuilder.getI32Type(), intAttr);
     auto range = mlir::ValueRange(intConstVal);
     mainBuilder.create<mlir::func::ReturnOp>(loc, range);

--- a/targets/systems/mock/Transforms/QubitLocalization.cpp
+++ b/targets/systems/mock/Transforms/QubitLocalization.cpp
@@ -182,7 +182,8 @@ void mock::MockQubitLocalizationPass::cloneRegionWithoutOps(
 } // cloneRegionWithoutOps
 
 auto mock::MockQubitLocalizationPass::addMainFunction(
-    Operation *moduleOperation, const Location &loc, bool addReturn) -> mlir::func::FuncOp {
+    Operation *moduleOperation, const Location &loc, bool addReturn)
+    -> mlir::func::FuncOp {
   OpBuilder b(moduleOperation->getRegion(0));
   auto funcOp = b.create<mlir::func::FuncOp>(
       loc, "main",
@@ -813,8 +814,8 @@ void mock::MockQubitLocalizationPass::runOnOperation(MockSystem &target) {
         llvm::StringRef("quir.physicalId"),
         controllerBuilder->getI32IntegerAttr(qubitIdx));
     mockModules[nodeId] = driveMod.getOperation();
-    mlir::func::FuncOp mockMainOp =
-        addMainFunction(driveMod.getOperation(), mainFunc->getLoc(), /*addReturn=*/isUnused);
+    mlir::func::FuncOp mockMainOp = addMainFunction(
+        driveMod.getOperation(), mainFunc->getLoc(), /*addReturn=*/isUnused);
     newBuilders->emplace(nodeId, new OpBuilder(mockMainOp.getBody()));
   }
 
@@ -842,8 +843,8 @@ void mock::MockQubitLocalizationPass::runOnOperation(MockSystem &target) {
         controllerBuilder->getI32ArrayAttr(
             ArrayRef<int>(config->acquireQubits(nodeId))));
     mockModules[nodeId] = acquireMod.getOperation();
-    mlir::func::FuncOp mockMainOp =
-        addMainFunction(acquireMod.getOperation(), mainFunc->getLoc(), /*addReturn=*/isUnused);
+    mlir::func::FuncOp mockMainOp = addMainFunction(
+        acquireMod.getOperation(), mainFunc->getLoc(), /*addReturn=*/isUnused);
     newBuilders->emplace(nodeId, new OpBuilder(mockMainOp.getBody()));
   }
 
@@ -914,7 +915,7 @@ void mock::MockQubitLocalizationPass::runOnOperation(MockSystem &target) {
     // delete the allocated opbuilders
     // TODO: use smart pointers to manage lifetimes
     delete controllerBuilder;
-    for (const auto &pair : *mockBuilders )
+    for (const auto &pair : *mockBuilders)
       delete pair.second;
     delete mockBuilders;
   } // while !blockAndBuilderWorklist.empty()

--- a/targets/systems/mock/Transforms/QubitLocalization.h
+++ b/targets/systems/mock/Transforms/QubitLocalization.h
@@ -87,7 +87,8 @@ struct MockQubitLocalizationPass
                              mlir::Region::iterator destPos,
                              mlir::IRMapping &mapper);
   auto addMainFunction(mlir::Operation *moduleOperation,
-                       const mlir::Location &loc, bool addReturn = false) -> mlir::func::FuncOp;
+                       const mlir::Location &loc, bool addReturn = false)
+      -> mlir::func::FuncOp;
   void cloneVariableDeclarations(mlir::ModuleOp topModuleOp);
 
   MockConfig *config;

--- a/targets/systems/mock/Transforms/QubitLocalization.h
+++ b/targets/systems/mock/Transforms/QubitLocalization.h
@@ -87,7 +87,7 @@ struct MockQubitLocalizationPass
                              mlir::Region::iterator destPos,
                              mlir::IRMapping &mapper);
   auto addMainFunction(mlir::Operation *moduleOperation,
-                       const mlir::Location &loc) -> mlir::func::FuncOp;
+                       const mlir::Location &loc, bool addReturn = false) -> mlir::func::FuncOp;
   void cloneVariableDeclarations(mlir::ModuleOp topModuleOp);
 
   MockConfig *config;

--- a/targets/systems/mock/test/python_lib/test_compile_mock.py
+++ b/targets/systems/mock/test/python_lib/test_compile_mock.py
@@ -25,11 +25,11 @@ from qss_compiler import (
     compile_file_async,
     compile_str,
     compile_str_async,
+    exceptions,
     InputType,
     OutputType,
     CompileOptions,
 )
-from qss_compiler.exceptions import QSSCompilationFailure
 
 compiler_extra_args = ["--enable-circuits=false"]
 
@@ -136,7 +136,7 @@ def test_compile_failing_str_to_qem(
     """Test that compiling an invalid OpenQASM3 string via the interface
     compile_str to a QEM payload will fail and result in an empty payload."""
 
-    with pytest.raises(QSSCompilationFailure):
+    with pytest.raises(exceptions.OpenQASM3UnsupportedInput):
         compile_str(
             example_unsupported_qasm3_str,
             input_type=InputType.QASM3,
@@ -154,7 +154,7 @@ def test_compile_failing_file_to_qem(
     """Test that compiling an invalid file input via the interface compile_file
     to a QEM payload will fail and result in an empty payload."""
 
-    with pytest.raises(QSSCompilationFailure):
+    with pytest.raises(exceptions.OpenQASM3UnsupportedInput):
         compile_file(
             example_unsupported_qasm3_tmpfile,
             input_type=InputType.QASM3,

--- a/test/Frontend/OpenQASM3/diagnostics-parse-error.qasm
+++ b/test/Frontend/OpenQASM3/diagnostics-parse-error.qasm
@@ -1,0 +1,16 @@
+OPENQASM 3.0;
+// Ensure piping of input also works with diagnostics.
+// TODO: Once https://github.com/openqasm/qe-qasm/issues/35
+// is fixed this test will error and the workaround
+// in OpenQASM3Frontend.cpp for line number offsets
+// will need to be removed for the test to pass.
+// RUN: cat %s | ( qss-compiler -X=qasm --emit=mlir || true ) 2>&1 | FileCheck %s --dump-input=fail
+// RUN: ( qss-compiler -X=qasm --emit=mlir %s || true ) 2>&1 | FileCheck %s --dump-input=fail
+
+int a;
+int b;
+
+a &&& b;
+// CHECK: error: While parsing OpenQASM3 input: syntax error, unexpected '&'
+// CHECK: a &&& b;
+// CHECK:     ^

--- a/test/Frontend/OpenQASM3/diagnostics-parse-error.qasm
+++ b/test/Frontend/OpenQASM3/diagnostics-parse-error.qasm
@@ -11,6 +11,6 @@ int a;
 int b;
 
 a &&& b;
-// CHECK: 13:5: error: While parsing OpenQASM3 input: syntax error, unexpected '&'
+// CHECK: 13:5: error: syntax error, unexpected '&'
 // CHECK: a &&& b;
 // CHECK:     ^

--- a/test/Frontend/OpenQASM3/diagnostics-parse-error.qasm
+++ b/test/Frontend/OpenQASM3/diagnostics-parse-error.qasm
@@ -11,6 +11,6 @@ int a;
 int b;
 
 a &&& b;
-// CHECK: error: While parsing OpenQASM3 input: syntax error, unexpected '&'
+// CHECK: 13:5: error: While parsing OpenQASM3 input: syntax error, unexpected '&'
 // CHECK: a &&& b;
 // CHECK:     ^

--- a/test/Frontend/OpenQASM3/diagnostics-parse-error.qasm
+++ b/test/Frontend/OpenQASM3/diagnostics-parse-error.qasm
@@ -4,8 +4,8 @@ OPENQASM 3.0;
 // is fixed this test will error and the workaround
 // in OpenQASM3Frontend.cpp for line number offsets
 // will need to be removed for the test to pass.
-// RUN: cat %s | ( qss-compiler -X=qasm --emit=mlir || true ) 2>&1 | FileCheck %s --dump-input=fail
-// RUN: ( qss-compiler -X=qasm --emit=mlir %s || true ) 2>&1 | FileCheck %s --dump-input=fail
+// RUN: cat %s | ( qss-compiler -X=qasm --emit=mlir || true ) 2>&1 | FileCheck %s
+// RUN: ( qss-compiler -X=qasm --emit=mlir %s || true ) 2>&1 | FileCheck %s
 
 int a;
 int b;

--- a/test/Frontend/OpenQASM3/diagnostics-unsupported-error.qasm
+++ b/test/Frontend/OpenQASM3/diagnostics-unsupported-error.qasm
@@ -1,0 +1,21 @@
+OPENQASM 3.0;
+// Ensure piping of input also works with diagnostics.
+// TODO: Once https://github.com/openqasm/qe-qasm/issues/35
+// is fixed this test will error and the workaround
+// in QUIRGenQASM3Visitor.cpp
+// for line number offsets
+// will need to be removed for the test to pass.
+// RUN: cat %s | ( qss-compiler -X=qasm --emit=mlir || true ) 2>&1 | FileCheck %s --dump-input=fail
+// RUN: ( qss-compiler -X=qasm --emit=mlir %s  || true ) 2>&1 | FileCheck %s --dump-input=fail
+
+int a;
+float b;
+int c;
+c =  float(a) + b;
+
+// CHECK: error: Unsupported cast destination type ASTTypeFloat
+// CHECK: c =  float(a) + b;
+// CHECK:      ^
+// CHECK: error: Addition is not supported on value of type: 'none'
+// CHECK: c =  float(a) + b;
+// CHECK:      ^

--- a/test/Frontend/OpenQASM3/diagnostics-unsupported-error.qasm
+++ b/test/Frontend/OpenQASM3/diagnostics-unsupported-error.qasm
@@ -5,8 +5,8 @@ OPENQASM 3.0;
 // in QUIRGenQASM3Visitor.cpp
 // for line number offsets
 // will need to be removed for the test to pass.
-// RUN: cat %s | ( qss-compiler -X=qasm --emit=mlir || true ) 2>&1 | FileCheck %s --dump-input=fail
-// RUN: ( qss-compiler -X=qasm --emit=mlir %s  || true ) 2>&1 | FileCheck %s --dump-input=fail
+// RUN: cat %s | ( qss-compiler -X=qasm --emit=mlir || true ) 2>&1 | FileCheck %s
+// RUN: ( qss-compiler -X=qasm --emit=mlir %s  || true ) 2>&1 | FileCheck %s
 
 int a;
 float b;

--- a/test/python_lib/conftest.py
+++ b/test/python_lib/conftest.py
@@ -82,10 +82,10 @@ def example_unsupported_qasm3_str():
     c =  float(a) + b;
     """
 
+
 @pytest.fixture
 def example_unsupported_qasm3_tmpfile(tmp_path, example_unsupported_qasm3_str):
-    return __create_tmpfile(tmp_path, example_unsupported_qasm3)
-
+    return __create_tmpfile(tmp_path, example_unsupported_qasm3_str)
 
 
 @pytest.fixture
@@ -96,8 +96,3 @@ def example_warning_not_in_errors():
     rz(7.35196807786455) $0;
     rz(a) $0;
     """
-
-
-@pytest.fixture
-def example_unsupported_qasm3_tmpfile(tmp_path, example_unsupported_qasm3_str):
-    return __create_tmpfile(tmp_path, example_unsupported_qasm3_str)

--- a/test/python_lib/conftest.py
+++ b/test/python_lib/conftest.py
@@ -110,8 +110,3 @@ def example_incorrect_qasm3():
     bit b;
     b = measure $0;
     """
-
-
-@pytest.fixture
-def example_unsupported_qasm3_tmpfile(tmp_path, example_unsupported_qasm3_str):
-    return __create_tmpfile(tmp_path, example_unsupported_qasm3_str)

--- a/test/python_lib/conftest.py
+++ b/test/python_lib/conftest.py
@@ -82,6 +82,11 @@ def example_unsupported_qasm3_str():
     c =  float(a) + b;
     """
 
+@pytest.fixture
+def example_unsupported_qasm3_tmpfile(tmp_path, example_unsupported_qasm3_str):
+    return __create_tmpfile(tmp_path, example_unsupported_qasm3)
+
+
 
 @pytest.fixture
 def example_warning_not_in_errors():

--- a/test/python_lib/test_compile.py
+++ b/test/python_lib/test_compile.py
@@ -176,6 +176,44 @@ def test_compile_invalid_str(example_invalid_qasm3_str):
     assert "unknown version number" in str(compfail.value)
 
 
+def test_compile_unsupported_openqasm_file(example_unsupported_qasm3_tmpfile):
+    """Test that we can attempt to compile unsupported OpenQASM 3 and receive an
+    error"""
+
+    with pytest.raises(exceptions.OpenQASM3UnsupportedInput):
+        compile_file(
+            example_unsupported_qasm3_tmpfile,
+            return_diagnostics=True,  # For testing purposes
+            input_type=InputType.QASM3,
+            output_type=OutputType.MLIR,
+            output_file=None,
+        )
+
+
+def test_compile_unsupported_openqasm_str(example_unsupported_qasm3_str):
+    """Test that we can attempt to compile unsupported OpenQASM 3 and receive an
+    error"""
+
+    with pytest.raises(exceptions.OpenQASM3UnsupportedInput) as compfail:
+        compile_str(
+            example_unsupported_qasm3_str,
+            return_diagnostics=True,  # For testing purposes
+            input_type=InputType.QASM3,
+            output_type=OutputType.MLIR,
+            output_file=None,
+        )
+
+    assert hasattr(compfail.value, "diagnostics")
+
+    diags = compfail.value.diagnostics
+
+    assert any(
+        diag.severity == Severity.Error
+        and diag.category == ErrorCategory.OpenQASM3UnsupportedInput
+        for diag in diags
+    )
+
+
 def test_warning_not_in_errors(example_warning_not_in_errors):
     """Test that warnings are not included in error."""
 

--- a/test/python_lib/test_compile.py
+++ b/test/python_lib/test_compile.py
@@ -239,10 +239,9 @@ def test_warning_not_in_errors(example_warning_not_in_errors):
     assert any("OpenQASM 3 parse error" in str(diag) for diag in diags)
 
     # check string representation of the exception to contain diagnostic messages
-    assert (
-        "Non-existent angle a passed as angle argument to Gate Call." in str(compfail.value)
-        and "Angle value exceeds 2pi." not in str(compfail.value)
-    )
+    assert "Non-existent angle a passed as angle argument to Gate Call." in str(
+        compfail.value
+    ) and "Angle value exceeds 2pi." not in str(compfail.value)
 
 
 def test_incorrect_qasm3(example_incorrect_qasm3):
@@ -271,8 +270,9 @@ def test_incorrect_qasm3(example_incorrect_qasm3):
     assert any("OpenQASM 3 parse error" in str(diag) for diag in diags)
 
     # check string representation of the exception to contain diagnostic messages
-    assert "1 inconsistent parameters in the gate call for the corresponding gate definition" in str(
-        compfail.value
+    assert (
+        "1 inconsistent parameters in the gate call for the corresponding gate definition"
+        in str(compfail.value)
     )
 
 

--- a/test/python_lib/test_compile.py
+++ b/test/python_lib/test_compile.py
@@ -240,8 +240,7 @@ def test_warning_not_in_errors(example_warning_not_in_errors):
 
     # check string representation of the exception to contain diagnostic messages
     assert (
-        "Error: OpenQASM 3 parse error" in str(compfail.value)
-        and "Non-existent angle a passed as angle argument to Gate Call." in str(compfail.value)
+        "Non-existent angle a passed as angle argument to Gate Call." in str(compfail.value)
         and "Angle value exceeds 2pi." not in str(compfail.value)
     )
 
@@ -272,9 +271,7 @@ def test_incorrect_qasm3(example_incorrect_qasm3):
     assert any("OpenQASM 3 parse error" in str(diag) for diag in diags)
 
     # check string representation of the exception to contain diagnostic messages
-    assert "Error: OpenQASM 3 parse error" in str(
-        compfail.value
-    ) and "1 inconsistent parameters in the gate call for the corresponding gate definition" in str(
+    assert "1 inconsistent parameters in the gate call for the corresponding gate definition" in str(
         compfail.value
     )
 

--- a/test/python_lib/test_compile.py
+++ b/test/python_lib/test_compile.py
@@ -208,8 +208,7 @@ def test_compile_unsupported_openqasm_str(example_unsupported_qasm3_str):
     diags = compfail.value.diagnostics
 
     assert any(
-        diag.severity == Severity.Error
-        and diag.category == ErrorCategory.OpenQASM3UnsupportedInput
+        diag.severity == Severity.Error and diag.category == ErrorCategory.OpenQASM3UnsupportedInput
         for diag in diags
     )
 


### PR DESCRIPTION
Closes #236. This PR adds support for returning diagnostics for OpenQASM3 generation errors. It also adds an extension to the MLIR diagnostics engine for returning qss-compiler diagnostics within any pass or context with better diagnostic handling through MLIR's builtin diagnostic handlers.

Returning a QSSC diagnostic from a pass should be as simple as
```
qssc::emitError(op, cat) << "Message";
```