### PR TITLE
Parameters Compiling Performance Improvements 

### DIFF
--- a/include/Dialect/QCS/IR/QCSOps.td
+++ b/include/Dialect/QCS/IR/QCSOps.td
@@ -267,7 +267,7 @@ def QCS_DeclareParameterOp : QCS_Op<"declare_parameter", [Symbol]> {
 }
 
 def QCS_ParameterLoadOp : QCS_Op<"parameter_load",
-                        [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+                        []> {
     let summary = "Use the current value of a parameter";
     let description = [{
         The operation `qcs.parameter_load` returns the current value of the
@@ -281,7 +281,7 @@ def QCS_ParameterLoadOp : QCS_Op<"parameter_load",
     }];
 
     let arguments = (ins
-        FlatSymbolRefAttr:$parameter_name
+        StrAttr:$parameter_name
     );
 
     let results = (outs AnyClassical:$res);

--- a/include/Dialect/QCS/IR/QCSOps.td
+++ b/include/Dialect/QCS/IR/QCSOps.td
@@ -287,10 +287,6 @@ def QCS_ParameterLoadOp : QCS_Op<"parameter_load",
     let results = (outs AnyClassical:$res);
 
     let extraClassDeclaration = [{
-        // Return the initial value - using ParameterInitialValueAnalysis
-        ParameterType getInitialValue(llvm::StringMap<ParameterType> &parameterNames);
-
-        // Return the initial value - slower SymbolTable version
         ParameterType getInitialValue();
     }];
 

--- a/include/Dialect/QCS/Utils/ParameterInitialValueAnalysis.h
+++ b/include/Dialect/QCS/Utils/ParameterInitialValueAnalysis.h
@@ -40,12 +40,12 @@ using InitialValueType = llvm::StringMap<ParameterType>;
 
 class ParameterInitialValueAnalysis {
 private:
-  InitialValueType initial_values_;
+  InitialValueType initialValues_;
   bool invalid_{true};
 
 public:
   ParameterInitialValueAnalysis(mlir::Operation *op);
-  InitialValueType &getNames() { return initial_values_; }
+  InitialValueType &getNames() { return initialValues_; }
   void invalidate() { invalid_ = true; }
   bool isInvalidated(const AnalysisManager::PreservedAnalyses &pa) {
     return invalid_;

--- a/include/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.h
+++ b/include/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.h
@@ -17,7 +17,6 @@
 #define QUIR_CIRCUITS_ANALYSIS_H
 
 #include "Dialect/Pulse/IR/PulseOps.h"
-#include "Dialect/QCS/Utils/ParameterInitialValueAnalysis.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
 
 #include "mlir/IR/BuiltinOps.h"
@@ -53,8 +52,7 @@ public:
   }
 
 private:
-  double getAngleValue(mlir::Value operand,
-                       mlir::qcs::ParameterInitialValueAnalysis *nameAnalysis);
+  double getAngleValue(mlir::Value operand);
   llvm::StringRef getParameterName(mlir::Value operand);
   quir::DurationAttr getDuration(mlir::Value operand);
 };
@@ -75,7 +73,6 @@ struct QUIRCircuitAnalysisPass
 
 llvm::Expected<double>
 angleValToDouble(mlir::Value inVal,
-                 mlir::qcs::ParameterInitialValueAnalysis *nameAnalysis,
                  mlir::quir::QUIRCircuitAnalysis *circuitAnalysis = nullptr);
 
 } // namespace mlir::quir

--- a/include/Frontend/OpenQASM3/QUIRGenQASM3Visitor.h
+++ b/include/Frontend/OpenQASM3/QUIRGenQASM3Visitor.h
@@ -319,6 +319,8 @@ private:
   ExpressionValueType getValueFromLiteral(const QASM::ASTMPDecimalNode *);
 
   mlir::Type getQUIRTypeFromDeclaration(const QASM::ASTDeclarationNode *);
+
+  bool enableParametersWarningEmitted = false;
 };
 
 } // namespace qssc::frontend::openqasm3

