### PR TITLE
Remove clang tidy check for misc-use-anonymous-namespace

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -44,7 +44,8 @@ Checks: >
   -modernize-use-override,
   -modernize-use-nodiscard,
   -bugprone-exception-escape,
-  -llvm-else-after-return
+  -llvm-else-after-return,
+  -misc-use-anonymous-namespace
   '
 
 WarningsAsErrors: >

--- a/lib/Dialect/QUIR/Transforms/ExtractCircuits.cpp
+++ b/lib/Dialect/QUIR/Transforms/ExtractCircuits.cpp
@@ -63,7 +63,6 @@ llvm::cl::opt<bool>
                    llvm::cl::desc("enable extract quir circuits"),
                    llvm::cl::init(false));
 
-// NOLINTNEXTLINE(misc-use-anonymous-namespace)
 static bool terminatesCircuit(Operation &op) {
   return (op.hasTrait<::mlir::RegionBranchOpInterface::Trait>() ||
           isa<qcs::ParallelControlFlowOp>(op) ||

--- a/tools/qss-opt/qss-opt.cpp
+++ b/tools/qss-opt/qss-opt.cpp
@@ -58,7 +58,6 @@
 using namespace qssc;
 using namespace qssc::hal;
 
-// NOLINTNEXTLINE(misc-use-anonymous-namespace)
 static const std::string toolName = "qss-opt";
 
 namespace {


### PR DESCRIPTION
Removes clang tidy's preference for anonymous namespaces in favor of LLVM coding guidelines.