### PR TITLE
[Backport 3.9] Add qasm3 generation error handling (#306)

### DIFF
--- a/include/Frontend/OpenQASM3/OpenQASM3Frontend.h
+++ b/include/Frontend/OpenQASM3/OpenQASM3Frontend.h
@@ -36,18 +36,17 @@ namespace qssc::frontend::openqasm3 {
 
 /// @brief Parse an OpenQASM 3 source file and emit high-level IR in the
 /// OpenQASM 3 dialect or dump the AST
+/// @param context The context to parse the module into
 /// @param sourceMgr Input source manager for the qasm3 source to be parsed
 /// @param emitRawAST whether the raw AST should be dumped
 /// @param emitPrettyAST whether a pretty-printed AST should be dumped
 /// @param emitMLIR whether high-level IR should be emitted
 /// @param newModule ModuleOp container for emitting MLIR into
-/// @param diagnosticCb a callback that will receive emitted diagnostics
 /// @return an llvm::Error in case of failure, or llvm::Error::success()
 /// otherwise
-llvm::Error parse(llvm::SourceMgr &sourceMgr, bool emitRawAST,
-                  bool emitPrettyAST, bool emitMLIR, mlir::ModuleOp newModule,
-                  OptDiagnosticCallback diagnosticCb,
-                  mlir::TimingScope &timing);
+llvm::Error parse(mlir::MLIRContext *context, llvm::SourceMgr &sourceMgr,
+                  bool emitRawAST, bool emitPrettyAST, bool emitMLIR,
+                  mlir::ModuleOp newModule, mlir::TimingScope &timing);
 
 }; // namespace qssc::frontend::openqasm3
 

--- a/include/Frontend/OpenQASM3/QUIRGenQASM3Visitor.h
+++ b/include/Frontend/OpenQASM3/QUIRGenQASM3Visitor.h
@@ -17,6 +17,8 @@
 #ifndef VISITOR_QUIR_GEN_VISITOR_H
 #define VISITOR_QUIR_GEN_VISITOR_H
 
+#include "API/errors.h"
+
 #include "Dialect/QUIR/IR/QUIRDialect.h"
 #include "Dialect/QUIR/IR/QUIREnums.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
@@ -45,10 +47,11 @@ private:
   mlir::OpBuilder circuitParentBuilder;
   mlir::ModuleOp newModule;
   mlir::quir::CircuitOp currentCircuitOp;
-  std::string filename;
   bool hasFailed{false};
   bool buildingInCircuit{false};
   uint circuitCount{0};
+  std::string fileName;
+  bool requiresParserLocationFix;
 
   mlir::Location getLocation(const QASM::ASTBase *);
   bool assign(mlir::Value &, const std::string &);
@@ -96,8 +99,10 @@ private:
   /// \param severity severity of the diagnostic
   ///
   /// \returns an in-flight diagnostic that allows adding messages and notes.
-  mlir::InFlightDiagnostic reportError(QASM::ASTBase const *location,
-                                       mlir::DiagnosticSeverity severity);
+  mlir::InFlightDiagnostic
+  reportError(QASM::ASTBase const *location, mlir::DiagnosticSeverity severity,
+              qssc::ErrorCategory category =
+                  qssc::ErrorCategory::OpenQASM3UnsupportedInput);
 
   template <class MLIROp>
   ExpressionValueType buildUnaryOp(llvm::StringRef name,
@@ -113,17 +118,23 @@ private:
 
 public:
   QUIRGenQASM3Visitor(QASM::ASTStatementList *sList, mlir::OpBuilder b,
-                      mlir::ModuleOp newModule, std::string f)
+                      mlir::ModuleOp newModule, std::string fileName,
+                      bool requiresParserLocationFix = false)
       : BaseQASM3Visitor(sList), builder(b), topLevelBuilder(b),
-        circuitParentBuilder(b), newModule(newModule), filename(std::move(f)),
+        circuitParentBuilder(b), newModule(newModule),
+        fileName(std::move(fileName)),
+        requiresParserLocationFix(requiresParserLocationFix),
         expression(llvm::createStringError(llvm::inconvertibleErrorCode(),
                                            "Testing error")),
         varHandler(builder) {}
 
   QUIRGenQASM3Visitor(mlir::OpBuilder b, mlir::ModuleOp newModule,
-                      std::string filename)
+                      std::string fileName,
+                      bool requiresParserLocationFix = false)
       : builder(b), topLevelBuilder(b), circuitParentBuilder(b),
