### PR TITLE
[Backport] remove qubits from SynchronizeOp (#322) 

### DIFF
--- a/include/Dialect/Pulse/Utils/Utils.h
+++ b/include/Dialect/Pulse/Utils/Utils.h
@@ -82,4 +82,21 @@ MixFrameOp getMixFrameOp(PulseOpTy pulseOp,
   return mixFrameOp;
 }
 
+template <typename PulseOpTy>
+llvm::StringRef getMixFrameName(PulseOpTy pulseOp, SequenceOp sequenceOp) {
+
+  auto frameArgIndex =
+      pulseOp.getTarget().template cast<BlockArgument>().getArgNumber();
+
+  assert(sequenceOp->hasAttrOfType<ArrayAttr>("pulse.args") and
+         "no pulse.args found for the pulse cal sequence.");
+
+  auto argAttr = sequenceOp->getAttrOfType<ArrayAttr>("pulse.args");
+
+  llvm::StringRef frameName =
+      argAttr[frameArgIndex].template dyn_cast<StringAttr>().getValue();
+
+  return frameName;
+}
+
 } // end namespace mlir::pulse

--- a/lib/Conversion/QUIRToPulse/LoadPulseCals.cpp
+++ b/lib/Conversion/QUIRToPulse/LoadPulseCals.cpp
@@ -22,6 +22,7 @@
 
 #include "Dialect/Pulse/IR/PulseDialect.h"
 #include "Dialect/Pulse/IR/PulseOps.h"
+#include "Dialect/QCS/IR/QCSOps.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
 #include "Dialect/QUIR/IR/QUIRTraits.h"
 #include "Dialect/QUIR/Utils/Utils.h"
@@ -145,7 +146,9 @@ void LoadPulseCalsPass::loadPulseCals(CallCircuitOp callCircuitOp,
       loadPulseCals(castOp, callCircuitOp, funcOp);
     else if (auto castOp = dyn_cast<mlir::quir::ResetQubitOp>(op))
       loadPulseCals(castOp, callCircuitOp, funcOp);
-    else {
+    else if (isa<mlir::qcs::DelayCyclesOp>(op)) {
+      // no pulse call to load for a delay cycles op
+    } else {
       LLVM_DEBUG(llvm::dbgs() << "no pulse cal loading needed for " << op);
       assert((!op->hasTrait<mlir::quir::UnitaryOp>() and
               !op->hasTrait<mlir::quir::CPTPOp>()) &&


### PR DESCRIPTION
Remove qubit arguments from qcs.syncronize when converting to pulse.