### PR TITLE
[Backport] Add Symbol Cache Analysis (#301)

### DIFF
--- a/include/Conversion/QUIRToPulse/QUIRToPulse.h
+++ b/include/Conversion/QUIRToPulse/QUIRToPulse.h
@@ -24,6 +24,7 @@
 #include "Dialect/OQ3/IR/OQ3Ops.h"
 #include "Dialect/Pulse/IR/PulseOps.h"
 #include "Dialect/QCS/IR/QCSOps.h"
+#include "Utils/SymbolCacheAnalysis.h"
 
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Pass/Pass.h"
@@ -157,9 +158,7 @@ struct QUIRToPulsePass
   void parsePulseWaveformContainerOps(std::string &waveformContainerPath);
   std::map<std::string, Waveform_CreateOp> pulseNameToWaveformMap;
 
-  llvm::StringMap<Operation *> symbolMap;
-  mlir::quir::CircuitOp getCircuitOp(mlir::quir::CallCircuitOp &callCircuitOp);
-  mlir::pulse::SequenceOp getSequenceOp(std::string const &symbolName);
+  qssc::utils::SymbolCacheAnalysis *symbolCache{nullptr};
 };
 } // namespace mlir::pulse
 

--- a/include/Dialect/Pulse/Transforms/SchedulePort.h
+++ b/include/Dialect/Pulse/Transforms/SchedulePort.h
@@ -30,6 +30,8 @@
 
 #include "Dialect/Pulse/IR/PulseOps.h"
 #include "Utils/DebugIndent.h"
+#include "Utils/SymbolCacheAnalysis.h"
+
 #include "mlir/Pass/Pass.h"
 
 #include <map>
@@ -60,7 +62,7 @@ private:
 
   void addTimepoints(mlir::OpBuilder &builder,
                      mixedFrameMap_t &mixedFrameSequences, int64_t &maxTime);
-  llvm::StringMap<mlir::pulse::SequenceOp> sequenceOps;
+  qssc::utils::SymbolCacheAnalysis *symbolCache{nullptr};
 };
 } // namespace mlir::pulse
 

--- a/include/Dialect/Pulse/Transforms/Scheduling.h
+++ b/include/Dialect/Pulse/Transforms/Scheduling.h
@@ -23,6 +23,7 @@
 #define SCHEDULING_PULSE_SEQUENCES_H
 
 #include "Dialect/Pulse/IR/PulseOps.h"
+#include "Utils/SymbolCacheAnalysis.h"
 
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Pass/Pass.h"
@@ -76,9 +77,7 @@ private:
   void updatePortAvailabilityMap(mlir::ArrayAttr ports,
                                  int updatedAvailableTime);
   bool sequenceOpIncludeCapture(mlir::pulse::SequenceOp quantumGateSequenceOp);
-  llvm::StringMap<Operation *> symbolMap;
-  mlir::pulse::SequenceOp
-  getSequenceOp(mlir::pulse::CallSequenceOp callSequenceOp);
+  qssc::utils::SymbolCacheAnalysis *symbolCache{nullptr};
 };
 } // namespace mlir::pulse
 

--- a/include/Dialect/QUIR/Transforms/BreakReset.h
+++ b/include/Dialect/QUIR/Transforms/BreakReset.h
@@ -21,6 +21,8 @@
 #ifndef QUIR_BREAK_RESET_H
 #define QUIR_BREAK_RESET_H
 
+#include "Utils/SymbolCacheAnalysis.h"
+
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 
@@ -73,7 +75,8 @@ struct BreakResetPass
 
 private:
   // keep track of all circuits
