### PR TITLE
[Backport 3.8] Terminate circuit on qcs.synchronize (#307)

### DIFF
--- a/lib/Dialect/QUIR/Transforms/ExtractCircuits.cpp
+++ b/lib/Dialect/QUIR/Transforms/ExtractCircuits.cpp
@@ -66,7 +66,8 @@ llvm::cl::opt<bool>
 static bool terminatesCircuit(Operation &op) {
   return (op.hasTrait<::mlir::RegionBranchOpInterface::Trait>() ||
           isa<qcs::ParallelControlFlowOp>(op) ||
-          isa<oq3::CBitInsertBitOp>(op) || isa<quir::SwitchOp>(op));
+          isa<oq3::CBitInsertBitOp>(op) || isa<quir::SwitchOp>(op) ||
+          isa<qcs::SynchronizeOp>(op));
 } // terminatesCircuit
 
 OpBuilder ExtractCircuitsPass::startCircuit(Location location,

--- a/test/Dialect/QUIR/Transforms/extract-circuits.mlir
+++ b/test/Dialect/QUIR/Transforms/extract-circuits.mlir
@@ -88,6 +88,13 @@ module {
         scf.yield
         // CHECK: scf.yield
       }
+      %5 = quir.measure(%0) : (!quir.qubit<1>) -> (i1)
+      // CHECK: %5 = quir.call_circuit @circuit_6(%0) : (!quir.qubit<1>) -> i1
+      // CHECK-NOT: %5 = quir.measure(%0) : (!quir.qubit<1>) -> (i1)
+      qcs.synchronize %0 : (!quir.qubit<1>) -> ()
+      %6 = quir.measure(%0) : (!quir.qubit<1>) -> (i1)
+      // CHECK: %6 = quir.call_circuit @circuit_7(%0) : (!quir.qubit<1>) -> i1
+       // CHECK-NOT: %6 = quir.measure(%0) : (!quir.qubit<1>) -> (i1)
     } {qcs.shot_loop, quir.classicalOnly = false, quir.physicalIds = [0 : i32, 1 : i32, 2 : i32]}
     qcs.finalize
     return %c0_i32 : i32


### PR DESCRIPTION
Fixes bug where ExtractCircuits did not properly terminate a circuit on a `qcs.synchronize`