### PR TITLE
add threading to updateParameters

### DIFF
--- a/include/API/api.h
+++ b/include/API/api.h
@@ -125,6 +125,11 @@ inline int asMainReturnCode(llvm::Error err) {
 /// @param treatWarningsAsErrors return errors in place of warnings
 /// @param diagnosticCb an optional callback that will receive emitted
 /// diagnostics
+/// @param numberOfThreads number of threads to use in binding
+///    -1 : number of cpus
+///    0
+///    > 0: limit
+///    defaults to -1
 /// @return 0 on success
 int bindArguments(std::string_view target, qssc::config::EmitAction action,
                   std::string_view configPath, std::string_view moduleInput,
@@ -132,7 +137,8 @@ int bindArguments(std::string_view target, qssc::config::EmitAction action,
                   std::unordered_map<std::string, double> const &arguments,
                   bool treatWarningsAsErrors, bool enableInMemoryInput,
                   std::string *inMemoryOutput,
-                  const OptDiagnosticCallback &onDiagnostic);
+                  const OptDiagnosticCallback &onDiagnostic,
+                  int numberOfThreads = -1);
 
 } // namespace qssc
 #endif // QSS_COMPILER_LIB_H

--- a/include/Arguments/Arguments.h
+++ b/include/Arguments/Arguments.h
@@ -79,13 +79,12 @@ public:
 };
 
 // TODO generalize type of arguments
-llvm::Error bindArguments(llvm::StringRef moduleInput,
-                          llvm::StringRef payloadOutputPath,
-                          ArgumentSource const &arguments,
-                          bool treatWarningsAsErrors, bool enableInMemoryInput,
-                          std::string *inMemoryOutput,
-                          BindArgumentsImplementationFactory &factory,
-                          const OptDiagnosticCallback &onDiagnostic);
+llvm::Error
+bindArguments(llvm::StringRef moduleInput, llvm::StringRef payloadOutputPath,
+              ArgumentSource const &arguments, bool treatWarningsAsErrors,
+              bool enableInMemoryInput, std::string *inMemoryOutput,
+              BindArgumentsImplementationFactory &factory,
+              const OptDiagnosticCallback &onDiagnostic, int numberOfThreads);
 
 } // namespace qssc::arguments
 

--- a/lib/API/api.cpp
+++ b/lib/API/api.cpp
@@ -811,7 +811,8 @@ bindArguments_(std::string_view target, qssc::config::EmitAction action,
                std::unordered_map<std::string, double> const &arguments,
                bool treatWarningsAsErrors, bool enableInMemoryInput,
                std::string *inMemoryOutput,
-               const qssc::OptDiagnosticCallback &onDiagnostic) {
+               const qssc::OptDiagnosticCallback &onDiagnostic,
+               int numberOfThreads) {
 
   MLIRContext context{};
 
@@ -850,7 +851,8 @@ bindArguments_(std::string_view target, qssc::config::EmitAction action,
       *factory.value();
   return qssc::arguments::bindArguments(
       moduleInput, payloadOutputPath, source, treatWarningsAsErrors,
-      enableInMemoryInput, inMemoryOutput, factoryRef, onDiagnostic);
+      enableInMemoryInput, inMemoryOutput, factoryRef, onDiagnostic,
+      numberOfThreads);
 }
 
 } // anonymous namespace
@@ -862,12 +864,12 @@ int qssc::bindArguments(
     std::unordered_map<std::string, double> const &arguments,
     bool treatWarningsAsErrors, bool enableInMemoryInput,
     std::string *inMemoryOutput,
-    const qssc::OptDiagnosticCallback &onDiagnostic) {
+    const qssc::OptDiagnosticCallback &onDiagnostic, int numberOfThreads) {
 
-  if (auto err =
-          bindArguments_(target, action, configPath, moduleInput,
-                         payloadOutputPath, arguments, treatWarningsAsErrors,
-                         enableInMemoryInput, inMemoryOutput, onDiagnostic)) {
+  if (auto err = bindArguments_(
+          target, action, configPath, moduleInput, payloadOutputPath, arguments,
+          treatWarningsAsErrors, enableInMemoryInput, inMemoryOutput,
+          onDiagnostic, numberOfThreads)) {
     llvm::logAllUnhandledErrors(std::move(err), llvm::errs());
     return 1;
   }

--- a/lib/Arguments/Arguments.cpp
+++ b/lib/Arguments/Arguments.cpp
@@ -208,7 +208,6 @@ bindArguments(llvm::StringRef moduleInput, llvm::StringRef payloadOutputPath,
   //    payload was on disk originally use writeBack
   if (auto err = payload->writeBack())
     return err;
-
   if (enableInMemoryOutput || enableInMemoryInput) {
     if (auto err = payload->writeString(inMemoryOutput))
       return err;
@@ -221,6 +220,7 @@ bindArguments(llvm::StringRef moduleInput, llvm::StringRef payloadOutputPath,
       *inMemoryOutput = "";
     }
   }
+
   return llvm::Error::success();
 }
 

--- a/lib/Arguments/Arguments.cpp
+++ b/lib/Arguments/Arguments.cpp
@@ -84,7 +84,10 @@ llvm::Error updateParameters(qssc::payload::PatchablePayload *payload,
       }));
 
   uint numThreads = 0;