-  llvm::StringMap<Operation *> circuitsSymbolMap;
+  qssc::utils::SymbolCacheAnalysis *symbolCache{nullptr};
+
   void insertMeasureInCircuit(mlir::func::FuncOp &mainFunc,
                               mlir::quir::MeasureOp measureOp);
   void insertCallGateInCircuit(mlir::func::FuncOp &mainFunc,

--- a/include/Dialect/QUIR/Transforms/ExtractCircuits.h
+++ b/include/Dialect/QUIR/Transforms/ExtractCircuits.h
@@ -22,6 +22,7 @@
 #define QUIR_EXTRACT_CIRCUITS_H
 
 #include "Dialect/QUIR/IR/QUIROps.h"
+#include "Utils/SymbolCacheAnalysis.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/PatternMatch.h"
@@ -53,7 +54,7 @@ private:
   void addToCircuit(mlir::Operation *currentOp, OpBuilder circuitBuilder,
                     llvm::SmallVector<Operation *> &eraseList);
   uint64_t circuitCount = 0;
-  llvm::StringMap<Operation *> circuitOpsMap;
+  qssc::utils::SymbolCacheAnalysis *symbolCache{nullptr};
 
   mlir::quir::CircuitOp currentCircuitOp = nullptr;
   mlir::quir::CallCircuitOp newCallCircuitOp;

--- a/include/Dialect/QUIR/Transforms/MergeCircuits.h
+++ b/include/Dialect/QUIR/Transforms/MergeCircuits.h
@@ -23,6 +23,7 @@
 #define QUIR_MERGE_CIRCUITS_H
 
 #include "Dialect/QUIR/IR/QUIROps.h"
+#include "Utils/SymbolCacheAnalysis.h"
 
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
@@ -34,12 +35,10 @@ struct MergeCircuitsPass
     : public PassWrapper<MergeCircuitsPass, OperationPass<>> {
   void runOnOperation() override;
 
-  static CircuitOp getCircuitOp(CallCircuitOp callCircuitOp,
-                                llvm::StringMap<Operation *> *symbolMap);
   static LogicalResult mergeCallCircuits(
       MLIRContext *context, PatternRewriter &rewriter,
       CallCircuitOp callCircuitOp, CallCircuitOp nextCallCircuitOp,
-      llvm::StringMap<Operation *> *symbolMap,
+      qssc::utils::SymbolCacheAnalysis *symbolCache,
       std::optional<llvm::SmallVector<Operation *>> barriers = std::nullopt);
 
   llvm::StringRef getArgument() const override;

--- a/include/Dialect/QUIR/Transforms/SubroutineCloning.h
+++ b/include/Dialect/QUIR/Transforms/SubroutineCloning.h
@@ -25,6 +25,8 @@
 #ifndef QUIR_SUBROUTINE_CLONING_H
 #define QUIR_SUBROUTINE_CLONING_H
 
+#include "Utils/SymbolCacheAnalysis.h"
+
 #include <deque>
 #include <unordered_set>
 
@@ -36,7 +38,7 @@ class Operation;
 
 namespace mlir::quir {
 
-using SymbolOpMap = llvm::StringMap<Operation *>;
+using SymbolCache = qssc::utils::SymbolCacheAnalysis;
 
 struct SubroutineCloningPass
     : public PassWrapper<SubroutineCloningPass, OperationPass<>> {
@@ -45,7 +47,7 @@ struct SubroutineCloningPass
   template <class CallLikeOp>
   auto getMangledName(Operation *op) -> std::string;
   template <class CallLikeOp, class FuncLikeOp>
-  void processCallOp(Operation *op, SymbolOpMap &symbolOpMap);
+  void processCallOp(Operation *op, SymbolCache &symbolOpMap);
 
   void runOnOperation() override;
 

--- a/include/Utils/SymbolCacheAnalysis.h
+++ b/include/Utils/SymbolCacheAnalysis.h
@@ -1,0 +1,203 @@
+//===- SymbolCacheAnalysis.h - Cache symbols --------------------*- C++ -*-===//
+//
+// (C) Copyright IBM 2024.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+///
+/// This file implements an analysis for caching symbols that match a
+/// call -> callee pattern. This currently includes circuit / call_circuit
+/// and sequence / call_sequence.
+///
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef CACHE_SYMBOLS_ANALYSIS_H
+#define CACHE_SYMBOLS_ANALYSIS_H
+
+#include "HAL/SystemConfiguration.h"
+
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/AnalysisManager.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Casting.h"
+
+#include <string>
+#include <typeinfo>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace qssc::utils {
+
+// This analysis maintains a mapping of symbol name to operation in
+// symbolOpsMap. It will also maintain a cache of CallOp to CalleeOp
+// when operations are looked up through the getOp method. The CallOp
+// to CalleeOp cache is intended to reduce string comparison where
+// possible
+//
+// Example usage:
+// auto & cache = getAnalysis<qssc::utils::SymbolCacheAnalysis>()
+//                .addToCache<CircuitOp>();
+//
+// multiple symbol types may be cached using:
+// auto & cache = getAnalysis<qssc::utils::SymbolCacheAnalysis>()
+//                .addToCache<CircuitOp>()
+//                .addToCache<SequenceOp>();
+//
+// This analysis is intended to be used with MLIR's getAnalysis
+// framework. It has been designed to reused the chached value
+// and will not be invalidated automatically with each pass.
+// If a pass manipulates the symbols that are cached with this
+// analysis then it should use the addCallee method to update the
+// map or call invalidate after appying updates.
+// Note this analysis should always be used by reference or
+// via a pointer to ensure that updates are applied to the maps
+// stored by the MLIR analysis framework.
+//
+// Passes may force the maps to be re-loaded by calling invalidate
+// before calling addToCache:
+//
+// auto & cache = getAnalysis<qssc::utils::SymbolCacheAnalysis>()
+//                .invalidate()
+//                .addToCache<CircuitOp>();
+
+class SymbolCacheAnalysis {
+public:
+  SymbolCacheAnalysis(mlir::Operation *op) {
+    if (topOp && topOp != op)
+      invalidate();
+    topOp = op;
+  }
+  SymbolCacheAnalysis(mlir::Operation *op,
+                      qssc::hal::SystemConfiguration *config) {
+    if (topOp && topOp != op)
+      invalidate();
+    topOp = op;
+  }
+
+  template <class CalleeOp>
+  SymbolCacheAnalysis &addToCache() {
+    return addToCache<CalleeOp>(topOp);
+  }
+
+  template <class CalleeOp>
+  SymbolCacheAnalysis &addToCache(mlir::Operation *op) {
+    std::string typeName = typeid(CalleeOp).name();
+
+    if (!invalid && (cachedTypes.find(typeName) != cachedTypes.end())) {
+      // already cached skipping
+      return *this;
+    }
+
+    op->walk([&](CalleeOp op) {
+      symbolOpsMap[op.getSymName()] = op.getOperation();
+    });
+    cachedTypes.insert(typeName);
+    invalid = false;
+    return *this;
+  }
+
+  template <class CallOp>
+  SymbolCacheAnalysis &cacheCallMap() {
+    return cacheCallMap<CallOp>(topOp);
+  }
+
+  template <class CallOp>
+  SymbolCacheAnalysis &cacheCallMap(mlir::Operation *op) {
+    std::string typeName = typeid(CallOp).name();
+    if ((cachedTypes.find(typeName) != cachedTypes.end()))
+      return *this;
+
+    op->walk([&](CallOp callOp) {
+      auto search = symbolOpsMap.find(callOp.getCallee());
+      if (search != symbolOpsMap.end())
+        callMap[callOp.getOperation()] = search->second;
+    });
+    return *this;
+  }
+
+  template <class CalleeOp>
+  CalleeOp getOpByName(llvm::StringRef callee) {
+    auto search = symbolOpsMap.find(callee);
+    assert(search != symbolOpsMap.end() && "matching callee not found");
+    auto calleeOp = llvm::dyn_cast<CalleeOp>(search->second);
+    assert(calleeOp && "callee is not of the expected type");
+    return calleeOp;
+  }
+
+  template <class CalleeOp, class CallOp>
+  CalleeOp getOpByCall(CallOp callOp) {
+    auto search = callMap.find(callOp.getOperation());
+    if (search == callMap.end()) {
+      auto calleeOp = getOpByName<CalleeOp>(callOp.getCallee());
+      callMap[callOp.getOperation()] = calleeOp.getOperation();
+      return calleeOp;
+    }
+    auto calleeOp = llvm::dyn_cast<CalleeOp>(search->second);
+    assert(calleeOp && "callee is not of the expected type");
+    return calleeOp;
+  }
+
+  template <class CalleeOp, class CallOp>
+  CalleeOp getOp(CallOp callOp) {
+    return getOpByCall<CalleeOp, CallOp>(callOp);
+  }
+
+  template <class CalleeOp>
+  void addCallee(CalleeOp calleeOp) {
+    addCallee(calleeOp.getSymName(), calleeOp.getOperation());
+  }
+
+  void addCallee(llvm::StringRef name, mlir::Operation *op) {
+    // if this is an update to existing symbol clear callMap cache
+    if (symbolOpsMap.contains(name))
+      callMap.clear();
+    symbolOpsMap[name] = op;
+  }
+
+  template <class CallOp, class CalleeOp>
+  void cacheCall(CallOp callOp, CalleeOp calleeOp) {
+    callMap[callOp.getOperation()] = calleeOp.getOperation();
+  }
+
+  bool contains(llvm::StringRef name) { return symbolOpsMap.contains(name); }
+
+  template <class CalleeOp>
+  void erase(CalleeOp calleeOp) {
+    symbolOpsMap.erase(calleeOp.getSymName());
+    // TODO: determine if it is worth just clearing the callers of calleeOp
+    callMap.clear();
+  }
+
+  SymbolCacheAnalysis &invalidate() {
+    symbolOpsMap.clear();
+    callMap.clear();
+    cachedTypes.clear();
+    invalid = true;
+    return *this;
+  }
+
+  bool isInvalidated(const mlir::AnalysisManager::PreservedAnalyses &pa) {
+    return invalid;
+  }
+
+  // for debugging purposes
+  void listSymbols() {
+    for (auto &[key, value] : symbolOpsMap)
+      llvm::errs() << key << "\n";
+  }
+
+private:
+  llvm::StringMap<mlir::Operation *> symbolOpsMap;
+  std::unordered_map<mlir::Operation *, mlir::Operation *> callMap;
+  std::unordered_set<std::string> cachedTypes;
+  mlir::Operation *topOp{nullptr};
+  bool invalid{true};
+};
+} // namespace qssc::utils
+
+#endif // CACHE_SYMBOLS_ANALYSIS_H

--- a/lib/Dialect/Pulse/Transforms/Scheduling.cpp
+++ b/lib/Dialect/Pulse/Transforms/Scheduling.cpp
@@ -23,6 +23,7 @@
 #include "Dialect/Pulse/IR/PulseInterfaces.h"
 #include "Dialect/Pulse/IR/PulseOps.h"
 #include "Dialect/QUIR/Utils/Utils.h"
+#include "Utils/SymbolCacheAnalysis.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -62,9 +63,9 @@ void QuantumCircuitPulseSchedulingPass::runOnOperation() {
   ModuleOp const moduleOp = getOperation();
 
   // populate/cache the symbol map
-  moduleOp->walk([&](SequenceOp sequenceOp) {
-    symbolMap[sequenceOp.getSymName()] = sequenceOp.getOperation();
-  });
+  symbolCache = &getAnalysis<qssc::utils::SymbolCacheAnalysis>()
+                     .invalidate()
+                     .addToCache<SequenceOp>();
 
   // schedule all the quantum circuits which are root call sequence ops
   moduleOp->walk([&](mlir::pulse::CallSequenceOp callSequenceOp) {
@@ -84,7 +85,9 @@ void QuantumCircuitPulseSchedulingPass::runOnOperation() {
 void QuantumCircuitPulseSchedulingPass::scheduleAlap(
     mlir::pulse::CallSequenceOp quantumCircuitCallSequenceOp) {
 
-  auto quantumCircuitSequenceOp = getSequenceOp(quantumCircuitCallSequenceOp);
+  assert(symbolCache && "symbolCache not set");
+  auto quantumCircuitSequenceOp =
+      symbolCache->getOp<SequenceOp>(quantumCircuitCallSequenceOp);
   std::string const sequenceName = quantumCircuitSequenceOp.getSymName().str();
   LLVM_DEBUG(llvm::dbgs() << "\nscheduling " << sequenceName << "\n");
 
@@ -107,7 +110,9 @@ void QuantumCircuitPulseSchedulingPass::scheduleAlap(
     if (auto quantumGateCallSequenceOp =
             dyn_cast<mlir::pulse::CallSequenceOp>(op)) {
       // find quantum gate SequenceOp
-      auto quantumGateSequenceOp = getSequenceOp(quantumGateCallSequenceOp);
+      assert(symbolCache && "symbolCache not set");
+      auto quantumGateSequenceOp =
+          symbolCache->getOp<SequenceOp>(quantumGateCallSequenceOp);
       const std::string quantumGateSequenceName =
           quantumGateSequenceOp.getSymName().str();
       LLVM_DEBUG(llvm::dbgs() << "\tprocessing inner sequence "
@@ -213,15 +218,6 @@ bool QuantumCircuitPulseSchedulingPass::sequenceOpIncludeCapture(
   });
 
   return sequenceOpIncludeCapture;
-}
-
-mlir::pulse::SequenceOp QuantumCircuitPulseSchedulingPass::getSequenceOp(
-    mlir::pulse::CallSequenceOp callSequenceOp) {
-  auto search = symbolMap.find(callSequenceOp.getCallee());
-  assert(search != symbolMap.end() && "matching sequence not found");
-  auto sequenceOp = dyn_cast<SequenceOp>(search->second);
-  assert(sequenceOp && "matching sequence not found");
-  return sequenceOp;
 }
 
 llvm::StringRef QuantumCircuitPulseSchedulingPass::getArgument() const {

--- a/lib/Dialect/QUIR/Transforms/ExtractCircuits.cpp
+++ b/lib/Dialect/QUIR/Transforms/ExtractCircuits.cpp
@@ -25,6 +25,7 @@
 #include "Dialect/QUIR/IR/QUIRAttributes.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
 #include "Dialect/QUIR/Utils/Utils.h"
+#include "Utils/SymbolCacheAnalysis.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Attributes.h"
@@ -42,7 +43,6 @@
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
@@ -85,7 +85,8 @@ OpBuilder ExtractCircuitsPass::startCircuit(Location location,
 
   std::string const circuitName = "circuit_";
   std::string newName = circuitName + std::to_string(circuitCount++);
-  while (circuitOpsMap.contains(newName))
+  assert(symbolCache && "symbolCache not set");
+  while (symbolCache->contains(newName))
     newName = circuitName + std::to_string(circuitCount++);
 
   currentCircuitOp =
@@ -94,7 +95,7 @@ OpBuilder ExtractCircuitsPass::startCircuit(Location location,
                                             /*inputs=*/ArrayRef<Type>(),
                                             /*results=*/ArrayRef<Type>()));
   currentCircuitOp.addEntryBlock();
-  circuitOpsMap[newName] = currentCircuitOp;
+  symbolCache->addCallee(currentCircuitOp);
 
   currentCircuitOp->setAttr(llvm::StringRef("quir.classicalOnly"),
                             topLevelBuilder.getBoolAttr(false));
@@ -275,11 +276,8 @@ void ExtractCircuitsPass::runOnOperation() {
 
   Operation *moduleOp = getOperation();
 
-  llvm::StringMap<Operation *> circuitOpsMap;
-
-  moduleOp->walk([&](CircuitOp circuitOp) {
-    circuitOpsMap[circuitOp.getSymName()] = circuitOp.getOperation();
-  });
+  symbolCache =
+      &getAnalysis<qssc::utils::SymbolCacheAnalysis>().addToCache<CircuitOp>();
 
   mlir::func::FuncOp mainFunc =
       dyn_cast<mlir::func::FuncOp>(quir::getMainFunction(moduleOp));

--- a/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
+++ b/lib/Dialect/QUIR/Transforms/MergeCircuitMeasures.cpp
@@ -25,6 +25,7 @@
 #include "Dialect/QUIR/IR/QUIRInterfaces.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
 #include "Dialect/QUIR/Utils/Utils.h"
+#include "Utils/SymbolCacheAnalysis.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Attributes.h"
@@ -42,7 +43,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 
 #include <algorithm>
@@ -61,27 +61,26 @@ using namespace mlir::quir;
 
 namespace {
 
-static std::string duplicateCircuit(PatternRewriter &rewriter,
-                                    CircuitOp circuitOp,
-                                    llvm::StringMap<Operation *> &symbolMap,
-                                    const std::string &newNameTemplate,
-                                    const std::string &salt) {
+static std::string
+duplicateCircuit(PatternRewriter &rewriter, CircuitOp circuitOp,
+                 qssc::utils::SymbolCacheAnalysis &symbolCache,
+                 const std::string &newNameTemplate, const std::string &salt) {
   rewriter.setInsertionPoint(circuitOp);
   auto *oldCircuitOp = rewriter.clone(*circuitOp);
-  symbolMap[circuitOp.getSymName()] = oldCircuitOp;
+  symbolCache.addCallee(circuitOp.getSymName(), oldCircuitOp);
 
   // merge circuit names with an additional salt for the merge
 
   std::string newName = newNameTemplate + salt;
   std::string testName = newName;
   int cnt = 0;
-  while (symbolMap.contains(testName))
+  while (symbolCache.contains(testName))
     testName = newName + std::to_string(cnt++);
   newName = testName;
 
   circuitOp->setAttr(SymbolTable::getSymbolAttrName(),
                      StringAttr::get(circuitOp->getContext(), newName));
-  symbolMap[newName] = circuitOp;
+  symbolCache.addCallee(circuitOp);
 
   return newName;
 }
@@ -233,16 +232,16 @@ static void mergeMeasurements(PatternRewriter &rewriter,
                               CallCircuitOp nextCallCircuitOp,
                               CircuitOp circuitOp, CircuitOp nextCircuitOp,
                               MeasureOp measureOp, MeasureOp nextMeasureOp,
-                              llvm::StringMap<Operation *> &symbolMap) {
+                              qssc::utils::SymbolCacheAnalysis &symbolCache) {
 
   // copy circuitOp in case there are multiple calls
   std::string const newNameTemplate =
       (circuitOp.getSymName() + "_" + nextCircuitOp.getSymName()).str();
   auto newName1 =
-      duplicateCircuit(rewriter, circuitOp, symbolMap, newNameTemplate, "+m");
+      duplicateCircuit(rewriter, circuitOp, symbolCache, newNameTemplate, "+m");
 
   // copy nextCircuitOp in case there are multiple calls
-  auto newName2 = duplicateCircuit(rewriter, nextCircuitOp, symbolMap,
+  auto newName2 = duplicateCircuit(rewriter, nextCircuitOp, symbolCache,
                                    newNameTemplate, "-m");
 
   // merge measurements
@@ -289,7 +288,7 @@ static void mergeMeasurements(PatternRewriter &rewriter,
   // delete the nextCircuit if it is now empty (starts with a return)
   auto firstReturnOp = dyn_cast<quir::ReturnOp>(&nextCircuitOp.front().front());
   if (firstReturnOp) {
-    symbolMap.erase(nextCircuitOp.getSymName());
+    symbolCache.erase(nextCircuitOp);
     rewriter.eraseOp(nextCircuitOp);
   }
 }
@@ -299,12 +298,12 @@ static void mergeMeasurements(PatternRewriter &rewriter,
 struct CallCircuitAndCallCircuitTopologicalPattern
     : public OpRewritePattern<CallCircuitOp> {
   explicit CallCircuitAndCallCircuitTopologicalPattern(
-      MLIRContext *ctx, llvm::StringMap<Operation *> &symbolMap)
+      MLIRContext *ctx, qssc::utils::SymbolCacheAnalysis &symbolCache)
       : OpRewritePattern<CallCircuitOp>(ctx) {
-    _symbolMap = &symbolMap;
+    _symbolCache = &symbolCache;
   }
 
-  llvm::StringMap<Operation *> *_symbolMap;
+  qssc::utils::SymbolCacheAnalysis *_symbolCache;
 
   LogicalResult matchAndRewrite(CallCircuitOp callCircuitOp,
                                 PatternRewriter &rewriter) const override {
@@ -317,10 +316,7 @@ struct CallCircuitAndCallCircuitTopologicalPattern
       return failure();
 
     // is there a measure in the current circuit
-    auto search1 = _symbolMap->find(callCircuitOp.getCallee());
-    assert(search1 != _symbolMap->end() && "matching circuit not found");
-
-    auto firstCircuit = dyn_cast<CircuitOp>(search1->second);
+    auto firstCircuit = _symbolCache->getOp<CircuitOp>(callCircuitOp);
 
     MeasureOp firstMeasureOp;
     std::set<uint32_t> currMeasureQubits;
@@ -346,10 +342,8 @@ struct CallCircuitAndCallCircuitTopologicalPattern
     if (!nextCallCircuitOp.has_value())
       return failure();
 
-    auto search2 = _symbolMap->find(nextCallCircuitOp->getCallee());
-    assert(search2 != _symbolMap->end() && "matching circuit not found");
-
-    auto secondCircuit = dyn_cast<CircuitOp>(search2->second);
+    auto secondCircuit =
+        _symbolCache->getOp<CircuitOp>(nextCallCircuitOp.value());
 
     // Find the next measurement operation accumulating qubits along the
     // topological path if it exists
@@ -392,7 +386,7 @@ struct CallCircuitAndCallCircuitTopologicalPattern
     // good to merge
     mergeMeasurements(rewriter, callCircuitOp, *nextCallCircuitOp, firstCircuit,
                       secondCircuit, firstMeasureOp, nextMeasureOp,
-                      *_symbolMap);
+                      *_symbolCache);
 
     return success();
   } // matchAndRewrite
@@ -402,15 +396,12 @@ struct CallCircuitAndCallCircuitTopologicalPattern
 void MergeCircuitMeasuresTopologicalPass::runOnOperation() {
   Operation *moduleOperation = getOperation();
 
-  llvm::StringMap<Operation *> circuitOpsMap;
-
-  moduleOperation->walk([&](CircuitOp circuitOp) {
-    circuitOpsMap[circuitOp.getSymName()] = circuitOp.getOperation();
-  });
+  auto &symbolCache =
+      getAnalysis<qssc::utils::SymbolCacheAnalysis>().addToCache<CircuitOp>();
 
   RewritePatternSet patterns(&getContext());
   patterns.add<CallCircuitAndCallCircuitTopologicalPattern>(&getContext(),
-                                                            circuitOpsMap);
+                                                            symbolCache);
 
   mlir::GreedyRewriteConfig config;
   // Disable to improve performance

--- a/releasenotes/notes/symbol-cache-analysis-e135ccc3fe625e2e.yaml
+++ b/releasenotes/notes/symbol-cache-analysis-e135ccc3fe625e2e.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    Adds SymbolCacheAnalysis for caching call to callee lookups in using an
+    MLIR analysis.


### PR DESCRIPTION
Adds a SymbolCacheAnalysis to standardizing the caching of symbols for Circuits, Sequences and other function like operations which follow a call_<name> by callee, <name> @callee pattern.