### PR TITLE
[Backport] Parameters Compiling Performance Improvements  (#330)

### DIFF
--- a/include/Dialect/QCS/IR/QCSOps.td
+++ b/include/Dialect/QCS/IR/QCSOps.td
@@ -267,7 +267,7 @@ def QCS_DeclareParameterOp : QCS_Op<"declare_parameter", [Symbol]> {
 }
 
 def QCS_ParameterLoadOp : QCS_Op<"parameter_load",
-                        [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+                        []> {
     let summary = "Use the current value of a parameter";
     let description = [{
         The operation `qcs.parameter_load` returns the current value of the
@@ -281,16 +281,12 @@ def QCS_ParameterLoadOp : QCS_Op<"parameter_load",
     }];
 
     let arguments = (ins
-        FlatSymbolRefAttr:$parameter_name
+        StrAttr:$parameter_name
     );
 
     let results = (outs AnyClassical:$res);
 
     let extraClassDeclaration = [{
-        // Return the initial value - using ParameterInitialValueAnalysis
-        ParameterType getInitialValue(llvm::StringMap<ParameterType> &parameterNames);
-
-        // Return the initial value - slower SymbolTable version
         ParameterType getInitialValue();
     }];
 

--- a/include/Dialect/QCS/Utils/ParameterInitialValueAnalysis.h
+++ b/include/Dialect/QCS/Utils/ParameterInitialValueAnalysis.h
@@ -40,12 +40,12 @@ using InitialValueType = llvm::StringMap<ParameterType>;
 
 class ParameterInitialValueAnalysis {
 private:
-  InitialValueType initial_values_;
+  InitialValueType initialValues_;
   bool invalid_{true};
 
 public:
   ParameterInitialValueAnalysis(mlir::Operation *op);
-  InitialValueType &getNames() { return initial_values_; }
+  InitialValueType &getNames() { return initialValues_; }
   void invalidate() { invalid_ = true; }
   bool isInvalidated(const AnalysisManager::PreservedAnalyses &pa) {
     return invalid_;

--- a/include/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.h
+++ b/include/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.h
@@ -17,7 +17,6 @@
 #define QUIR_CIRCUITS_ANALYSIS_H
 
 #include "Dialect/Pulse/IR/PulseOps.h"
-#include "Dialect/QCS/Utils/ParameterInitialValueAnalysis.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
 
 #include "mlir/IR/BuiltinOps.h"
@@ -53,8 +52,7 @@ public:
   }
 
 private:
-  double getAngleValue(mlir::Value operand,
-                       mlir::qcs::ParameterInitialValueAnalysis *nameAnalysis);
+  double getAngleValue(mlir::Value operand);
   llvm::StringRef getParameterName(mlir::Value operand);
   quir::DurationAttr getDuration(mlir::Value operand);
 };
@@ -75,7 +73,6 @@ struct QUIRCircuitAnalysisPass
 
 llvm::Expected<double>
 angleValToDouble(mlir::Value inVal,
-                 mlir::qcs::ParameterInitialValueAnalysis *nameAnalysis,
                  mlir::quir::QUIRCircuitAnalysis *circuitAnalysis = nullptr);
 
 } // namespace mlir::quir

--- a/include/Frontend/OpenQASM3/QUIRGenQASM3Visitor.h
+++ b/include/Frontend/OpenQASM3/QUIRGenQASM3Visitor.h
@@ -319,6 +319,8 @@ private:
   ExpressionValueType getValueFromLiteral(const QASM::ASTMPDecimalNode *);
 
   mlir::Type getQUIRTypeFromDeclaration(const QASM::ASTDeclarationNode *);
+
+  bool enableParametersWarningEmitted = false;
 };
 
 } // namespace qssc::frontend::openqasm3

--- a/lib/Dialect/QCS/IR/QCSOps.cpp
+++ b/lib/Dialect/QCS/IR/QCSOps.cpp
@@ -21,18 +21,11 @@
 #include "Dialect/QCS/IR/QCSOps.h"
 
 #include "Dialect/QCS/IR/QCSTypes.h"