-  for (const auto &[binaryName, patchPoints] : sig.patchPointsByBinary) {
+  for (const auto &entry : sig.patchPointsByBinary) {
+
+    const auto &binaryName = entry.first;
+    const auto &patchPoints = entry.second;
 
     if (patchPoints.size() == 0) // no patch points
       continue;

--- a/python_lib/qss_compiler/lib.cpp
+++ b/python_lib/qss_compiler/lib.cpp
@@ -228,7 +228,7 @@ py::tuple py_link_file(const std::string &input, const bool enableInMemoryInput,
                        const std::unordered_map<std::string, double> &arguments,
                        bool treatWarningsAsErrors,
                        qssc::DiagnosticCallback onDiagnostic,
-                       int numberOfThreads = 10) {
+                       int numberOfThreads = -1) {
 
   std::string inMemoryOutput("");
 

--- a/python_lib/qss_compiler/lib.cpp
+++ b/python_lib/qss_compiler/lib.cpp
@@ -227,14 +227,15 @@ py::tuple py_link_file(const std::string &input, const bool enableInMemoryInput,
                        const std::string &configPath,
                        const std::unordered_map<std::string, double> &arguments,
                        bool treatWarningsAsErrors,
-                       qssc::DiagnosticCallback onDiagnostic) {
+                       qssc::DiagnosticCallback onDiagnostic,
+                       int numberOfThreads = 10) {
 
   std::string inMemoryOutput("");
 
   int const status = qssc::bindArguments(
       target, qssc::config::EmitAction::QEM, configPath, input, outputPath,
       arguments, treatWarningsAsErrors, enableInMemoryInput, &inMemoryOutput,
-      std::move(onDiagnostic));
+      std::move(onDiagnostic), numberOfThreads);
 
   bool const success = status == 0;
 #ifndef NDEBUG

--- a/python_lib/qss_compiler/link.py
+++ b/python_lib/qss_compiler/link.py
@@ -53,9 +53,9 @@ class LinkOptions:
     """Treat link warnings as errors"""
     on_diagnostic: Optional[Callable[[Diagnostic], Any]] = None
     """Optional callback for processing diagnostic messages from the linker."""
-    number_of_threads: int = 10
+    number_of_threads: int = -1
     """Number of threads to use in linking
-          -1 = unlimited,
+          -1 = number of cpus reported,
           0 disabled,
           > 1 = limit,
           defaults = -1

--- a/python_lib/qss_compiler/link.py
+++ b/python_lib/qss_compiler/link.py
@@ -53,6 +53,13 @@ class LinkOptions:
     """Treat link warnings as errors"""
     on_diagnostic: Optional[Callable[[Diagnostic], Any]] = None
     """Optional callback for processing diagnostic messages from the linker."""
+    number_of_threads: int = 10
+    """Number of threads to use in linking
+          -1 = unlimited,
+          0 disabled,
+          > 1 = limit,
+          defaults = -1
+    """
 
 
 def _prepare_link_options(link_options: Optional[LinkOptions] = None, **kwargs) -> LinkOptions:
@@ -133,6 +140,7 @@ def link_file(
             link_options.arguments,
             link_options.treat_warnings_as_errors,
             link_options.on_diagnostic,
+            link_options.number_of_threads,
         )
         if not success:
             exception_mapping = {

--- a/releasenotes/notes/link-threading-d295374d01595205.yaml
+++ b/releasenotes/notes/link-threading-d295374d01595205.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds `number_of_threads` parameter to qss_compiler.link_file
+    interface to control number of threads used during linking. 

--- a/releasenotes/notes/link-threading-d295374d01595205.yaml
+++ b/releasenotes/notes/link-threading-d295374d01595205.yaml
@@ -2,4 +2,4 @@
 features:
   - |
     Adds `number_of_threads` parameter to qss_compiler.link_file
-    interface to control number of threads used during linking. 
+    interface to control number of threads used during linking.


### PR DESCRIPTION
Adds threading support to the updateParameters method used in bindArguments. This will create threads for the patch point expression conversion from string to a calculated value. 

The number of threads is controlled by the python interfaces `number_of_threads` option:
* `-1`: set to number of CPUs reported
* `0`: diable
* `> 1`: limit

defaults to -1


Testing indicates that the majority of time in spent in the [zip_close](https://github.com/openqasm/qe-compiler/blob/1f506a70e51a042c9e21767faa1aa24720c016c5/lib/Payload/ZipPayload/PatchableZipPayload.cpp#L183)  line limiting opportunities for applying additional parallelism. 