--- a/lib/Dialect/QCS/IR/QCSOps.cpp
+++ b/lib/Dialect/QCS/IR/QCSOps.cpp
@@ -47,7 +47,7 @@ verifyQCSParameterOpSymbolUses(SymbolTableCollection &symbolTable,
                                mlir::Operation *op,
                                bool operandMustMatchSymbolType = false) {
   assert(op);
-
+  return success();
   // Check that op has attribute variable_name
   auto paramRefAttr = op->getAttrOfType<FlatSymbolRefAttr>("parameter_name");
   if (!paramRefAttr)
@@ -98,14 +98,15 @@ verifyQCSParameterOpSymbolUses(SymbolTableCollection &symbolTable,
 // ParameterLoadOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult
-ParameterLoadOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyQCSParameterOpSymbolUses(symbolTable, getOperation(), true);
-}
+// LogicalResult
+// ParameterLoadOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+//   return verifyQCSParameterOpSymbolUses(symbolTable, getOperation(), true);
+// }
 
 // Returns the float value from the initial value of this parameter
 ParameterType ParameterLoadOp::getInitialValue() {
   auto *op = getOperation();
+#if 0
   auto paramRefAttr =
       op->getAttrOfType<mlir::FlatSymbolRefAttr>("parameter_name");
   auto declOp =
@@ -151,6 +152,16 @@ ParameterType ParameterLoadOp::getInitialValue() {
 
   op->emitError("Does not have initial value set.");
   return 0.0;
+#else 
+  double retVal = 0.0;
+  if (op->hasAttr("initial_value")) {
+    auto initAttr = op->getAttr("initial_value").dyn_cast<FloatAttr>();
+    if (initAttr) {
+      retVal = initAttr.getValue().convertToDouble();
+    }
+  }
+  return retVal;
+#endif
 }
 
 // Returns the float value from the initial value of this parameter
@@ -158,6 +169,7 @@ ParameterType ParameterLoadOp::getInitialValue() {
 // in order to avoid slow SymbolTable lookups
 ParameterType ParameterLoadOp::getInitialValue(
     llvm::StringMap<ParameterType> &declareParametersMap) {
+#if 0
   auto *op = getOperation();
   auto paramRefAttr =
       op->getAttrOfType<mlir::FlatSymbolRefAttr>("parameter_name");
@@ -171,6 +183,9 @@ ParameterType ParameterLoadOp::getInitialValue(
   }
 
   return paramOpEntry->second;
+#else 
+  return getInitialValue();
+#endif
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/QCS/IR/QCSOps.cpp
+++ b/lib/Dialect/QCS/IR/QCSOps.cpp
@@ -39,59 +39,6 @@ using namespace mlir::qcs;
 // NOLINTNEXTLINE(misc-include-cleaner): Required for MLIR registrations
 #include "Dialect/QCS/IR/QCSOps.cpp.inc"
 
-namespace {
-LogicalResult
-verifyQCSParameterOpSymbolUses(SymbolTableCollection &symbolTable,
-                               mlir::Operation *op,
-                               bool operandMustMatchSymbolType = false) {
-  assert(op);
-  return success();
-  // Check that op has attribute variable_name
-  auto paramRefAttr = op->getAttrOfType<FlatSymbolRefAttr>("parameter_name");
-  if (!paramRefAttr)
-    return op->emitOpError(
-        "requires a symbol reference attribute 'parameter_name'");
-
-  // Check that symbol reference resolves to a parameter declaration
-  auto declOp =
-      symbolTable.lookupNearestSymbolFrom<DeclareParameterOp>(op, paramRefAttr);
-
-  // check higher level modules
-  if (!declOp) {
-    auto targetModuleOp = op->getParentOfType<mlir::ModuleOp>();
-    if (targetModuleOp) {
-      auto topLevelModuleOp = targetModuleOp->getParentOfType<mlir::ModuleOp>();
-      if (!declOp && topLevelModuleOp)
-        declOp = symbolTable.lookupNearestSymbolFrom<DeclareParameterOp>(
-            topLevelModuleOp, paramRefAttr);
-    }
-  }
-
-  if (!declOp)
-    return op->emitOpError() << "no valid reference to a parameter '"
-                             << paramRefAttr.getValue() << "'";
-
-  assert(op->getNumResults() <= 1 && "assume none or single result");
-
-  // Check that type of variables matches result type of this Op
-  if (op->getNumResults() == 1) {
-    if (op->getResult(0).getType() != declOp.getType())
-      return op->emitOpError(
-          "type mismatch between variable declaration and variable use");
-  }
-
-  if (op->getNumOperands() > 0 && operandMustMatchSymbolType) {
-    assert(op->getNumOperands() == 1 &&
-           "type check only supported for a single operand");
-    if (op->getOperand(0).getType() != declOp.getType())
-      return op->emitOpError(
-          "type mismatch between variable declaration and variable assignment");
-  }
-  return success();
-}
-
-} // anonymous namespace
-
 //===----------------------------------------------------------------------===//
 // ParameterLoadOp
 //===----------------------------------------------------------------------===//
@@ -100,8 +47,8 @@ verifyQCSParameterOpSymbolUses(SymbolTableCollection &symbolTable,
 ParameterType ParameterLoadOp::getInitialValue() {
   auto *op = getOperation();
   double retVal = 0.0;
-  if (op->hasAttr("initial_value")) {
-    auto initAttr = op->getAttr("initial_value").dyn_cast<FloatAttr>();
+  if (op->hasAttr("initialValue")) {
+    auto initAttr = op->getAttr("initialValue").dyn_cast<FloatAttr>();
     if (initAttr)
       retVal = initAttr.getValue().convertToDouble();
   }

--- a/lib/Dialect/QCS/IR/QCSOps.cpp
+++ b/lib/Dialect/QCS/IR/QCSOps.cpp
@@ -21,7 +21,6 @@
 #include "Dialect/QCS/IR/QCSOps.h"
 
 #include "Dialect/QCS/IR/QCSTypes.h"
-#include "Dialect/QUIR/IR/QUIRAttributes.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -30,7 +29,6 @@
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/Support/LogicalResult.h>
 
-#include "llvm/ADT/StringMap.h"
 
 #include <cassert>
 
@@ -109,9 +107,8 @@ ParameterType ParameterLoadOp::getInitialValue() {
   double retVal = 0.0;
   if (op->hasAttr("initial_value")) {
     auto initAttr = op->getAttr("initial_value").dyn_cast<FloatAttr>();
-    if (initAttr) {
+    if (initAttr)
       retVal = initAttr.getValue().convertToDouble();
-    }
   }
   return retVal;
 }

--- a/lib/Dialect/QCS/IR/QCSOps.cpp
+++ b/lib/Dialect/QCS/IR/QCSOps.cpp
@@ -27,7 +27,6 @@
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/Support/LogicalResult.h>
 
-
 using namespace mlir;
 using namespace mlir::qcs;
 

--- a/lib/Dialect/QCS/IR/QCSOps.cpp
+++ b/lib/Dialect/QCS/IR/QCSOps.cpp
@@ -23,13 +23,10 @@
 #include "Dialect/QCS/IR/QCSTypes.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/SymbolTable.h"
 #include <mlir/IR/OpImplementation.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/Support/LogicalResult.h>
 
-#include <cassert>
 
 using namespace mlir;
 using namespace mlir::qcs;

--- a/lib/Dialect/QCS/IR/QCSOps.cpp
+++ b/lib/Dialect/QCS/IR/QCSOps.cpp
@@ -29,7 +29,6 @@
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/Support/LogicalResult.h>
 
-
 #include <cassert>
 
 using namespace mlir;

--- a/lib/Dialect/QCS/IR/QCSOps.cpp
+++ b/lib/Dialect/QCS/IR/QCSOps.cpp
@@ -106,53 +106,6 @@ verifyQCSParameterOpSymbolUses(SymbolTableCollection &symbolTable,
 // Returns the float value from the initial value of this parameter
 ParameterType ParameterLoadOp::getInitialValue() {
   auto *op = getOperation();
-#if 0
-  auto paramRefAttr =
-      op->getAttrOfType<mlir::FlatSymbolRefAttr>("parameter_name");
-  auto declOp =
-      mlir::SymbolTable::lookupNearestSymbolFrom<mlir::qcs::DeclareParameterOp>(
-          op, paramRefAttr);
-
-  // check higher level modules
-
-  auto currentScopeOp = op->getParentOfType<mlir::ModuleOp>();
-  do {
-    declOp = mlir::SymbolTable::lookupNearestSymbolFrom<
-        mlir::qcs::DeclareParameterOp>(currentScopeOp, paramRefAttr);
-    if (declOp)
-      break;
-    currentScopeOp = currentScopeOp->getParentOfType<mlir::ModuleOp>();
-    assert(currentScopeOp);
-  } while (!declOp);
-
-  assert(declOp);
-
-  double retVal;
-
-  auto iniValue = declOp.getInitialValue();
-  if (iniValue.has_value()) {
-    auto angleAttr = iniValue.value().dyn_cast<mlir::quir::AngleAttr>();
-
-    auto floatAttr = iniValue.value().dyn_cast<FloatAttr>();
-
-    if (!(angleAttr || floatAttr)) {
-      op->emitError(
-          "Parameters are currently limited to angles or float[64] only.");
-      return 0.0;
-    }
-
-    if (angleAttr)
-      retVal = angleAttr.getValue().convertToDouble();
-
-    if (floatAttr)
-      retVal = floatAttr.getValue().convertToDouble();
-
-    return retVal;
-  }
-
-  op->emitError("Does not have initial value set.");
-  return 0.0;
-#else 
   double retVal = 0.0;
   if (op->hasAttr("initial_value")) {
     auto initAttr = op->getAttr("initial_value").dyn_cast<FloatAttr>();
@@ -161,31 +114,6 @@ ParameterType ParameterLoadOp::getInitialValue() {
     }
   }
   return retVal;
-#endif
-}
-
-// Returns the float value from the initial value of this parameter
-// this version uses a precomputed map of parameter_name to the initial_value
-// in order to avoid slow SymbolTable lookups
-ParameterType ParameterLoadOp::getInitialValue(
-    llvm::StringMap<ParameterType> &declareParametersMap) {
-#if 0
-  auto *op = getOperation();
-  auto paramRefAttr =
-      op->getAttrOfType<mlir::FlatSymbolRefAttr>("parameter_name");
-
-  auto paramOpEntry = declareParametersMap.find(paramRefAttr.getValue());
-
-  if (paramOpEntry == declareParametersMap.end()) {
-    op->emitError("Could not find declare parameter op " +
-                  paramRefAttr.getValue().str());
-    return 0.0;
-  }
-
-  return paramOpEntry->second;
-#else 
-  return getInitialValue();
-#endif
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/QCS/IR/QCSOps.cpp
+++ b/lib/Dialect/QCS/IR/QCSOps.cpp
@@ -96,11 +96,6 @@ verifyQCSParameterOpSymbolUses(SymbolTableCollection &symbolTable,
 // ParameterLoadOp
 //===----------------------------------------------------------------------===//
 
-// LogicalResult
-// ParameterLoadOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-//   return verifyQCSParameterOpSymbolUses(symbolTable, getOperation(), true);
-// }
-
 // Returns the float value from the initial value of this parameter
 ParameterType ParameterLoadOp::getInitialValue() {
   auto *op = getOperation();

--- a/lib/Dialect/QCS/Utils/ParameterInitialValueAnalysis.cpp
+++ b/lib/Dialect/QCS/Utils/ParameterInitialValueAnalysis.cpp
@@ -63,7 +63,7 @@ ParameterInitialValueAnalysis::ParameterInitialValueAnalysis(
           if (!parameterLoadOp)
             continue;
 
-          double initialValue =
+          const double initialValue =
               std::get<double>(parameterLoadOp.getInitialValue());
           initialValues_[parameterLoadOp.getParameterName()] = initialValue;
           foundParameters = true;

--- a/lib/Dialect/QCS/Utils/ParameterInitialValueAnalysis.cpp
+++ b/lib/Dialect/QCS/Utils/ParameterInitialValueAnalysis.cpp
@@ -63,9 +63,9 @@ ParameterInitialValueAnalysis::ParameterInitialValueAnalysis(
           if (!parameterLoadOp)
             continue;
 
-          double initial_value =
+          double initialValue =
               std::get<double>(parameterLoadOp.getInitialValue());
-          initial_values_[parameterLoadOp.getParameterName()] = initial_value;
+          initialValues_[parameterLoadOp.getParameterName()] = initialValue;
           foundParameters = true;
         }
     if (!foundParameters) {
@@ -80,9 +80,9 @@ ParameterInitialValueAnalysis::ParameterInitialValueAnalysis(
 
   // debugging / test print out
   if (printAnalysisEntries) {
-    for (auto &initial_value : initial_values_) {
-      llvm::outs() << initial_value.first() << " = "
-                   << std::get<double>(initial_value.second) << "\n";
+    for (auto &initialValue : initialValues_) {
+      llvm::outs() << initialValue.first() << " = "
+                   << std::get<double>(initialValue.second) << "\n";
     }
   }
 }

--- a/lib/Dialect/QCS/Utils/ParameterInitialValueAnalysis.cpp
+++ b/lib/Dialect/QCS/Utils/ParameterInitialValueAnalysis.cpp
@@ -19,7 +19,6 @@
 #include "Dialect/QCS/Utils/ParameterInitialValueAnalysis.h"
 
 #include "Dialect/QCS/IR/QCSOps.h"
-#include "Dialect/QUIR/IR/QUIRAttributes.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -64,7 +63,8 @@ ParameterInitialValueAnalysis::ParameterInitialValueAnalysis(
           if (!parameterLoadOp)
             continue;
 
-          double initial_value = std::get<double>(parameterLoadOp.getInitialValue());
+          double initial_value =
+              std::get<double>(parameterLoadOp.getInitialValue());
           initial_values_[parameterLoadOp.getParameterName()] = initial_value;
           foundParameters = true;
         }

--- a/lib/Dialect/QUIR/Transforms/LoadElimination.cpp
+++ b/lib/Dialect/QUIR/Transforms/LoadElimination.cpp
@@ -21,7 +21,6 @@
 #include "Dialect/QUIR/Transforms/LoadElimination.h"
 
 #include "Dialect/OQ3/IR/OQ3Ops.h"
-#include "Dialect/QUIR/IR/QUIRAttributes.h"
 
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/SymbolTable.h"

--- a/lib/Dialect/QUIR/Transforms/LoadElimination.cpp
+++ b/lib/Dialect/QUIR/Transforms/LoadElimination.cpp
@@ -81,17 +81,6 @@ void LoadEliminationPass::runOnOperation() {
 
     auto varAssignmentOp = mlir::cast<mlir::oq3::VariableAssignOp>(assignment);
 
-    // Transfer marker for input parameters
-    // Note: for arith.constant operations, canonicalization will drop these
-    // attributes and we need to find another way (to be specific:
-    // canonicalization will move constants to the begin of ops like Functions
-    // by means of dialect->materializeConstant(...) that creates new
-    // constants). For now and for angle constants, this approach is good-enough
-    // while not satisfying.
-    if (decl.isInputVariable())
-      varAssignmentOp.getAssignedValue().getDefiningOp()->setAttr(
-          mlir::quir::getInputParameterAttrName(), decl.getNameAttr());
-
     for (auto *userOp : symbolUses) {
 
       if (!mlir::isa<mlir::oq3::VariableLoadOp>(userOp))

--- a/lib/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.cpp
+++ b/lib/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.cpp
@@ -126,10 +126,8 @@ llvm::StringRef QUIRCircuitAnalysis::getParameterName(mlir::Value operand) {
           dyn_cast<qcs::ParameterLoadOp>(castOp.getArg().getDefiningOp());
   }
 
-  if (parameterLoad &&
-      parameterLoad->hasAttr(mlir::quir::getInputParameterAttrName())) {
-    parameterName = parameterLoad->getAttrOfType<StringAttr>(
-        mlir::quir::getInputParameterAttrName());
+  if (parameterLoad) {
+    parameterName = parameterLoad.getParameterName();
   }
   return parameterName;
 }

--- a/lib/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.cpp
+++ b/lib/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.cpp
@@ -43,8 +43,7 @@ using namespace mlir;
 
 namespace mlir::quir {
 
-double
-parameterValToDouble(mlir::qcs::ParameterLoadOp defOp) {
+double parameterValToDouble(mlir::qcs::ParameterLoadOp defOp) {
   return std::get<double>(defOp.getInitialValue());
 }
 
@@ -97,8 +96,7 @@ angleValToDouble(mlir::Value inVal,
   return llvm::createStringError(llvm::inconvertibleErrorCode(), errorStr);
 } // angleValToDouble
 
-double QUIRCircuitAnalysis::getAngleValue(
-    mlir::Value operand) {
+double QUIRCircuitAnalysis::getAngleValue(mlir::Value operand) {
   auto valueOrError = angleValToDouble(operand);
   if (auto err = valueOrError.takeError()) {
     operand.getDefiningOp()->emitOpError() << toString(std::move(err)) + "\n";
@@ -119,9 +117,8 @@ llvm::StringRef QUIRCircuitAnalysis::getParameterName(mlir::Value operand) {
           dyn_cast<qcs::ParameterLoadOp>(castOp.getArg().getDefiningOp());
   }
 
-  if (parameterLoad) {
+  if (parameterLoad)
     parameterName = parameterLoad.getParameterName();
-  }
   return parameterName;
 }
 

--- a/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
@@ -1185,7 +1185,7 @@ void QUIRGenQASM3Visitor::visit(const ASTDeclarationNode *node) {
 
       if (genParameter) {
         auto load = varHandler.generateParameterLoad(
-            loc, "input_" + idNode->GetName(), val);
+            loc, idNode->GetName(), val);
         varHandler.generateVariableAssignment(loc, idNode->GetName(), load);
         genVariableWithVal = false;
       }

--- a/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
@@ -1167,13 +1167,19 @@ void QUIRGenQASM3Visitor::visit(const ASTDeclarationNode *node) {
     if (node->GetModifierType() == QASM::ASTTypeInputModifier) {
       bool genParameter = true;
       if (!enableParameters) {
+        if (!enableParametersWarningEmitted) {
         reportError(node, mlir::DiagnosticSeverity::Warning)
             << "Input parameter " << idNode->GetName()
             << " warning. Parameters are not enabled. Enable with "
                "--enable-parameters.";
+          enableParametersWarningEmitted = true;
+        }
         genParameter = false;
       } else if (!(variableType.isa<mlir::quir::AngleType>() ||
                    variableType.isa<mlir::Float64Type>())) {
+        reportError(node, mlir::DiagnosticSeverity::Error)
+            << "Input parameter " << idNode->GetName()
+            << " type error. Input parameters must be angle or float[64].";
         genParameter = false;
       }
 

--- a/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
@@ -1174,17 +1174,12 @@ void QUIRGenQASM3Visitor::visit(const ASTDeclarationNode *node) {
         genParameter = false;
       } else if (!(variableType.isa<mlir::quir::AngleType>() ||
                    variableType.isa<mlir::Float64Type>())) {
-        reportError(node, mlir::DiagnosticSeverity::Error)
-            << "Input parameter " << idNode->GetName()
-            << " type error. Input parameters must be angle or float[64].";
         genParameter = false;
       }
 
       if (genParameter) {
-        varHandler.generateParameterDeclaration(loc, idNode->GetMangledName(),
-                                                variableType, val);
         auto load = varHandler.generateParameterLoad(
-            loc, idNode->GetMangledName(), val);
+            loc, "input_" + idNode->GetName(), val);
         varHandler.generateVariableAssignment(loc, idNode->GetName(), load);
         genVariableWithVal = false;
       }

--- a/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
@@ -1168,10 +1168,10 @@ void QUIRGenQASM3Visitor::visit(const ASTDeclarationNode *node) {
       bool genParameter = true;
       if (!enableParameters) {
         if (!enableParametersWarningEmitted) {
-        reportError(node, mlir::DiagnosticSeverity::Warning)
-            << "Input parameter " << idNode->GetName()
-            << " warning. Parameters are not enabled. Enable with "
-               "--enable-parameters.";
+          reportError(node, mlir::DiagnosticSeverity::Warning)
+              << "Input parameter " << idNode->GetName()
+              << " warning. Parameters are not enabled. Enable with "
+                 "--enable-parameters.";
           enableParametersWarningEmitted = true;
         }
         genParameter = false;
@@ -1184,8 +1184,8 @@ void QUIRGenQASM3Visitor::visit(const ASTDeclarationNode *node) {
       }
 
       if (genParameter) {
-        auto load = varHandler.generateParameterLoad(
-            loc, idNode->GetName(), val);
+        auto load =
+            varHandler.generateParameterLoad(loc, idNode->GetName(), val);
         varHandler.generateVariableAssignment(loc, idNode->GetName(), load);
         genVariableWithVal = false;
       }

--- a/lib/Frontend/OpenQASM3/QUIRVariableBuilder.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRVariableBuilder.cpp
@@ -128,9 +128,15 @@ QUIRVariableBuilder::generateParameterLoad(mlir::Location location,
         variableName.str());
 
     double initialValue = 0.0;
-    auto constAttr = constantOp.getValue().dyn_cast<mlir::FloatAttr>();
-    if (constAttr) {
-      initialValue = constAttr.getValueAsDouble();
+    
+    auto constFloatAttr = constantOp.getValue().dyn_cast<mlir::FloatAttr>();
+    if (constFloatAttr) {
+      initialValue = constFloatAttr.getValueAsDouble();
+    } else {
+      auto constAngleAttr = constantOp.getValue().dyn_cast<mlir::quir::AngleAttr>();
+      if (constAngleAttr) {
+        initialValue = constAngleAttr.getValue().convertToDouble();
+      }
     }
 
     mlir::FloatAttr floatAttr = getClassicalBuilder().getF64FloatAttr(initialValue);

--- a/lib/Frontend/OpenQASM3/QUIRVariableBuilder.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRVariableBuilder.cpp
@@ -126,6 +126,15 @@ QUIRVariableBuilder::generateParameterLoad(mlir::Location location,
     auto op = getClassicalBuilder().create<mlir::qcs::ParameterLoadOp>(
         location, builder.getType<mlir::quir::AngleType>(64),
         variableName.str());
+
+    double initialValue = 0.0;
+    auto constAttr = constantOp.getValue().dyn_cast<mlir::FloatAttr>();
+    if (constAttr) {
+      initialValue = constAttr.getValueAsDouble();
+    }
+
+    mlir::FloatAttr floatAttr = getClassicalBuilder().getF64FloatAttr(initialValue);
+    op->setAttr("initial_value", floatAttr);
     return op;
   }
 
@@ -134,6 +143,13 @@ QUIRVariableBuilder::generateParameterLoad(mlir::Location location,
           assignedValue.getDefiningOp())) {
     auto loadOp = getClassicalBuilder().create<mlir::qcs::ParameterLoadOp>(
         location, constantOp.getType(), variableName.str());
+    double initialValue = 0.0;
+    auto constAttr = constantOp.getValue().dyn_cast<mlir::FloatAttr>();
+    if (constAttr) {
+      initialValue = constAttr.getValueAsDouble();
+    }
+    mlir::FloatAttr floatAttr = getClassicalBuilder().getF64FloatAttr(initialValue);
+    loadOp->setAttr("initial_value", floatAttr);
     return loadOp;
   }
 

--- a/lib/Frontend/OpenQASM3/QUIRVariableBuilder.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRVariableBuilder.cpp
@@ -23,6 +23,7 @@
 
 #include "Dialect/OQ3/IR/OQ3Ops.h"
 #include "Dialect/QCS/IR/QCSOps.h"
+#include "Dialect/QUIR/IR/QUIRAttributes.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
 #include "Dialect/QUIR/IR/QUIRTypes.h"
 
@@ -128,18 +129,19 @@ QUIRVariableBuilder::generateParameterLoad(mlir::Location location,
         variableName.str());
 
     double initialValue = 0.0;
-    
+
     auto constFloatAttr = constantOp.getValue().dyn_cast<mlir::FloatAttr>();
     if (constFloatAttr) {
       initialValue = constFloatAttr.getValueAsDouble();
     } else {
-      auto constAngleAttr = constantOp.getValue().dyn_cast<mlir::quir::AngleAttr>();
-      if (constAngleAttr) {
+      auto constAngleAttr =
+          constantOp.getValue().dyn_cast<mlir::quir::AngleAttr>();
+      if (constAngleAttr)
         initialValue = constAngleAttr.getValue().convertToDouble();
-      }
     }
 
-    mlir::FloatAttr floatAttr = getClassicalBuilder().getF64FloatAttr(initialValue);
+    mlir::FloatAttr const floatAttr =
+        getClassicalBuilder().getF64FloatAttr(initialValue);
     op->setAttr("initial_value", floatAttr);
     return op;
   }
@@ -151,10 +153,10 @@ QUIRVariableBuilder::generateParameterLoad(mlir::Location location,
         location, constantOp.getType(), variableName.str());
     double initialValue = 0.0;
     auto constAttr = constantOp.getValue().dyn_cast<mlir::FloatAttr>();
-    if (constAttr) {
+    if (constAttr)
       initialValue = constAttr.getValueAsDouble();
-    }
-    mlir::FloatAttr floatAttr = getClassicalBuilder().getF64FloatAttr(initialValue);
+    mlir::FloatAttr const floatAttr =
+        getClassicalBuilder().getF64FloatAttr(initialValue);
     loadOp->setAttr("initial_value", floatAttr);
     return loadOp;
   }

--- a/lib/Frontend/OpenQASM3/QUIRVariableBuilder.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRVariableBuilder.cpp
@@ -142,7 +142,7 @@ QUIRVariableBuilder::generateParameterLoad(mlir::Location location,
 
     mlir::FloatAttr const floatAttr =
         getClassicalBuilder().getF64FloatAttr(initialValue);
-    op->setAttr("initial_value", floatAttr);
+    op->setAttr("initialValue", floatAttr);
     return op;
   }
 
@@ -157,7 +157,7 @@ QUIRVariableBuilder::generateParameterLoad(mlir::Location location,
       initialValue = constAttr.getValueAsDouble();
     mlir::FloatAttr const floatAttr =
         getClassicalBuilder().getF64FloatAttr(initialValue);
-    loadOp->setAttr("initial_value", floatAttr);
+    loadOp->setAttr("initialValue", floatAttr);
     return loadOp;
   }
 

--- a/test/Dialect/QCS/Utils/parameter-initial-value-analysis.mlir
+++ b/test/Dialect/QCS/Utils/parameter-initial-value-analysis.mlir
@@ -17,7 +17,7 @@
 module {
     // without nested pass manager should only find
     // alpha and beta
-    qcs.parameter_load "alpha" : !quir.angle<64> {initialValue = 1.000000e+00 :f64} 
+    qcs.parameter_load "alpha" : !quir.angle<64> {initialValue = 1.000000e+00 :f64}
     qcs.parameter_load "beta" : f64 {initialValue = 2.000000e+00 :f64}
     module @first {
         // nested test should find alpha and beta

--- a/test/Dialect/QCS/Utils/parameter-initial-value-analysis.mlir
+++ b/test/Dialect/QCS/Utils/parameter-initial-value-analysis.mlir
@@ -17,12 +17,12 @@
 module {
     // without nested pass manager should only find
     // alpha and beta
-    qcs.declare_parameter @alpha : !quir.angle<64> = #quir.angle<1.000000e+00> : !quir.angle<64>
-    qcs.declare_parameter @beta : f64 = 2.000000e+00 : f64
+    qcs.parameter_load "alpha" : !quir.angle<64> {initialValue = 1.000000e+00 :f64} 
+    qcs.parameter_load "beta" : f64 {initialValue = 2.000000e+00 :f64}
     module @first {
         // nested test should find alpha and beta
-        qcs.declare_parameter @theta : !quir.angle<64> = #quir.angle<3.140000e+00> : !quir.angle<64>
-        qcs.declare_parameter @phi : f64 = 1.500000e+00 : f64
+        qcs.parameter_load "theta" : !quir.angle<64> {initialValue = 3.140000e+00 :f64}
+        qcs.parameter_load "phi" : f64 {initialValue = 1.500000e+00 :f64}
     }
     module @second {
         // test module without declare_parameter

--- a/test/Dialect/QUIR/Transforms/load-elimination2.mlir
+++ b/test/Dialect/QUIR/Transforms/load-elimination2.mlir
@@ -27,8 +27,8 @@ module {
 
   func.func @main() -> !quir.angle<64> {
 
-    // CHECK: [[CONST314_ANGLE:%.*]] = quir.constant {quir.inputParameter = "a"} #quir.angle<3.140000e+00> : !quir.angle<64>
-    // REMOVE-UNUSED: [[CONST314_ANGLE:%.*]] = quir.constant {quir.inputParameter = "a"} #quir.angle<3.140000e+00> : !quir.angle<64>
+    // CHECK: [[CONST314_ANGLE:%.*]] = quir.constant #quir.angle<3.140000e+00> : !quir.angle<64>
+    // REMOVE-UNUSED: [[CONST314_ANGLE:%.*]] = quir.constant #quir.angle<3.140000e+00> : !quir.angle<64>
     %angle = quir.constant #quir.angle<3.140000e+00> : !quir.angle<64>
     %angle2 = quir.constant #quir.angle<3.140000e+00> : !quir.angle<64>
 

--- a/test/Frontend/OpenQASM3/input-parameters-if.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters-if.qasm
@@ -26,7 +26,6 @@ gate x q { }
 gate rz(phi) q { }
 
 input angle theta = 3.141;
-// CHECK: qcs.declare_parameter @_QX64_5thetaEE_ : !quir.angle<64> = #quir.angle<3.141000e+00> : !quir.angle<64>
 
 x $2;
 rz(theta) $2;
@@ -50,6 +49,9 @@ is_excited = measure $2;
 // CHECK: scf.for %arg0 = %c0 to %c1000 step %c1 {
 // CHECK: [[QUBIT2:%.*]] = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
 // CHECK: [[QUBIT3:%.*]] = quir.declare_qubit {id = 3 : i32} : !quir.qubit<1>
+
+// CHECK: [[PARAM:%.*]] = qcs.parameter_load "input_theta" : !quir.angle<64> {initial_value = 0.000000e+00 : f64}
+// CHECK: oq3.variable_assign @theta : !quir.angle<64> = [[PARAM]]
 
 // CHECK: [[EXCITED:%.*]] = oq3.variable_load @is_excited : !quir.cbit<1>
 // CHECK: [[CONST:%[0-9a-z_]+]] = arith.constant 1 : i32

--- a/test/Frontend/OpenQASM3/input-parameters-if.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters-if.qasm
@@ -50,7 +50,7 @@ is_excited = measure $2;
 // CHECK: [[QUBIT2:%.*]] = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
 // CHECK: [[QUBIT3:%.*]] = quir.declare_qubit {id = 3 : i32} : !quir.qubit<1>
 
-// CHECK: [[PARAM:%.*]] = qcs.parameter_load "input_theta" : !quir.angle<64> {initial_value = 0.000000e+00 : f64}
+// CHECK: [[PARAM:%.*]] = qcs.parameter_load "theta" : !quir.angle<64> {initial_value = 3.141000e+00 : f64}
 // CHECK: oq3.variable_assign @theta : !quir.angle<64> = [[PARAM]]
 
 // CHECK: [[EXCITED:%.*]] = oq3.variable_load @is_excited : !quir.cbit<1>

--- a/test/Frontend/OpenQASM3/input-parameters-if.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters-if.qasm
@@ -50,7 +50,7 @@ is_excited = measure $2;
 // CHECK: [[QUBIT2:%.*]] = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
 // CHECK: [[QUBIT3:%.*]] = quir.declare_qubit {id = 3 : i32} : !quir.qubit<1>
 
-// CHECK: [[PARAM:%.*]] = qcs.parameter_load "theta" : !quir.angle<64> {initial_value = 3.141000e+00 : f64}
+// CHECK: [[PARAM:%.*]] = qcs.parameter_load "theta" : !quir.angle<64> {initialValue = 3.141000e+00 : f64}
 // CHECK: oq3.variable_assign @theta : !quir.angle<64> = [[PARAM]]
 
 // CHECK: [[EXCITED:%.*]] = oq3.variable_load @is_excited : !quir.cbit<1>

--- a/test/Frontend/OpenQASM3/input-parameters-while.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters-while.qasm
@@ -21,7 +21,6 @@ gate h q {
 gate rz(phi) q { }
 
 input angle theta = 3.141;
-// CHECK: qcs.declare_parameter @_QX64_5thetaEE_ : !quir.angle<64> = #quir.angle<3.141000e+00> : !quir.angle<64>
 
 qubit $0;
 int n = 1;
@@ -59,6 +58,7 @@ bit is_excited;
 
 // CHECK: func.func @main() -> i32 {
 // CHECK: scf.for %arg0 = %c0 to %c1000 step %c1 {
+// CHECK: {{.*}} = qcs.parameter_load "input_theta" : !quir.angle<64> {initial_value = 0.000000e+00 : f64}
 // CHECK: [[QUBIT:%.*]] = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
 // CHECK: scf.while : () -> () {
 // CHECK:    [[N:%.*]] = oq3.variable_load @n : i32

--- a/test/Frontend/OpenQASM3/input-parameters-while.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters-while.qasm
@@ -58,7 +58,7 @@ bit is_excited;
 
 // CHECK: func.func @main() -> i32 {
 // CHECK: scf.for %arg0 = %c0 to %c1000 step %c1 {
-// CHECK: {{.*}} = qcs.parameter_load "theta" : !quir.angle<64> {initial_value = 3.141000e+00 : f64}
+// CHECK: {{.*}} = qcs.parameter_load "theta" : !quir.angle<64> {initialValue = 3.141000e+00 : f64}
 // CHECK: [[QUBIT:%.*]] = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
 // CHECK: scf.while : () -> () {
 // CHECK:    [[N:%.*]] = oq3.variable_load @n : i32

--- a/test/Frontend/OpenQASM3/input-parameters-while.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters-while.qasm
@@ -58,7 +58,7 @@ bit is_excited;
 
 // CHECK: func.func @main() -> i32 {
 // CHECK: scf.for %arg0 = %c0 to %c1000 step %c1 {
-// CHECK: {{.*}} = qcs.parameter_load "input_theta" : !quir.angle<64> {initial_value = 0.000000e+00 : f64}
+// CHECK: {{.*}} = qcs.parameter_load "theta" : !quir.angle<64> {initial_value = 3.141000e+00 : f64}
 // CHECK: [[QUBIT:%.*]] = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
 // CHECK: scf.while : () -> () {
 // CHECK:    [[N:%.*]] = oq3.variable_load @n : i32

--- a/test/Frontend/OpenQASM3/input-parameters.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters.qasm
@@ -65,9 +65,9 @@ c = measure $0;
 // CHECK: %0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
 // CHECK: %1 = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
 
-// CHECK: %2 = qcs.parameter_load "input_theta" : !quir.angle<64> {initial_value = 0.000000e+00 : f64}
+// CHECK: %2 = qcs.parameter_load "theta" : !quir.angle<64> {initial_value = 3.141000e+00 : f64}
 // CHECK: oq3.variable_assign @theta : !quir.angle<64> = %2
-// CHECK: %3 = qcs.parameter_load "input_theta2" : f64 {initial_value = 1.560000e+00 : f64}
+// CHECK: %3 = qcs.parameter_load "theta2" : f64 {initial_value = 1.560000e+00 : f64}
 // CHECK: oq3.variable_assign @theta2 : f64 = %3
 // CHECK-XX: quir.reset %0 : !quir.qubit<1>
 // CHECK-NOT: oq3.variable_assign @theta : !quir.angle<64> = %angle

--- a/test/Frontend/OpenQASM3/input-parameters.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters.qasm
@@ -28,10 +28,8 @@ gate sx q { }
 gate rz(phi) q { }
 
 input angle theta = 3.141;
-// CHECK: qcs.declare_parameter @_QX64_5thetaEE_ : !quir.angle<64> = #quir.angle<3.141000e+00> : !quir.angle<64>
 
 input float[64] theta2 = 1.56;
-// CHECK: qcs.declare_parameter @_QDDd64_6theta2EE_ : f64 = 1.560000e+00 : f64
 
 reset $0;
 
@@ -67,9 +65,9 @@ c = measure $0;
 // CHECK: %0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
 // CHECK: %1 = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
 
-// CHECK: %2 = qcs.parameter_load @_QX64_5thetaEE_ : !quir.angle<64>
+// CHECK: %2 = qcs.parameter_load "input_theta" : !quir.angle<64> {initial_value = 0.000000e+00 : f64}
 // CHECK: oq3.variable_assign @theta : !quir.angle<64> = %2
-// CHECK: %3 = qcs.parameter_load @_QDDd64_6theta2EE_ : f64
+// CHECK: %3 = qcs.parameter_load "input_theta2" : f64 {initial_value = 1.560000e+00 : f64}
 // CHECK: oq3.variable_assign @theta2 : f64 = %3
 // CHECK-XX: quir.reset %0 : !quir.qubit<1>
 // CHECK-NOT: oq3.variable_assign @theta : !quir.angle<64> = %angle

--- a/test/Frontend/OpenQASM3/input-parameters.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters.qasm
@@ -65,9 +65,9 @@ c = measure $0;
 // CHECK: %0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
 // CHECK: %1 = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
 
-// CHECK: %2 = qcs.parameter_load "theta" : !quir.angle<64> {initial_value = 3.141000e+00 : f64}
+// CHECK: %2 = qcs.parameter_load "theta" : !quir.angle<64> {initialValue = 3.141000e+00 : f64}
 // CHECK: oq3.variable_assign @theta : !quir.angle<64> = %2
-// CHECK: %3 = qcs.parameter_load "theta2" : f64 {initial_value = 1.560000e+00 : f64}
+// CHECK: %3 = qcs.parameter_load "theta2" : f64 {initialValue = 1.560000e+00 : f64}
 // CHECK: oq3.variable_assign @theta2 : f64 = %3
 // CHECK-XX: quir.reset %0 : !quir.qubit<1>
 // CHECK-NOT: oq3.variable_assign @theta : !quir.angle<64> = %angle


### PR DESCRIPTION
Improves performance of compilation when using parameters by dropping the use of the DeclareParameterOp and resulting symbol lookup. The initial value has been moved to an attribute of the ParameterLoadOp. Removes the use of ParameterInitialValueAnalysis.