### PR TITLE
Fix default-only switch statements

### DIFF
--- a/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
@@ -540,11 +540,10 @@ void QUIRGenQASM3Visitor::visit(const ASTSwitchStatementNode *node) {
   SmallVector<uint32_t> caseValues;
   for (auto const &[key, caseStatement] : node->GetCaseStatementsMap())
     caseValues.push_back(caseStatement->GetCaseIndex());
-  if (!caseValues.empty())
-    caseValuesAttr = DenseIntElementsAttr::get(
-        VectorType::get(static_cast<int64_t>(caseValues.size()),
-                        builder.getIntegerType(32)),
-        caseValues);
+  caseValuesAttr = DenseIntElementsAttr::get(
+      VectorType::get(static_cast<int64_t>(caseValues.size()),
+                      builder.getIntegerType(32)),
+      caseValues);
 
   auto caseOperands = node->GetCaseStatementsMap();
 

--- a/releasenotes/notes/default-only-switch-64bb951256d7d2b5.yaml
+++ b/releasenotes/notes/default-only-switch-64bb951256d7d2b5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Switch statements with only a default region will now correctly compile.

--- a/test/Frontend/OpenQASM3/switch-default-only.qasm3
+++ b/test/Frontend/OpenQASM3/switch-default-only.qasm3
@@ -1,0 +1,32 @@
+OPENQASM 3.0;
+// RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm=false| FileCheck %s --match-full-lines --check-prefixes MLIR
+// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-circuits-from-qasm | FileCheck %s --match-full-lines --check-prefixes MLIR
+
+//
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2023, 2024.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+int i = 15;
+qubit $0;
+// MLIR: quir.switch %{{.*}}{
+// MLIR-NEXT: }[]
+// AST-PRETTY: SwitchStatementNode(SwitchQuantity(name=i, type=ASTTypeIdentifier),
+switch (i) {
+    // AST-PRETTY:statements=[
+    // AST-PRETTY:],
+    // AST-PRETTY:default statement=[
+    // AST-PRETTY:])
+    default: {
+    }
+    break;
+}


### PR DESCRIPTION
This PR fixes a problem in QUIRGenQasm3Visitor that was causing segmentation faults when verifying switch statements that contain only a default region. 