-        newModule(newModule), filename(std::move(filename)),
+        fileName(std::move(fileName)),
+        requiresParserLocationFix(requiresParserLocationFix),
+        newModule(newModule),
         expression(llvm::createStringError(llvm::inconvertibleErrorCode(),
                                            "Testing error")),
         varHandler(builder) {}

--- a/lib/API/errors.cpp
+++ b/lib/API/errors.cpp
@@ -20,10 +20,19 @@
 
 #include "API/errors.h"
 
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Operation.h"
+
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -36,6 +45,9 @@ std::string_view getErrorCategoryAsString(qssc::ErrorCategory category) {
   switch (category) {
   case ErrorCategory::OpenQASM3ParseFailure:
     return "OpenQASM 3 parse error";
+
+  case ErrorCategory::OpenQASM3UnsupportedInput:
+    return "OpenQASM 3 semantics are unsupported";
 
   case ErrorCategory::QSSCompilerError:
     return "Unknown compiler error";
@@ -136,6 +148,195 @@ llvm::Error emitDiagnostic(const OptDiagnosticCallback &onDiagnostic,
                            std::string message, std::error_code ec) {
   qssc::Diagnostic const diag{severity, category, std::move(message)};
   return emitDiagnostic(onDiagnostic, diag, ec);
+}
+
+std::string ErrorCategoryAttrName = "QSSCErrorCategory";
+
+static std::optional<ErrorCategory>
+getQSSCDiagnosticCategory(mlir::DiagnosticArgument &arg) {
+  if (arg.getKind() ==
+      mlir::DiagnosticArgument::DiagnosticArgumentKind::Attribute) {
+    if (auto dictAttr =
+            arg.getAsAttribute().dyn_cast_or_null<mlir::DictionaryAttr>()) {
+      if (auto namedAttr = dictAttr.getNamed(ErrorCategoryAttrName)) {
+        if (auto catInt =
+                namedAttr.value().getValue().dyn_cast<mlir::IntegerAttr>())
+          return static_cast<ErrorCategory>((uint32_t)catInt.getInt());
+
+        llvm_unreachable("Invalid attribute type for error category. Must "
+                         "be an integer.");
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+// We decode the QSSC ErrorCategory as an attribute argument that a dictionary
+// attribute containing a named attribute that is an integer encoding the error
+// category enum value.
+static std::optional<ErrorCategory>
+lookupErrorCategory(mlir::Diagnostic &diagnostic) {
+  for (auto &note : diagnostic.getNotes()) {
+    for (auto &arg : note.getArguments())
+      if (auto cat = getQSSCDiagnosticCategory(arg))
+        return cat.value();
+  }
+  // Not found
+  return std::nullopt;
+}
+
+// Recursively populate diagnostic (including notes except those that are for
+// the QSSC error category)
+static void populateDiagnosticIgnoringQSSC(mlir::Diagnostic &from,
+                                           mlir::Diagnostic &to) {
+  for (auto &arg : from.getArguments()) {
+    // Do not copy diagnostic category
+    if (!getQSSCDiagnosticCategory(arg).has_value())
+      to.append(arg);
+  }
+  // Recurse on notes
+  for (auto &fromNote : from.getNotes()) {
+    // First past through args and ensure there are non-qssc notes
+    // as we do not want to add an empty note.
+    bool containsNonQSSCNote = false;
+    for (auto &arg : fromNote.getArguments()) {
+      // Do not copy diagnostic category
+      if (!getQSSCDiagnosticCategory(arg).has_value())
+        containsNonQSSCNote = true;
+    }
+    if (containsNonQSSCNote) {
+      auto &toNote = to.attachNote(fromNote.getLocation());
+      populateDiagnosticIgnoringQSSC(fromNote, toNote);
+    }
+  }
+}
+
+// We encode the QSSC ErrorCategory as an attribute argument that a dictionary
+// attribute containing a named attribute that is an integer encoding the error
+// category enum value.
+void encodeQSSCError(mlir::MLIRContext *context,
+                     mlir::InFlightDiagnostic &diagnostic,
+                     ErrorCategory category) {
+  return encodeQSSCError(context, diagnostic.getUnderlyingDiagnostic(),
+                         category);
+}
+
+void encodeQSSCError(mlir::MLIRContext *context, mlir::Diagnostic *diagnostic,
+                     ErrorCategory category) {
+  auto builder = mlir::OpBuilder(context);
+  mlir::StringAttr const key = builder.getStringAttr(ErrorCategoryAttrName);
+  mlir::IntegerAttr const value =
+      builder.getI32IntegerAttr(static_cast<int32_t>(category));
+  auto attr = builder.getDictionaryAttr(builder.getNamedAttr(key, value));
+  diagnostic->attachNote().append(attr);
+}
+
+mlir::InFlightDiagnostic emitError(mlir::Operation *op, ErrorCategory category,
+                                   const llvm::Twine &message) {
+  auto diagnostic = op->emitError(message);
+  encodeQSSCError(op->getContext(), diagnostic, category);
+  return diagnostic;
+}
+
+mlir::InFlightDiagnostic emitOpError(mlir::Operation *op,
+                                     ErrorCategory category,
+                                     const llvm::Twine &message) {
+  auto diagnostic = op->emitOpError(message);
+  encodeQSSCError(op->getContext(), diagnostic, category);
+  return diagnostic;
+}
+
+mlir::InFlightDiagnostic emitRemark(mlir::Operation *op, ErrorCategory category,
+                                    const llvm::Twine &message) {
+  auto diagnostic = op->emitRemark(message);
+  encodeQSSCError(op->getContext(), diagnostic, category);
+  return diagnostic;
+}
+
+mlir::InFlightDiagnostic emitWarning(mlir::Operation *op,
+                                     ErrorCategory category,
+                                     const llvm::Twine &message) {
+  auto diagnostic = op->emitWarning(message);
+  encodeQSSCError(op->getContext(), diagnostic, category);
+  return diagnostic;
+}
+
+QSSCMLIRDiagnosticHandler::QSSCMLIRDiagnosticHandler(
+    llvm::SourceMgr &mgr, mlir::MLIRContext *ctx,
+    const OptDiagnosticCallback &diagnosticCb)
+    : mlir::SourceMgrDiagnosticHandler(mgr, ctx, capturedOutputStream),
+      diagnosticCb(diagnosticCb) {
+
+  // Replace the source manager handler set through inheritance
+  // with our own implementation. This will eventually call the
+  // source manager handler.
+  setHandler([&](mlir::Diagnostic &diag) { this->emitDiagnostic(diag); });
+}
+
+void QSSCMLIRDiagnosticHandler::emitDiagnostic(mlir::Diagnostic &diagnostic) {
+  // emit diagnostic cast to void to discard result as it is not needed here
+  // Extract message from output stream
+  if (auto decoded = decodeQSSCDiagnostic(diagnostic)) {
+    (void)qssc::emitDiagnostic(diagnosticCb, decoded.value());
+    llvm::errs() << decoded.value().message;
+    return;
+  }
+
+  // If no diagnostic
+  // emit message using source manager diagnostic handler
+  // as passthrough.
+  auto filteredDiagnostic = filterQSSCDiagnostic(diagnostic);
+  mlir::SourceMgrDiagnosticHandler::emitDiagnostic(filteredDiagnostic);
+  llvm::errs() << capturedString;
+  capturedString.clear();
+}
+
+std::optional<Diagnostic>
+QSSCMLIRDiagnosticHandler::decodeQSSCDiagnostic(mlir::Diagnostic &diagnostic) {
+  // map diagnostic severity to qssc severity
+  auto severity = diagnostic.getSeverity();
+  qssc::Severity qsscSeverity = qssc::Severity::Error;
+  switch (severity) {
+  case mlir::DiagnosticSeverity::Error:
+    qsscSeverity = qssc::Severity::Error;
+    break;
+  case mlir::DiagnosticSeverity::Warning:
+    qsscSeverity = qssc::Severity::Warning;
+    break;
+  case mlir::DiagnosticSeverity::Note:
+  case mlir::DiagnosticSeverity::Remark:
+    qsscSeverity = qssc::Severity::Info;
+  }
+
+  auto errorCategory = lookupErrorCategory(diagnostic);
+
+  // Capture formatted string from source manager diagnostic handler
+  capturedString.clear();
+  auto filteredDiagnostic = filterQSSCDiagnostic(diagnostic);
+  mlir::SourceMgrDiagnosticHandler::emitDiagnostic(filteredDiagnostic);
+  std::string diagnosticOutput;
+  capturedString.swap(diagnosticOutput);
+
+  if (errorCategory.has_value())
+    return Diagnostic(qsscSeverity, errorCategory.value(), diagnosticOutput);
+
+  // Default error category for unspecified MLIR error diagnostics of Error
+  // severity.
+  if (qsscSeverity == qssc::Severity::Error)
+    return Diagnostic(qsscSeverity, ErrorCategory::QSSCompilationFailure,
+                      diagnosticOutput);
+
+  return std::nullopt;
+}
+
+mlir::Diagnostic
+QSSCMLIRDiagnosticHandler::filterQSSCDiagnostic(mlir::Diagnostic &diagnostic) {
+  auto filteredDiagnostic =
+      mlir::Diagnostic(diagnostic.getLocation(), diagnostic.getSeverity());
+
+  populateDiagnosticIgnoringQSSC(diagnostic, filteredDiagnostic);
+
+  return filteredDiagnostic;
 }
 
 } // namespace qssc

--- a/python_lib/qss_compiler/compile.py
+++ b/python_lib/qss_compiler/compile.py
@@ -61,7 +61,7 @@ from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 from . import exceptions
-from .py_qssc import _compile_bytes, _compile_file, Diagnostic, ErrorCategory
+from .py_qssc import _compile_bytes, _compile_file, Diagnostic
 
 # use the forkserver context to create a server process
 # for forking new compiler processes
@@ -289,33 +289,8 @@ class _CompilationManager:
                     return_diagnostics=self.return_diagnostics,
                 )
 
-            # Place all higher-level diagnostics related to user input here
-            # TODO: Best way to deal with multiple diagnostics?
-            for diag in diagnostics:
-                if diag.category == ErrorCategory.QSSCompilerSequenceTooLong:
-                    raise exceptions.QSSCompilerSequenceTooLong(
-                        diag.message,
-                        diagnostics,
-                        return_diagnostics=self.return_diagnostics,
-                    )
-                if diag.category == ErrorCategory.QSSControlSystemResourcesExceeded:
-                    raise exceptions.QSSControlSystemResourcesExceeded(
-                        diag.message,
-                        diagnostics,
-                        return_diagnostics=self.return_diagnostics,
-                    )
-                if diag.category == ErrorCategory.QSSTargetUnsupportedOperation:
-                    raise exceptions.QSSTargetUnsupportedOperation(
-                        diag.message,
-                        diagnostics,
-                        return_diagnostics=self.return_diagnostics,
-                    )
-                if diag.category == ErrorCategory.OpenQASM3ParseFailure:
-                    raise exceptions.OpenQASM3ParseFailure(
-                        diag.message,
-                        diagnostics,
-                        return_diagnostics=self.return_diagnostics,
-                    )
+            # Convert diagnostics to Python exceptions if necessary
+            exceptions.raise_diagnostics(diagnostics, return_diagnostics=self.return_diagnostics)
 
             if not success:
                 raise exceptions.QSSCompilationFailure(

--- a/python_lib/qss_compiler/examples/parse.py
+++ b/python_lib/qss_compiler/examples/parse.py
@@ -22,7 +22,6 @@ from qss_compiler.mlir.ir import Context, Module
 from qss_compiler.mlir.dialects import pulse, quir
 
 with Context() as ctx:
-
     pulse.pulse.register_dialect()
     quir.quir.register_dialect()
 

--- a/python_lib/qss_compiler/examples/pulse.py
+++ b/python_lib/qss_compiler/examples/pulse.py
@@ -34,7 +34,6 @@ samples_2d[:, 1] = np.imag(samples)
 
 
 with Context() as ctx:
-
     pulse.pulse.register_dialect()
     quir.quir.register_dialect()
 
@@ -55,7 +54,6 @@ with Context() as ctx:
             mainFunc.add_entry_block()
 
         with InsertionPoint(module.body):
-
             seq1 = pulse.SequenceOp("seq_1", [wf, wf, mf, mf], [i1])
             seq1.add_entry_block()
 

--- a/python_lib/qss_compiler/lib.cpp
+++ b/python_lib/qss_compiler/lib.cpp
@@ -196,8 +196,10 @@ py::tuple py_compile_bytes(const std::string &bytes,
                            qssc::DiagnosticCallback onDiagnostic) {
 
   // Set up the input file.
+  // <stdin> is treated specially for diagnostic handling
+  // so assign buffer identifier.
   std::unique_ptr<llvm::MemoryBuffer> input =
-      llvm::MemoryBuffer::getMemBuffer(bytes);
+      llvm::MemoryBuffer::getMemBuffer(bytes, "<stdin>");
 
   return compileOptionalOutput(outputFile, std::move(input), args,
                                std::move(onDiagnostic));

--- a/python_lib/qss_compiler/lib_enums.cpp
+++ b/python_lib/qss_compiler/lib_enums.cpp
@@ -45,6 +45,8 @@ void addErrorCategory(py::module &m) {
              qssc::ErrorCategory::QSSControlSystemResourcesExceeded)
       .value("QSSTargetUnsupportedOperation",
              qssc::ErrorCategory::QSSTargetUnsupportedOperation)
+      .value("OpenQASM3UnsupportedInput",
+             qssc::ErrorCategory::OpenQASM3UnsupportedInput)
       .value("UncategorizedError", qssc::ErrorCategory::UncategorizedError)
       .export_values();
 }

--- a/python_lib/qss_compiler/link.py
+++ b/python_lib/qss_compiler/link.py
@@ -135,7 +135,6 @@ def link_file(
             link_options.on_diagnostic,
         )
         if not success:
-
             exception_mapping = {
                 ErrorCategory.QSSLinkerNotImplemented: exceptions.QSSLinkerNotImplemented,
                 ErrorCategory.QSSLinkSignatureWarning: exceptions.QSSLinkSignatureWarning,

--- a/releasenotes/notes/add-qssc-error-reporting-mechanisms-82fa32e30d30ccce.yaml
+++ b/releasenotes/notes/add-qssc-error-reporting-mechanisms-82fa32e30d30ccce.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Added the ability to easily return QSSC diagnostics from the standard MLIR diagnostic mechanisms
+    and callback handlers through easy to use helper methods. It is now possible to write code like:
+
+    .. code-block:: cpp
+
+        qssc::emitError(op, qssc::ErrorCategory::OpenQASM3UnsupportedInput) << "Error message \n";
+
+    The diagnostic will be treated like a normal MLIR diagnostic but will also encode the QSSC
+    information to be decoded by the compiler's diagnostic handlers.

--- a/releasenotes/notes/add-unsupported-openqasm3-input-a584bb990cd9c9ff.yaml
+++ b/releasenotes/notes/add-unsupported-openqasm3-input-a584bb990cd9c9ff.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    A new diagnostic has been added for unsupported OpenQASM 3 semantics - ``OpenQASM3UnsupportedInput``.
+    This should be raised when the input OpenQASM 3 semantics are not valid for the compiler.

--- a/targets/systems/mock/Transforms/QubitLocalization.cpp
+++ b/targets/systems/mock/Transforms/QubitLocalization.cpp
@@ -42,6 +42,7 @@
 #include "mlir/IR/TypeRange.h"
 #include "mlir/IR/Types.h"
 #include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/LLVM.h"
 
@@ -182,7 +183,8 @@ void mock::MockQubitLocalizationPass::cloneRegionWithoutOps(
 } // cloneRegionWithoutOps
 
 auto mock::MockQubitLocalizationPass::addMainFunction(
-    Operation *moduleOperation, const Location &loc) -> mlir::func::FuncOp {
+    Operation *moduleOperation, const Location &loc, bool addReturn)
+    -> mlir::func::FuncOp {
   OpBuilder b(moduleOperation->getRegion(0));
   auto funcOp = b.create<mlir::func::FuncOp>(
       loc, "main",
@@ -192,6 +194,16 @@ auto mock::MockQubitLocalizationPass::addMainFunction(
   funcOp.getOperation()->setAttr(llvm::StringRef("quir.classicalOnly"),
                                  b.getBoolAttr(false));
   funcOp.addEntryBlock();
+
+  if (addReturn) {
+    OpBuilder mainBuilder(funcOp.getBody());
+    auto intAttr = mainBuilder.getI32IntegerAttr(0);
+    const mlir::Value intConstVal = mainBuilder.create<mlir::arith::ConstantOp>(
+        loc, mainBuilder.getI32Type(), intAttr);
+    auto range = mlir::ValueRange(intConstVal);
+    mainBuilder.create<mlir::func::ReturnOp>(loc, range);
+  }
+
   return funcOp;
 } // addMainFunction
 
@@ -740,6 +752,26 @@ void mock::MockQubitLocalizationPass::runOnOperation(MockSystem &target) {
     return signalPassFailure();
   }
 
+  mainFunc->walk([&](DeclareQubitOp qubitOp) {
+    llvm::outs() << qubitOp.getOperation()->getName()
+                 << " id: " << qubitOp.getId() << "\n";
+    if (!qubitOp.getId().has_value() ||
+        qubitOp.getId().value() > config->getNumQubits()) {
+      qubitOp->emitOpError()
+          << "Error! Found a qubit without an ID or with ID > "
+          << std::to_string(config->getNumQubits())
+          << " (the number of qubits in the config)"
+          << " during qubit localization!\n";
+      signalPassFailure();
+    }
+    uint const qId = qubitOp.getId().value();
+    seenQubitIds.emplace(qId);
+    driveNodeIds.emplace(config->driveNode(qId));
+    acquireNodeIds.emplace(config->acquireNode(qId));
+    seenNodeIds.emplace(config->driveNode(qId));
+    seenNodeIds.emplace(config->acquireNode(qId));
+  });
+
   // Initialize the Controller Module
   auto b = OpBuilder::atBlockEnd(topModuleOp.getBody());
   // ModuleOp test = ModuleOp::create(b.getUnknownLoc());
@@ -763,6 +795,12 @@ void mock::MockQubitLocalizationPass::runOnOperation(MockSystem &target) {
   for (const auto &result : llvm::enumerate(config->getDriveNodes())) {
     uint const qubitIdx = result.index();
     uint const nodeId = result.value();
+
+    // Only populate used nodes
+    bool isUnused = false;
+    if (seenNodeIds.find(nodeId) == seenNodeIds.end())
+      isUnused = true;
+
     llvm::outs() << "Creating module for drive Mocks " << qubitIdx << "\n";
     auto driveMod = b.create<ModuleOp>(
         b.getUnknownLoc(),
@@ -777,14 +815,20 @@ void mock::MockQubitLocalizationPass::runOnOperation(MockSystem &target) {
         llvm::StringRef("quir.physicalId"),
         controllerBuilder->getI32IntegerAttr(qubitIdx));
     mockModules[nodeId] = driveMod.getOperation();
-    mlir::func::FuncOp mockMainOp =
-        addMainFunction(driveMod.getOperation(), mainFunc->getLoc());
+    mlir::func::FuncOp mockMainOp = addMainFunction(
+        driveMod.getOperation(), mainFunc->getLoc(), /*addReturn=*/isUnused);
     newBuilders->emplace(nodeId, new OpBuilder(mockMainOp.getBody()));
   }
 
   for (const auto &result : llvm::enumerate(config->getAcquireNodes())) {
     uint const acquireIdx = result.index();
     uint const nodeId = result.value();
+
+    // Only populate used nodes
+    bool isUnused = false;
+    if (seenNodeIds.find(nodeId) == seenNodeIds.end())
+      isUnused = true;
+
     llvm::outs() << "Creating module for acquire Mocks " << acquireIdx << "\n";
     auto acquireMod = b.create<ModuleOp>(
         b.getUnknownLoc(),
@@ -800,30 +844,10 @@ void mock::MockQubitLocalizationPass::runOnOperation(MockSystem &target) {
         controllerBuilder->getI32ArrayAttr(
             ArrayRef<int>(config->acquireQubits(nodeId))));
     mockModules[nodeId] = acquireMod.getOperation();
-    mlir::func::FuncOp mockMainOp =
-        addMainFunction(acquireMod.getOperation(), mainFunc->getLoc());
+    mlir::func::FuncOp mockMainOp = addMainFunction(
+        acquireMod.getOperation(), mainFunc->getLoc(), /*addReturn=*/isUnused);
     newBuilders->emplace(nodeId, new OpBuilder(mockMainOp.getBody()));
   }
-
-  mainFunc->walk([&](DeclareQubitOp qubitOp) {
-    llvm::outs() << qubitOp.getOperation()->getName()
-                 << " id: " << qubitOp.getId() << "\n";
-    if (!qubitOp.getId().has_value() ||
-        qubitOp.getId().value() > config->getNumQubits()) {
-      qubitOp->emitOpError()
-          << "Error! Found a qubit without an ID or with ID > "
-          << std::to_string(config->getNumQubits())
-          << " (the number of qubits in the config)"
-          << " during qubit localization!\n";
-      signalPassFailure();
-    }
-    uint const qId = qubitOp.getId().value();
-    seenQubitIds.emplace(qId);
-    driveNodeIds.emplace(config->driveNode(qId));
-    acquireNodeIds.emplace(config->acquireNode(qId));
-    seenNodeIds.emplace(config->driveNode(qId));
-    seenNodeIds.emplace(config->acquireNode(qId));
-  });
 
   // refill the worklist
   std::deque<std::tuple<Block *, OpBuilder *,
@@ -888,10 +912,12 @@ void mock::MockQubitLocalizationPass::runOnOperation(MockSystem &target) {
         }
       } // some classical op
     }   // for Operations
+
     // delete the allocated opbuilders
+    // TODO: use smart pointers to manage lifetimes
     delete controllerBuilder;
-    for (uint const nodeId : seenNodeIds)
-      delete (*mockBuilders)[nodeId];
+    for (const auto &pair : *mockBuilders)
+      delete pair.second;
     delete mockBuilders;
   } // while !blockAndBuilderWorklist.empty()
 

--- a/targets/systems/mock/Transforms/QubitLocalization.h
+++ b/targets/systems/mock/Transforms/QubitLocalization.h
@@ -87,7 +87,8 @@ struct MockQubitLocalizationPass
                              mlir::Region::iterator destPos,
                              mlir::IRMapping &mapper);
   auto addMainFunction(mlir::Operation *moduleOperation,
-                       const mlir::Location &loc) -> mlir::func::FuncOp;
+                       const mlir::Location &loc, bool addReturn = false)
+      -> mlir::func::FuncOp;
   void cloneVariableDeclarations(mlir::ModuleOp topModuleOp);
 
   MockConfig *config;

--- a/targets/systems/mock/test/python_lib/test_compile_mock.py
+++ b/targets/systems/mock/test/python_lib/test_compile_mock.py
@@ -25,11 +25,11 @@ from qss_compiler import (
     compile_file_async,
     compile_str,
     compile_str_async,
+    exceptions,
     InputType,
     OutputType,
     CompileOptions,
 )
-from qss_compiler.exceptions import QSSCompilationFailure
 
 compiler_extra_args = ["--enable-circuits=false"]
 
@@ -136,7 +136,7 @@ def test_compile_failing_str_to_qem(
     """Test that compiling an invalid OpenQASM3 string via the interface
     compile_str to a QEM payload will fail and result in an empty payload."""
 
-    with pytest.raises(QSSCompilationFailure):
+    with pytest.raises(exceptions.OpenQASM3UnsupportedInput):
         compile_str(
             example_unsupported_qasm3_str,
             input_type=InputType.QASM3,
@@ -154,7 +154,7 @@ def test_compile_failing_file_to_qem(
     """Test that compiling an invalid file input via the interface compile_file
     to a QEM payload will fail and result in an empty payload."""
 
-    with pytest.raises(QSSCompilationFailure):
+    with pytest.raises(exceptions.OpenQASM3UnsupportedInput):
         compile_file(
             example_unsupported_qasm3_tmpfile,
             input_type=InputType.QASM3,

--- a/test/Frontend/OpenQASM3/diagnostics-parse-error.qasm
+++ b/test/Frontend/OpenQASM3/diagnostics-parse-error.qasm
@@ -1,0 +1,16 @@
+OPENQASM 3.0;
+// Ensure piping of input also works with diagnostics.
+// TODO: Once https://github.com/openqasm/qe-qasm/issues/35
+// is fixed this test will error and the workaround
+// in OpenQASM3Frontend.cpp for line number offsets
+// will need to be removed for the test to pass.
+// RUN: cat %s | ( qss-compiler -X=qasm --emit=mlir || true ) 2>&1 | FileCheck %s
+// RUN: ( qss-compiler -X=qasm --emit=mlir %s || true ) 2>&1 | FileCheck %s
+
+int a;
+int b;
+
+a &&& b;
+// CHECK: 13:5: error: syntax error, unexpected '&'
+// CHECK: a &&& b;
+// CHECK:     ^

--- a/test/Frontend/OpenQASM3/diagnostics-unsupported-error.qasm
+++ b/test/Frontend/OpenQASM3/diagnostics-unsupported-error.qasm
@@ -1,0 +1,21 @@
+OPENQASM 3.0;
+// Ensure piping of input also works with diagnostics.
+// TODO: Once https://github.com/openqasm/qe-qasm/issues/35
+// is fixed this test will error and the workaround
+// in QUIRGenQASM3Visitor.cpp
+// for line number offsets
+// will need to be removed for the test to pass.
+// RUN: cat %s | ( qss-compiler -X=qasm --emit=mlir || true ) 2>&1 | FileCheck %s
+// RUN: ( qss-compiler -X=qasm --emit=mlir %s  || true ) 2>&1 | FileCheck %s
+
+int a;
+float b;
+int c;
+c =  float(a) + b;
+
+// CHECK: error: Unsupported cast destination type ASTTypeFloat
+// CHECK: c =  float(a) + b;
+// CHECK:      ^
+// CHECK: error: Addition is not supported on value of type: 'none'
+// CHECK: c =  float(a) + b;
+// CHECK:      ^

--- a/test/python_lib/conftest.py
+++ b/test/python_lib/conftest.py
@@ -84,6 +84,11 @@ def example_unsupported_qasm3_str():
 
 
 @pytest.fixture
+def example_unsupported_qasm3_tmpfile(tmp_path, example_unsupported_qasm3_str):
+    return __create_tmpfile(tmp_path, example_unsupported_qasm3_str)
+
+
+@pytest.fixture
 def example_warning_not_in_errors():
     return """OPENQASM 3.0;
     gate rz(theta) q {}
@@ -105,8 +110,3 @@ def example_incorrect_qasm3():
     bit b;
     b = measure $0;
     """
-
-
-@pytest.fixture
-def example_unsupported_qasm3_tmpfile(tmp_path, example_unsupported_qasm3_str):
-    return __create_tmpfile(tmp_path, example_unsupported_qasm3_str)

--- a/test/python_lib/test_compile.py
+++ b/test/python_lib/test_compile.py
@@ -176,6 +176,43 @@ def test_compile_invalid_str(example_invalid_qasm3_str):
     assert "unknown version number" in str(compfail.value)
 
 
+def test_compile_unsupported_openqasm_file(example_unsupported_qasm3_tmpfile):
+    """Test that we can attempt to compile unsupported OpenQASM 3 and receive an
+    error"""
+
+    with pytest.raises(exceptions.OpenQASM3UnsupportedInput):
+        compile_file(
+            example_unsupported_qasm3_tmpfile,
+            return_diagnostics=True,  # For testing purposes
+            input_type=InputType.QASM3,
+            output_type=OutputType.MLIR,
+            output_file=None,
+        )
+
+
+def test_compile_unsupported_openqasm_str(example_unsupported_qasm3_str):
+    """Test that we can attempt to compile unsupported OpenQASM 3 and receive an
+    error"""
+
+    with pytest.raises(exceptions.OpenQASM3UnsupportedInput) as compfail:
+        compile_str(
+            example_unsupported_qasm3_str,
+            return_diagnostics=True,  # For testing purposes
+            input_type=InputType.QASM3,
+            output_type=OutputType.MLIR,
+            output_file=None,
+        )
+
+    assert hasattr(compfail.value, "diagnostics")
+
+    diags = compfail.value.diagnostics
+
+    assert any(
+        diag.severity == Severity.Error and diag.category == ErrorCategory.OpenQASM3UnsupportedInput
+        for diag in diags
+    )
+
+
 def test_warning_not_in_errors(example_warning_not_in_errors):
     """Test that warnings are not included in error."""
 
@@ -202,11 +239,9 @@ def test_warning_not_in_errors(example_warning_not_in_errors):
     assert any("OpenQASM 3 parse error" in str(diag) for diag in diags)
 
     # check string representation of the exception to contain diagnostic messages
-    assert (
-        "Error: OpenQASM 3 parse error" in str(compfail.value)
-        and "Non-existent angle a passed as angle argument to Gate Call." in str(compfail.value)
-        and "Angle value exceeds 2pi." not in str(compfail.value)
-    )
+    assert "Non-existent angle a passed as angle argument to Gate Call." in str(
+        compfail.value
+    ) and "Angle value exceeds 2pi." not in str(compfail.value)
 
 
 def test_incorrect_qasm3(example_incorrect_qasm3):
@@ -235,10 +270,9 @@ def test_incorrect_qasm3(example_incorrect_qasm3):
     assert any("OpenQASM 3 parse error" in str(diag) for diag in diags)
 
     # check string representation of the exception to contain diagnostic messages
-    assert "Error: OpenQASM 3 parse error" in str(
-        compfail.value
-    ) and "1 inconsistent parameters in the gate call for the corresponding gate definition" in str(
-        compfail.value
+    assert (
+        "1 inconsistent parameters in the gate call for the corresponding gate definition"
+        in str(compfail.value)
     )
 
 


### PR DESCRIPTION
Backports support for returning diagnostics for OpenQASM3 generation errors. It also adds an extension to the MLIR diagnostics engine for returning qss-compiler diagnostics within any pass or context with better diagnostic handling through MLIR's builtin diagnostic handlers.

Returning a QSSC diagnostic from a pass should be as simple as
```
qssc::emitError(op, cat) << "Message";
```