-#include "Dialect/QUIR/IR/QUIRAttributes.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/SymbolTable.h"
 #include <mlir/IR/OpImplementation.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/Support/LogicalResult.h>
-
-#include "llvm/ADT/StringMap.h"
-
-#include <cassert>
 
 using namespace mlir;
 using namespace mlir::qcs;
@@ -41,136 +34,20 @@ using namespace mlir::qcs;
 // NOLINTNEXTLINE(misc-include-cleaner): Required for MLIR registrations
 #include "Dialect/QCS/IR/QCSOps.cpp.inc"
 
-namespace {
-LogicalResult
-verifyQCSParameterOpSymbolUses(SymbolTableCollection &symbolTable,
-                               mlir::Operation *op,
-                               bool operandMustMatchSymbolType = false) {
-  assert(op);
-
-  // Check that op has attribute variable_name
-  auto paramRefAttr = op->getAttrOfType<FlatSymbolRefAttr>("parameter_name");
-  if (!paramRefAttr)
-    return op->emitOpError(
-        "requires a symbol reference attribute 'parameter_name'");
-
-  // Check that symbol reference resolves to a parameter declaration
-  auto declOp =
-      symbolTable.lookupNearestSymbolFrom<DeclareParameterOp>(op, paramRefAttr);
-
-  // check higher level modules
-  if (!declOp) {
-    auto targetModuleOp = op->getParentOfType<mlir::ModuleOp>();
-    if (targetModuleOp) {
-      auto topLevelModuleOp = targetModuleOp->getParentOfType<mlir::ModuleOp>();
-      if (!declOp && topLevelModuleOp)
-        declOp = symbolTable.lookupNearestSymbolFrom<DeclareParameterOp>(
-            topLevelModuleOp, paramRefAttr);
-    }
-  }
-
-  if (!declOp)
-    return op->emitOpError() << "no valid reference to a parameter '"
-                             << paramRefAttr.getValue() << "'";
-
-  assert(op->getNumResults() <= 1 && "assume none or single result");
-
-  // Check that type of variables matches result type of this Op
-  if (op->getNumResults() == 1) {
-    if (op->getResult(0).getType() != declOp.getType())
-      return op->emitOpError(
-          "type mismatch between variable declaration and variable use");
-  }
-
-  if (op->getNumOperands() > 0 && operandMustMatchSymbolType) {
-    assert(op->getNumOperands() == 1 &&
-           "type check only supported for a single operand");
-    if (op->getOperand(0).getType() != declOp.getType())
-      return op->emitOpError(
-          "type mismatch between variable declaration and variable assignment");
-  }
-  return success();
-}
-
-} // anonymous namespace
-
 //===----------------------------------------------------------------------===//
 // ParameterLoadOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult
-ParameterLoadOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyQCSParameterOpSymbolUses(symbolTable, getOperation(), true);
-}
-
 // Returns the float value from the initial value of this parameter
 ParameterType ParameterLoadOp::getInitialValue() {
   auto *op = getOperation();
-  auto paramRefAttr =
-      op->getAttrOfType<mlir::FlatSymbolRefAttr>("parameter_name");
-  auto declOp =
-      mlir::SymbolTable::lookupNearestSymbolFrom<mlir::qcs::DeclareParameterOp>(
-          op, paramRefAttr);
-
-  // check higher level modules
-
-  auto currentScopeOp = op->getParentOfType<mlir::ModuleOp>();
-  do {
-    declOp = mlir::SymbolTable::lookupNearestSymbolFrom<
-        mlir::qcs::DeclareParameterOp>(currentScopeOp, paramRefAttr);
-    if (declOp)
-      break;
-    currentScopeOp = currentScopeOp->getParentOfType<mlir::ModuleOp>();
-    assert(currentScopeOp);
-  } while (!declOp);
-
-  assert(declOp);
-
-  double retVal;
-
-  auto iniValue = declOp.getInitialValue();
-  if (iniValue.has_value()) {
-    auto angleAttr = iniValue.value().dyn_cast<mlir::quir::AngleAttr>();
-
-    auto floatAttr = iniValue.value().dyn_cast<FloatAttr>();
-
-    if (!(angleAttr || floatAttr)) {
-      op->emitError(
-          "Parameters are currently limited to angles or float[64] only.");
-      return 0.0;
-    }
-
-    if (angleAttr)
-      retVal = angleAttr.getValue().convertToDouble();
-
-    if (floatAttr)
-      retVal = floatAttr.getValue().convertToDouble();
-
-    return retVal;
+  double retVal = 0.0;
+  if (op->hasAttr("initialValue")) {
+    auto initAttr = op->getAttr("initialValue").dyn_cast<FloatAttr>();
+    if (initAttr)
+      retVal = initAttr.getValue().convertToDouble();
   }
-
-  op->emitError("Does not have initial value set.");
-  return 0.0;
-}
-
-// Returns the float value from the initial value of this parameter
-// this version uses a precomputed map of parameter_name to the initial_value
-// in order to avoid slow SymbolTable lookups
-ParameterType ParameterLoadOp::getInitialValue(
-    llvm::StringMap<ParameterType> &declareParametersMap) {
-  auto *op = getOperation();
-  auto paramRefAttr =
-      op->getAttrOfType<mlir::FlatSymbolRefAttr>("parameter_name");
-
-  auto paramOpEntry = declareParametersMap.find(paramRefAttr.getValue());
-
-  if (paramOpEntry == declareParametersMap.end()) {
-    op->emitError("Could not find declare parameter op " +
-                  paramRefAttr.getValue().str());
-    return 0.0;
-  }
-
-  return paramOpEntry->second;
+  return retVal;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/QUIR/Transforms/LoadElimination.cpp
+++ b/lib/Dialect/QUIR/Transforms/LoadElimination.cpp
@@ -21,7 +21,6 @@
 #include "Dialect/QUIR/Transforms/LoadElimination.h"
 
 #include "Dialect/OQ3/IR/OQ3Ops.h"
-#include "Dialect/QUIR/IR/QUIRAttributes.h"
 
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/SymbolTable.h"
@@ -80,17 +79,6 @@ void LoadEliminationPass::runOnOperation() {
       return WalkResult::advance();
 
     auto varAssignmentOp = mlir::cast<mlir::oq3::VariableAssignOp>(assignment);
-
-    // Transfer marker for input parameters
-    // Note: for arith.constant operations, canonicalization will drop these
-    // attributes and we need to find another way (to be specific:
-    // canonicalization will move constants to the begin of ops like Functions
-    // by means of dialect->materializeConstant(...) that creates new
-    // constants). For now and for angle constants, this approach is good-enough
-    // while not satisfying.
-    if (decl.isInputVariable())
-      varAssignmentOp.getAssignedValue().getDefiningOp()->setAttr(
-          mlir::quir::getInputParameterAttrName(), decl.getNameAttr());
 
     for (auto *userOp : symbolUses) {
 

--- a/lib/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.cpp
+++ b/lib/Dialect/QUIR/Transforms/QUIRCircuitAnalysis.cpp
@@ -17,7 +17,6 @@
 
 #include "Dialect/OQ3/IR/OQ3Ops.h"
 #include "Dialect/QCS/IR/QCSOps.h"
-#include "Dialect/QCS/Utils/ParameterInitialValueAnalysis.h"
 #include "Dialect/QUIR/IR/QUIRAttributes.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
 #include "Dialect/QUIR/IR/QUIRTypes.h"
@@ -44,17 +43,12 @@ using namespace mlir;
 
 namespace mlir::quir {
 
-double
-parameterValToDouble(mlir::qcs::ParameterLoadOp defOp,
-                     mlir::qcs::ParameterInitialValueAnalysis *nameAnalysis) {
-  assert(nameAnalysis &&
-         "A valid ParameterInitialValueAnalysis pointer is required");
-  return std::get<double>(defOp.getInitialValue(nameAnalysis->getNames()));
+double parameterValToDouble(mlir::qcs::ParameterLoadOp defOp) {
+  return std::get<double>(defOp.getInitialValue());
 }
 
 llvm::Expected<double>
 angleValToDouble(mlir::Value inVal,
-                 mlir::qcs::ParameterInitialValueAnalysis *nameAnalysis,
                  mlir::quir::QUIRCircuitAnalysis *circuitAnalysis) {
 
   llvm::StringRef errorStr;
@@ -63,7 +57,7 @@ angleValToDouble(mlir::Value inVal,
     return defOp.getAngleValueFromConstant().convertToDouble();
 
   if (auto defOp = inVal.getDefiningOp<mlir::qcs::ParameterLoadOp>())
-    return parameterValToDouble(defOp, nameAnalysis);
+    return parameterValToDouble(defOp);
 
   if (auto blockArg = inVal.dyn_cast<mlir::BlockArgument>()) {
     auto circuitOp = mlir::dyn_cast<mlir::quir::CircuitOp>(
@@ -85,7 +79,7 @@ angleValToDouble(mlir::Value inVal,
   if (auto castOp = inVal.getDefiningOp<mlir::oq3::CastOp>()) {
     auto defOp = castOp.getArg().getDefiningOp<mlir::qcs::ParameterLoadOp>();
     if (defOp)
-      return parameterValToDouble(defOp, nameAnalysis);
+      return parameterValToDouble(defOp);
     if (auto constOp =
             castOp.getArg().getDefiningOp<mlir::arith::ConstantOp>()) {
       if (auto angleAttr = constOp.getValue().dyn_cast<mlir::quir::AngleAttr>())
@@ -102,11 +96,8 @@ angleValToDouble(mlir::Value inVal,
   return llvm::createStringError(llvm::inconvertibleErrorCode(), errorStr);
 } // angleValToDouble
 
-double QUIRCircuitAnalysis::getAngleValue(
-    mlir::Value operand,
-    mlir::qcs::ParameterInitialValueAnalysis *nameAnalysis) {
-  assert(nameAnalysis && "valid nameAnalysis pointer required");
-  auto valueOrError = angleValToDouble(operand, nameAnalysis);
+double QUIRCircuitAnalysis::getAngleValue(mlir::Value operand) {
+  auto valueOrError = angleValToDouble(operand);
   if (auto err = valueOrError.takeError()) {
     operand.getDefiningOp()->emitOpError() << toString(std::move(err)) + "\n";
     assert(false && "unhandled value in angleValToDouble");
@@ -126,11 +117,8 @@ llvm::StringRef QUIRCircuitAnalysis::getParameterName(mlir::Value operand) {
           dyn_cast<qcs::ParameterLoadOp>(castOp.getArg().getDefiningOp());
   }
 
-  if (parameterLoad &&
-      parameterLoad->hasAttr(mlir::quir::getInputParameterAttrName())) {
-    parameterName = parameterLoad->getAttrOfType<StringAttr>(
-        mlir::quir::getInputParameterAttrName());
-  }
+  if (parameterLoad)
+    parameterName = parameterLoad.getParameterName();
   return parameterName;
 }
 
@@ -148,23 +136,6 @@ QUIRCircuitAnalysis::QUIRCircuitAnalysis(mlir::Operation *moduleOp,
 
   if (not invalid_)
     return;
-
-  bool runGetAnalysis = true;
-
-  mlir::qcs::ParameterInitialValueAnalysis *nameAnalysis;
-  auto topLevelModuleOp = moduleOp->getParentOfType<ModuleOp>();
-  if (topLevelModuleOp) {
-    auto nameAnalysisOptional =
-        am.getCachedParentAnalysis<mlir::qcs::ParameterInitialValueAnalysis>(
-            moduleOp->getParentOfType<ModuleOp>());
-    if (nameAnalysisOptional.has_value()) {
-      nameAnalysis = &nameAnalysisOptional.value().get();
-      runGetAnalysis = false;
-    }
-  }
-
-  if (runGetAnalysis)
-    nameAnalysis = &am.getAnalysis<mlir::qcs::ParameterInitialValueAnalysis>();
 
   std::unordered_map<mlir::Operation *, std::map<llvm::StringRef, Operation *>>
       circuitOps;
@@ -198,7 +169,7 @@ QUIRCircuitAnalysis::QUIRCircuitAnalysis(mlir::Operation *moduleOp,
       // cache angle values and parameter names
       if (auto angType = operand.getType().dyn_cast<quir::AngleType>()) {
 
-        value = getAngleValue(operand, nameAnalysis);
+        value = getAngleValue(operand);
         parameterName = getParameterName(operand);
         circuitOperands[parentModuleOp][circuitOp][ii] = {value, parameterName,
                                                           duration};
@@ -218,7 +189,7 @@ QUIRCircuitAnalysis::QUIRCircuitAnalysis(mlir::Operation *moduleOp,
 
 void QUIRCircuitAnalysisPass::runOnOperation() {
   mlir::Pass::getAnalysis<QUIRCircuitAnalysis>();
-} // ParameterInitialValueAnalysisPass::runOnOperation()
+}
 
 llvm::StringRef QUIRCircuitAnalysisPass::getArgument() const {
   return "quir-circuit-analysis";

--- a/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRGenQASM3Visitor.cpp
@@ -1167,10 +1167,13 @@ void QUIRGenQASM3Visitor::visit(const ASTDeclarationNode *node) {
     if (node->GetModifierType() == QASM::ASTTypeInputModifier) {
       bool genParameter = true;
       if (!enableParameters) {
-        reportError(node, mlir::DiagnosticSeverity::Warning)
-            << "Input parameter " << idNode->GetName()
-            << " warning. Parameters are not enabled. Enable with "
-               "--enable-parameters.";
+        if (!enableParametersWarningEmitted) {
+          reportError(node, mlir::DiagnosticSeverity::Warning)
+              << "Input parameter " << idNode->GetName()
+              << " warning. Parameters are not enabled. Enable with "
+                 "--enable-parameters.";
+          enableParametersWarningEmitted = true;
+        }
         genParameter = false;
       } else if (!(variableType.isa<mlir::quir::AngleType>() ||
                    variableType.isa<mlir::Float64Type>())) {
@@ -1181,10 +1184,8 @@ void QUIRGenQASM3Visitor::visit(const ASTDeclarationNode *node) {
       }
 
       if (genParameter) {
-        varHandler.generateParameterDeclaration(loc, idNode->GetMangledName(),
-                                                variableType, val);
-        auto load = varHandler.generateParameterLoad(
-            loc, idNode->GetMangledName(), val);
+        auto load =
+            varHandler.generateParameterLoad(loc, idNode->GetName(), val);
         varHandler.generateVariableAssignment(loc, idNode->GetName(), load);
         genVariableWithVal = false;
       }

--- a/lib/Frontend/OpenQASM3/QUIRVariableBuilder.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRVariableBuilder.cpp
@@ -23,6 +23,7 @@
 
 #include "Dialect/OQ3/IR/OQ3Ops.h"
 #include "Dialect/QCS/IR/QCSOps.h"
+#include "Dialect/QUIR/IR/QUIRAttributes.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
 #include "Dialect/QUIR/IR/QUIRTypes.h"
 
@@ -126,6 +127,22 @@ QUIRVariableBuilder::generateParameterLoad(mlir::Location location,
     auto op = getClassicalBuilder().create<mlir::qcs::ParameterLoadOp>(
         location, builder.getType<mlir::quir::AngleType>(64),
         variableName.str());
+
+    double initialValue = 0.0;
+
+    auto constFloatAttr = constantOp.getValue().dyn_cast<mlir::FloatAttr>();
+    if (constFloatAttr) {
+      initialValue = constFloatAttr.getValueAsDouble();
+    } else {
+      auto constAngleAttr =
+          constantOp.getValue().dyn_cast<mlir::quir::AngleAttr>();
+      if (constAngleAttr)
+        initialValue = constAngleAttr.getValue().convertToDouble();
+    }
+
+    mlir::FloatAttr const floatAttr =
+        getClassicalBuilder().getF64FloatAttr(initialValue);
+    op->setAttr("initialValue", floatAttr);
     return op;
   }
 
@@ -134,6 +151,13 @@ QUIRVariableBuilder::generateParameterLoad(mlir::Location location,
           assignedValue.getDefiningOp())) {
     auto loadOp = getClassicalBuilder().create<mlir::qcs::ParameterLoadOp>(
         location, constantOp.getType(), variableName.str());
+    double initialValue = 0.0;
+    auto constAttr = constantOp.getValue().dyn_cast<mlir::FloatAttr>();
+    if (constAttr)
+      initialValue = constAttr.getValueAsDouble();
+    mlir::FloatAttr const floatAttr =
+        getClassicalBuilder().getF64FloatAttr(initialValue);
+    loadOp->setAttr("initialValue", floatAttr);
     return loadOp;
   }
 

--- a/test/Dialect/QCS/Utils/parameter-initial-value-analysis.mlir
+++ b/test/Dialect/QCS/Utils/parameter-initial-value-analysis.mlir
@@ -17,12 +17,12 @@
 module {
     // without nested pass manager should only find
     // alpha and beta
-    qcs.declare_parameter @alpha : !quir.angle<64> = #quir.angle<1.000000e+00> : !quir.angle<64>
-    qcs.declare_parameter @beta : f64 = 2.000000e+00 : f64
+    qcs.parameter_load "alpha" : !quir.angle<64> {initialValue = 1.000000e+00 :f64}
+    qcs.parameter_load "beta" : f64 {initialValue = 2.000000e+00 :f64}
     module @first {
         // nested test should find alpha and beta
-        qcs.declare_parameter @theta : !quir.angle<64> = #quir.angle<3.140000e+00> : !quir.angle<64>
-        qcs.declare_parameter @phi : f64 = 1.500000e+00 : f64
+        qcs.parameter_load "theta" : !quir.angle<64> {initialValue = 3.140000e+00 :f64}
+        qcs.parameter_load "phi" : f64 {initialValue = 1.500000e+00 :f64}
     }
     module @second {
         // test module without declare_parameter

--- a/test/Dialect/QUIR/Transforms/load-elimination2.mlir
+++ b/test/Dialect/QUIR/Transforms/load-elimination2.mlir
@@ -27,8 +27,8 @@ module {
 
   func.func @main() -> !quir.angle<64> {
 
-    // CHECK: [[CONST314_ANGLE:%.*]] = quir.constant {quir.inputParameter = "a"} #quir.angle<3.140000e+00> : !quir.angle<64>
-    // REMOVE-UNUSED: [[CONST314_ANGLE:%.*]] = quir.constant {quir.inputParameter = "a"} #quir.angle<3.140000e+00> : !quir.angle<64>
+    // CHECK: [[CONST314_ANGLE:%.*]] = quir.constant #quir.angle<3.140000e+00> : !quir.angle<64>
+    // REMOVE-UNUSED: [[CONST314_ANGLE:%.*]] = quir.constant #quir.angle<3.140000e+00> : !quir.angle<64>
     %angle = quir.constant #quir.angle<3.140000e+00> : !quir.angle<64>
     %angle2 = quir.constant #quir.angle<3.140000e+00> : !quir.angle<64>
 

--- a/test/Frontend/OpenQASM3/input-parameters-if.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters-if.qasm
@@ -26,7 +26,6 @@ gate x q { }
 gate rz(phi) q { }
 
 input angle theta = 3.141;
-// CHECK: qcs.declare_parameter @_QX64_5thetaEE_ : !quir.angle<64> = #quir.angle<3.141000e+00> : !quir.angle<64>
 
 x $2;
 rz(theta) $2;
@@ -50,6 +49,9 @@ is_excited = measure $2;
 // CHECK: scf.for %arg0 = %c0 to %c1000 step %c1 {
 // CHECK: [[QUBIT2:%.*]] = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
 // CHECK: [[QUBIT3:%.*]] = quir.declare_qubit {id = 3 : i32} : !quir.qubit<1>
+
+// CHECK: [[PARAM:%.*]] = qcs.parameter_load "theta" : !quir.angle<64> {initialValue = 3.141000e+00 : f64}
+// CHECK: oq3.variable_assign @theta : !quir.angle<64> = [[PARAM]]
 
 // CHECK: [[EXCITED:%.*]] = oq3.variable_load @is_excited : !quir.cbit<1>
 // CHECK: [[CONST:%[0-9a-z_]+]] = arith.constant 1 : i32

--- a/test/Frontend/OpenQASM3/input-parameters-while.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters-while.qasm
@@ -21,7 +21,6 @@ gate h q {
 gate rz(phi) q { }
 
 input angle theta = 3.141;
-// CHECK: qcs.declare_parameter @_QX64_5thetaEE_ : !quir.angle<64> = #quir.angle<3.141000e+00> : !quir.angle<64>
 
 qubit $0;
 int n = 1;
@@ -59,6 +58,7 @@ bit is_excited;
 
 // CHECK: func.func @main() -> i32 {
 // CHECK: scf.for %arg0 = %c0 to %c1000 step %c1 {
+// CHECK: {{.*}} = qcs.parameter_load "theta" : !quir.angle<64> {initialValue = 3.141000e+00 : f64}
 // CHECK: [[QUBIT:%.*]] = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
 // CHECK: scf.while : () -> () {
 // CHECK:    [[N:%.*]] = oq3.variable_load @n : i32

--- a/test/Frontend/OpenQASM3/input-parameters.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters.qasm
@@ -28,10 +28,8 @@ gate sx q { }
 gate rz(phi) q { }
 
 input angle theta = 3.141;
-// CHECK: qcs.declare_parameter @_QX64_5thetaEE_ : !quir.angle<64> = #quir.angle<3.141000e+00> : !quir.angle<64>
 
 input float[64] theta2 = 1.56;
-// CHECK: qcs.declare_parameter @_QDDd64_6theta2EE_ : f64 = 1.560000e+00 : f64
 
 reset $0;
 
@@ -67,9 +65,9 @@ c = measure $0;
 // CHECK: %0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
 // CHECK: %1 = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
 
-// CHECK: %2 = qcs.parameter_load @_QX64_5thetaEE_ : !quir.angle<64>
+// CHECK: %2 = qcs.parameter_load "theta" : !quir.angle<64> {initialValue = 3.141000e+00 : f64}
 // CHECK: oq3.variable_assign @theta : !quir.angle<64> = %2
-// CHECK: %3 = qcs.parameter_load @_QDDd64_6theta2EE_ : f64
+// CHECK: %3 = qcs.parameter_load "theta2" : f64 {initialValue = 1.560000e+00 : f64}
 // CHECK: oq3.variable_assign @theta2 : f64 = %3
 // CHECK-XX: quir.reset %0 : !quir.qubit<1>
 // CHECK-NOT: oq3.variable_assign @theta : !quir.angle<64> = %angle


### PR DESCRIPTION
Improves performance of compilation when using parameters by dropping the use of the DeclareParameterOp and resulting symbol lookup. The initial value has been moved to an attribute of the ParameterLoadOp. Removes the use of ParameterInitialValueAnalysis.