### PR TITLE
[Backport 3.10]Update parameter/constant op handling for performance (#335)

### DIFF
--- a/conan/qasm/conandata.yml
+++ b/conan/qasm/conandata.yml
@@ -1,5 +1,5 @@
 sources:
-  hash: "f6d695fd9f18462e65f6290d05ccb4ccb371b288"
+  hash: "ec7731bf645240a597cd9ebb2c395b114f155ed2"
 requirements:
   - "gmp/6.3.0"
   - "mpfr/4.1.0"

--- a/conan/qasm/conanfile.py
+++ b/conan/qasm/conanfile.py
@@ -17,7 +17,7 @@ import subprocess
 
 class QasmConan(ConanFile):
     name = "qasm"
-    version = "0.3.2"
+    version = "0.3.3"
     url = "https://github.com/openqasm/qe-qasm.git"
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False], "examples": [True, False]}

--- a/conandata.yml
+++ b/conandata.yml
@@ -7,4 +7,4 @@ requirements:
   - pybind11/2.11.1
   - clang-tools-extra/17.0.5-0@
   - llvm/17.0.5-0@
-  - qasm/0.3.2@qss/stable
+  - qasm/0.3.3@qss/stable

--- a/include/Conversion/QUIRToPulse/QUIRToPulse.h
+++ b/include/Conversion/QUIRToPulse/QUIRToPulse.h
@@ -127,7 +127,7 @@ struct QUIRToPulsePass
                                    mlir::func::FuncOp &mainFunc);
   // map of the hashed location of quir angle/duration ops to their converted
   // pulse ops
-  std::unordered_map<std::string, mlir::Value>
+  std::unordered_map<Operation *, mlir::Value>
       classicalQUIROpLocToConvertedPulseOpMap;
 
   // port name to Port_CreateOp map

--- a/include/Dialect/QUIR/Transforms/ExtractCircuits.h
+++ b/include/Dialect/QUIR/Transforms/ExtractCircuits.h
@@ -25,11 +25,11 @@
 #include "Utils/SymbolCacheAnalysis.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 
-#include "llvm/ADT/SmallVector.h"
-
+#include <set>
 #include <unordered_map>
 
 namespace mlir::quir {
@@ -49,14 +49,14 @@ private:
                     OpBuilder circuitBuilder);
   OpBuilder startCircuit(mlir::Location location, OpBuilder topLevelBuilder);
   void endCircuit(mlir::Operation *firstOp, mlir::Operation *lastOp,
-                  OpBuilder topLevelBuilder, OpBuilder circuitBuilder,
-                  llvm::SmallVector<Operation *> &eraseList);
-  void addToCircuit(mlir::Operation *currentOp, OpBuilder circuitBuilder,
-                    llvm::SmallVector<Operation *> &eraseList);
+                  OpBuilder topLevelBuilder, OpBuilder circuitBuilder);
+  void addToCircuit(mlir::Operation *currentOp, OpBuilder circuitBuilder);
+
   uint64_t circuitCount = 0;
   qssc::utils::SymbolCacheAnalysis *symbolCache{nullptr};
 
   mlir::quir::CircuitOp currentCircuitOp = nullptr;
+  mlir::IRMapping currentCircuitMapper;
   mlir::quir::CallCircuitOp newCallCircuitOp;
 
   llvm::SmallVector<Type> inputTypes;
@@ -68,6 +68,8 @@ private:
 
   std::unordered_map<Operation *, uint32_t> circuitOperands;
   llvm::SmallVector<OpResult> originalResults;
+  std::set<Operation *> eraseConstSet;
+  std::set<Operation *> eraseOpSet;
 
 }; // struct ExtractCircuitsPass
 } // namespace mlir::quir

--- a/include/Frontend/OpenQASM3/QUIRGenQASM3Visitor.h
+++ b/include/Frontend/OpenQASM3/QUIRGenQASM3Visitor.h
@@ -321,6 +321,9 @@ private:
   mlir::Type getQUIRTypeFromDeclaration(const QASM::ASTDeclarationNode *);
 
   bool enableParametersWarningEmitted = false;
+
+  /// Cached dummy value for error handling
+  mlir::Value voidValue;
 };
 
 } // namespace qssc::frontend::openqasm3

--- a/include/Frontend/OpenQASM3/QUIRVariableBuilder.h
+++ b/include/Frontend/OpenQASM3/QUIRVariableBuilder.h
@@ -68,7 +68,7 @@ public:
 
   mlir::Value generateParameterLoad(mlir::Location location,
                                     llvm::StringRef variableName,
-                                    mlir::Value assignedValue);
+                                    double initialValue);
 
   /// Generate code for declaring an array (at the builder's current insertion
   /// point).

--- a/lib/Conversion/QUIRToPulse/LoadPulseCals.cpp
+++ b/lib/Conversion/QUIRToPulse/LoadPulseCals.cpp
@@ -152,7 +152,7 @@ void LoadPulseCalsPass::loadPulseCals(CallCircuitOp callCircuitOp,
       LLVM_DEBUG(llvm::dbgs() << "no pulse cal loading needed for " << op);
       assert((!op->hasTrait<mlir::quir::UnitaryOp>() and
               !op->hasTrait<mlir::quir::CPTPOp>()) &&
-             "unkown operation");
+             "unknown operation");
     }
   });
 }

--- a/lib/Dialect/Pulse/IR/PulseOps.cpp
+++ b/lib/Dialect/Pulse/IR/PulseOps.cpp
@@ -17,6 +17,7 @@
 #include "Dialect/Pulse/IR/PulseOps.h"
 
 #include "Dialect/Pulse/IR/PulseTraits.h"
+#include "Dialect/QCS/IR/QCSOps.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -356,8 +357,9 @@ LogicalResult verifyClassical_(SequenceOp op) {
   mlir::Operation *classicalOp = nullptr;
   WalkResult const result = op->walk([&](Operation *subOp) {
     if (isa<mlir::arith::ConstantOp>(subOp) || isa<quir::ConstantOp>(subOp) ||
-        isa<CallSequenceOp>(subOp) || isa<pulse::ReturnOp>(subOp) ||
-        isa<SequenceOp>(subOp) || isa<mlir::complex::CreateOp>(subOp) ||
+        isa<qcs::ParameterLoadOp>(subOp) || isa<CallSequenceOp>(subOp) ||
+        isa<pulse::ReturnOp>(subOp) || isa<SequenceOp>(subOp) ||
+        isa<mlir::complex::CreateOp>(subOp) ||
         subOp->hasTrait<mlir::pulse::SequenceAllowed>() ||
         subOp->hasTrait<mlir::pulse::SequenceRequired>())
       return WalkResult::advance();

--- a/lib/Dialect/Pulse/Transforms/Scheduling.cpp
+++ b/lib/Dialect/Pulse/Transforms/Scheduling.cpp
@@ -112,6 +112,7 @@ void QuantumCircuitPulseSchedulingPass::scheduleAlap(
             opEnd = quantumCircuitSequenceOpBlock->rend();
        opIt != opEnd; ++opIt) {
     auto &op = *opIt;
+
     if (auto quantumGateCallSequenceOp =
             dyn_cast<mlir::pulse::CallSequenceOp>(op)) {
       // find quantum gate SequenceOp

--- a/lib/Dialect/QUIR/IR/QUIROps.cpp
+++ b/lib/Dialect/QUIR/IR/QUIROps.cpp
@@ -380,8 +380,9 @@ LogicalResult verifyClassical_(CircuitOp op) {
   mlir::Operation *classicalOp = nullptr;
   WalkResult const result = op->walk([&](Operation *subOp) {
     if (isa<mlir::arith::ConstantOp>(subOp) || isa<quir::ConstantOp>(subOp) ||
-        isa<CallCircuitOp>(subOp) || isa<quir::ReturnOp>(subOp) ||
-        isa<CircuitOp>(subOp) || subOp->hasTrait<mlir::quir::UnitaryOp>() ||
+        isa<qcs::ParameterLoadOp>(subOp) || isa<CallCircuitOp>(subOp) ||
+        isa<quir::ReturnOp>(subOp) || isa<CircuitOp>(subOp) ||
+        subOp->hasTrait<mlir::quir::UnitaryOp>() ||
         subOp->hasTrait<mlir::quir::CPTPOp>())
       return WalkResult::advance();
     classicalOp = subOp;

--- a/lib/Dialect/QUIR/Transforms/ReorderMeasurements.cpp
+++ b/lib/Dialect/QUIR/Transforms/ReorderMeasurements.cpp
@@ -21,6 +21,7 @@
 #include "Dialect/QUIR/Transforms/ReorderMeasurements.h"
 
 #include "Dialect/OQ3/IR/OQ3Ops.h"
+#include "Dialect/QCS/IR/QCSOps.h"
 #include "Dialect/QUIR/IR/QUIRInterfaces.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
 #include "Dialect/QUIR/IR/QUIRTraits.h"
@@ -85,11 +86,14 @@ bool mayMoveVariableLoadOp(MeasureOp measureOp,
 bool mayMoveCastOp(MeasureOp measureOp, oq3::CastOp castOp,
                    MoveListVec &moveList) {
   bool moveCastOp = false;
-  auto variableLoadOp =
-      dyn_cast<oq3::VariableLoadOp>(castOp.getArg().getDefiningOp());
-  if (variableLoadOp)
+
+  auto *definingOp = castOp.getArg().getDefiningOp();
+  if (auto variableLoadOp = dyn_cast<oq3::VariableLoadOp>(definingOp))
     moveCastOp = mayMoveVariableLoadOp(measureOp, variableLoadOp, moveList);
-  auto castMeasureOp = dyn_cast<MeasureOp>(castOp.getArg().getDefiningOp());
+  else if (isa<qcs::ParameterLoadOp>(definingOp))
+    moveCastOp = true;
+
+  auto castMeasureOp = dyn_cast<MeasureOp>(definingOp);
   if (castMeasureOp)
     moveCastOp = ((castMeasureOp != measureOp) &&
                   (castMeasureOp->isBeforeInBlock(measureOp) ||
@@ -168,6 +172,13 @@ struct ReorderMeasureAndNonMeasurePat : public OpRewritePattern<MeasureOp> {
             if (variableLoadOp) {
               moveOps =
                   mayMoveVariableLoadOp(measureOp, variableLoadOp, moveList);
+            }
+
+            // if the defining op is a parameter load op we are are safe
+            // to move
+            if (auto parameterLoadOp = dyn_cast<qcs::ParameterLoadOp>(defOp)) {
+              moveOps = true;
+              moveList.push_back(parameterLoadOp);
             }
 
             auto castOp = dyn_cast<oq3::CastOp>(defOp);

--- a/lib/Dialect/QUIR/Transforms/UnusedVariable.cpp
+++ b/lib/Dialect/QUIR/Transforms/UnusedVariable.cpp
@@ -23,74 +23,45 @@
 
 #include "Dialect/OQ3/IR/OQ3Ops.h"
 
-#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/Visitors.h"
 #include "mlir/Support/LLVM.h"
-#include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include "llvm/ADT/StringRef.h"
-
-#include <utility>
 
 using namespace mlir;
 using namespace quir;
 using namespace oq3;
 
-namespace {
-/// This pattern matches on variable declarations that are not marked 'output'
-/// and are not followed by a use of the same variable, and removes them
-struct UnusedVariablePat : public OpRewritePattern<DeclareVariableOp> {
-  UnusedVariablePat(MLIRContext *context, mlir::SymbolUserMap &symbolUses)
-      : OpRewritePattern<DeclareVariableOp>(context, /*benefit=*/1),
-        symbolUses(symbolUses) {}
-  mlir::SymbolUserMap &symbolUses;
-  LogicalResult
-  matchAndRewrite(DeclareVariableOp declOp,
-                  mlir::PatternRewriter &rewriter) const override {
+///
+/// \brief Entry point for the pass.
+void UnusedVariablePass::runOnOperation() {
+  mlir::SymbolTableCollection symbolTable;
+  mlir::SymbolUserMap symbolUsers(symbolTable, getOperation());
+
+  getOperation()->walk([&](DeclareVariableOp declOp) {
     if (declOp.isOutputVariable())
-      return failure();
+      return mlir::WalkResult::advance();
 
     // iterate through uses
-    for (auto *useOp : symbolUses.getUsers(declOp)) {
+    for (auto *useOp : symbolUsers.getUsers(declOp)) {
       if (auto useVariable = dyn_cast<VariableLoadOp>(useOp)) {
         if (!useVariable || !useVariable.use_empty())
-          return failure();
+          return mlir::WalkResult::advance();
       }
     }
 
     // No uses found, so now we can erase all references (just stores) and the
     // declaration
-    for (auto *useOp : symbolUses.getUsers(declOp))
-      rewriter.eraseOp(useOp);
+    for (auto *useOp : symbolUsers.getUsers(declOp))
+      useOp->erase();
+    ;
 
-    rewriter.eraseOp(declOp);
-    return success();
-  } // matchAndRewrite
+    declOp->erase();
 
-}; // struct UnusedVariablePat
-} // anonymous namespace
-
-///
-/// \brief Entry point for the pass.
-void UnusedVariablePass::runOnOperation() {
-  RewritePatternSet patterns(&getContext());
-  mlir::GreedyRewriteConfig config;
-  mlir::SymbolTableCollection symbolTable;
-  mlir::SymbolUserMap symbolUsers(symbolTable, getOperation());
-
-  // use cheaper top-down traversal (in this case, bottom-up would not behave
-  // any differently)
-  config.useTopDownTraversal = true;
-  // Disable to improve performance
-  config.enableRegionSimplification = false;
-
-  patterns.add<UnusedVariablePat>(&getContext(), symbolUsers);
-
-  if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
-                                          config)))
-    signalPassFailure();
+    return mlir::WalkResult::advance();
+  });
 }
 
 llvm::StringRef UnusedVariablePass::getArgument() const {

--- a/lib/Frontend/OpenQASM3/QUIRVariableBuilder.cpp
+++ b/lib/Frontend/OpenQASM3/QUIRVariableBuilder.cpp
@@ -23,7 +23,6 @@
 
 #include "Dialect/OQ3/IR/OQ3Ops.h"
 #include "Dialect/QCS/IR/QCSOps.h"
-#include "Dialect/QUIR/IR/QUIRAttributes.h"
 #include "Dialect/QUIR/IR/QUIROps.h"
 #include "Dialect/QUIR/IR/QUIRTypes.h"
 
@@ -54,6 +53,11 @@ void QUIRVariableBuilder::generateVariableDeclaration(
     mlir::Location location, llvm::StringRef variableName, mlir::Type type,
     bool isInputVariable, bool isOutputVariable) {
 
+  // Input variables are not used as parameter loads replace them
+  // for performance reasons.
+  // TODO: Replace many parameters with array accesses.
+  if (isInputVariable)
+    return;
   // variables are symbols and thus need to be placed directly in a surrounding
   // Op that contains a symbol table.
   mlir::OpBuilder::InsertionGuard const g(builder);
@@ -73,8 +77,6 @@ void QUIRVariableBuilder::generateVariableDeclaration(
 
   lastDeclaration[surroundingModuleOp] = declareOp; // save this to insert after
 
-  if (isInputVariable)
-    declareOp.setInputAttr(builder.getUnitAttr());
   if (isOutputVariable)
     declareOp.setOutputAttr(builder.getUnitAttr());
   variables.emplace(variableName.str(), type);
@@ -120,49 +122,19 @@ void QUIRVariableBuilder::generateParameterDeclaration(
 mlir::Value
 QUIRVariableBuilder::generateParameterLoad(mlir::Location location,
                                            llvm::StringRef variableName,
-                                           mlir::Value assignedValue) {
+                                           double initialValue) {
 
-  if (auto constantOp = mlir::dyn_cast<mlir::quir::ConstantOp>(
-          assignedValue.getDefiningOp())) {
-    auto op = getClassicalBuilder().create<mlir::qcs::ParameterLoadOp>(
-        location, builder.getType<mlir::quir::AngleType>(64),
-        variableName.str());
+  auto op = getClassicalBuilder().create<mlir::qcs::ParameterLoadOp>(
+      location, builder.getType<mlir::quir::AngleType>(64), variableName.str());
 
-    double initialValue = 0.0;
-
-    auto constFloatAttr = constantOp.getValue().dyn_cast<mlir::FloatAttr>();
-    if (constFloatAttr) {
-      initialValue = constFloatAttr.getValueAsDouble();
-    } else {
-      auto constAngleAttr =
-          constantOp.getValue().dyn_cast<mlir::quir::AngleAttr>();
-      if (constAngleAttr)
-        initialValue = constAngleAttr.getValue().convertToDouble();
-    }
-
+  // Only store initial value if it is not zero for performance reasons.
+  if (initialValue != 0.0) {
     mlir::FloatAttr const floatAttr =
         getClassicalBuilder().getF64FloatAttr(initialValue);
     op->setAttr("initialValue", floatAttr);
-    return op;
   }
 
-  // if the source is a arith::ConstantOp cast to angle
-  if (auto constantOp = mlir::dyn_cast<mlir::arith::ConstantOp>(
-          assignedValue.getDefiningOp())) {
-    auto loadOp = getClassicalBuilder().create<mlir::qcs::ParameterLoadOp>(
-        location, constantOp.getType(), variableName.str());
-    double initialValue = 0.0;
-    auto constAttr = constantOp.getValue().dyn_cast<mlir::FloatAttr>();
-    if (constAttr)
-      initialValue = constAttr.getValueAsDouble();
-    mlir::FloatAttr const floatAttr =
-        getClassicalBuilder().getF64FloatAttr(initialValue);
-    loadOp->setAttr("initialValue", floatAttr);
-    return loadOp;
-  }
-
-  llvm_unreachable(
-      "Unsupported defining value operation for parameter variable");
+  return op;
 }
 
 void QUIRVariableBuilder::generateArrayVariableDeclaration(

--- a/releasenotes/notes/update-parameter-handling-cfa04a0bd7250401.yaml
+++ b/releasenotes/notes/update-parameter-handling-cfa04a0bd7250401.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Handling of ``qcs.parameter_load`` operations has been modified to be more direct
+    with reads straight from the angle variables. This brings significant performance enhancements
+    as a large number of MLIR operations have been removed. The consequence is that if an OpenQASM 3
+    input parameter value is written to this value will not be dynamically resolved. This could be
+    fixed in later versions of the compiler by using memref like semantics for parameters.
+fixes:
+  - |
+    Significant performance enhancements for both constant and parameter gate angles.

--- a/test/Dialect/QUIR/Transforms/extract-circuits.mlir
+++ b/test/Dialect/QUIR/Transforms/extract-circuits.mlir
@@ -18,8 +18,8 @@ module {
     return
   }
   // CHECK: quir.circuit @circuit_0
-  // CHECK: quir.delay %arg0, (%arg1)
-  // CHECK: %0:2 = quir.measure(%arg2, %arg3)
+  // CHECK: quir.delay %dur, (%arg0)
+  // CHECK: %0:2 = quir.measure(%arg1, %arg2)
   // CHECK: quir.return %0#0, %0#1 : i1, i1
   // CHECK: quir.circuit @circuit_1
   // CHECK: quir.call_gate @x(%arg0)
@@ -47,7 +47,7 @@ module {
       %4:2 = quir.measure(%0, %2) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
       // CHECK-NOT: quir.delay %dur_0, (%1) : !quir.duration<dt>, (!quir.qubit<1>) -> ()
       // CHECK-NOT: %4:2 = quir.measure(%0, %2) : (!quir.qubit<1>, !quir.qubit<1>) -> (i1, i1)
-      // CHECK: %4:2 = quir.call_circuit @circuit_0(%dur_0, %1, %0, %2)
+      // CHECK: %4:2 = quir.call_circuit @circuit_0(%1, %0, %2)
       qcs.parallel_control_flow {
       // CHECK: qcs.parallel_control_flow
       scf.if %4#0 {

--- a/test/Dialect/QUIR/Transforms/reorder-measurements.mlir
+++ b/test/Dialect/QUIR/Transforms/reorder-measurements.mlir
@@ -28,10 +28,13 @@ func.func @three(%c : memref<1xi1>, %ind : index, %angle_0 : !quir.angle<64>) {
   quir.call_gate @rz(%q1, %angle_0) : (!quir.qubit<1>, !quir.angle<64>) -> ()
   %res1 = quir.measure(%q1) : (!quir.qubit<1>) -> (i1)
   memref.store %res1, %c[%ind] : memref<1xi1>
-  quir.call_gate @rz(%q2, %angle_0) : (!quir.qubit<1>, !quir.angle<64>) -> ()
+  %angle_1 = "qcs.parameter_load"() {parameter_name = "test"} : () -> !quir.angle<64>
+  quir.call_gate @rz(%q2, %angle_1) : (!quir.qubit<1>, !quir.angle<64>) -> ()
   quir.call_gate @sx(%q2) : (!quir.qubit<1>) -> ()
-  quir.call_gate @rz(%q2, %angle_0) : (!quir.qubit<1>, !quir.angle<64>) -> ()
+  %angle_2 = quir.constant #quir.angle<3.0> : !quir.angle<64>
+  quir.call_gate @rz(%q2, %angle_2) : (!quir.qubit<1>, !quir.angle<64>) -> ()
   %res2 = quir.measure(%q2) : (!quir.qubit<1>) -> (i1)
+// CHECK: {{.*}} = quir.constant #quir.angle<3.000000e+00> : !quir.angle<64>
 // CHECK: [[Q00:%.*]] = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
 // CHECK: [[Q01:%.*]] = quir.declare_qubit {id = 1 : i32} : !quir.qubit<1>
 // CHECK: [[Q02:%.*]] = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
@@ -41,7 +44,8 @@ func.func @three(%c : memref<1xi1>, %ind : index, %angle_0 : !quir.angle<64>) {
 // CHECK-NEXT:     quir.call_gate @rz([[Q01]], {{%.*}}) : (!quir.qubit<1>, !quir.angle<64>) -> ()
 // CHECK-NEXT:     quir.call_gate @sx([[Q01]]) : (!quir.qubit<1>) -> ()
 // CHECK-NEXT:     quir.call_gate @rz([[Q01]], {{%.*}}) : (!quir.qubit<1>, !quir.angle<64>) -> ()
-// CHECK-NEXT:     quir.call_gate @rz([[Q02]], {{%.*}}) : (!quir.qubit<1>, !quir.angle<64>) -> ()
+// CHECK-NEXT:     [[ANGLE:%.*]] = qcs.parameter_load "test" : !quir.angle<64>
+// CHECK-NEXT:     quir.call_gate @rz([[Q02]], [[ANGLE]]) : (!quir.qubit<1>, !quir.angle<64>) -> ()
 // CHECK-NEXT:     quir.call_gate @sx([[Q02]]) : (!quir.qubit<1>) -> ()
 // CHECK-NEXT:     quir.call_gate @rz([[Q02]], {{%.*}}) : (!quir.qubit<1>, !quir.angle<64>) -> ()
 // CHECK-NEXT:     [[RES00:%.*]] = quir.measure([[Q00]]) : (!quir.qubit<1>) -> i1

--- a/test/Frontend/OpenQASM3/input-output-variables.qasm
+++ b/test/Frontend/OpenQASM3/input-output-variables.qasm
@@ -1,6 +1,5 @@
 OPENQASM 3.0;
 // RUN: qss-compiler -X=qasm --emit=ast-pretty %s | FileCheck %s --match-full-lines --check-prefix AST-PRETTY
-// RUN: qss-compiler -X=qasm --emit=mlir %s --enable-parameters=false | FileCheck %s --match-full-lines --check-prefix MLIR
 // RUN: (! qss-compiler -X=qasm --emit=mlir --enable-parameters --enable-circuits-from-qasm %s 2>&1 ) | FileCheck %s --check-prefix CIRCUITS
 
 //
@@ -28,12 +27,10 @@ input int basis;
 // CIRCUITS: error: Input parameter basis type error. Input parameters must be angle or float[64].
 
 // AST-PRETTY: DeclarationNode(type=ASTTypeBitset, CBitNode(name=flags, bits=32), inputVariable)
-// MLIR-DAG: oq3.declare_variable {input} @flags : !quir.cbit<32>
 input bit[32] flags;
 // CIRCUITS: error: Input parameter flags type error. Input parameters must be angle or float[64].
 
 // AST-PRETTY: DeclarationNode(type=ASTTypeBitset, CBitNode(name=result, bits=1), outputVariable)
-// MLIR-DAG: oq3.declare_variable {output} @result : !quir.cbit<1>
 output bit result;
 
 // TODO

--- a/test/Frontend/OpenQASM3/input-parameters-if.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters-if.qasm
@@ -25,7 +25,7 @@ bit result;
 gate x q { }
 gate rz(phi) q { }
 
-input angle theta = 3.141;
+input angle theta;
 
 x $2;
 rz(theta) $2;
@@ -50,8 +50,7 @@ is_excited = measure $2;
 // CHECK: [[QUBIT2:%.*]] = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
 // CHECK: [[QUBIT3:%.*]] = quir.declare_qubit {id = 3 : i32} : !quir.qubit<1>
 
-// CHECK: [[PARAM:%.*]] = qcs.parameter_load "theta" : !quir.angle<64> {initialValue = 3.141000e+00 : f64}
-// CHECK: oq3.variable_assign @theta : !quir.angle<64> = [[PARAM]]
+// CHECK: [[PARAM:%.*]] = qcs.parameter_load "theta" : !quir.angle<64>
 
 // CHECK: [[EXCITED:%.*]] = oq3.variable_load @is_excited : !quir.cbit<1>
 // CHECK: [[CONST:%[0-9a-z_]+]] = arith.constant 1 : i32
@@ -68,7 +67,7 @@ if (is_excited == 1) {
 // CHECK: [[COND1:%.*]] = arith.cmpi eq, [[OTHERCAST]], [[CONST]] : i32
 // CHECK: scf.if [[COND1]] {
   if (other == 1){
-// CHECK: [[THETA:%.*]] = oq3.variable_load @theta : !quir.angle<64>
+// CHECK: [[THETA:%.*]] = qcs.parameter_load "theta" : !quir.angle<64>
 // CHECK: quir.call_circuit @circuit_2([[QUBIT2]], [[THETA]]) : (!quir.qubit<1>, !quir.angle<64>) -> ()
      x $2;
      rz(theta) $2;

--- a/test/Frontend/OpenQASM3/input-parameters-while.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters-while.qasm
@@ -58,7 +58,6 @@ bit is_excited;
 
 // CHECK: func.func @main() -> i32 {
 // CHECK: scf.for %arg0 = %c0 to %c1000 step %c1 {
-// CHECK: {{.*}} = qcs.parameter_load "theta" : !quir.angle<64> {initialValue = 3.141000e+00 : f64}
 // CHECK: [[QUBIT:%.*]] = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
 // CHECK: scf.while : () -> () {
 // CHECK:    [[N:%.*]] = oq3.variable_load @n : i32
@@ -76,7 +75,7 @@ while (n != 0) {
 
     // CHECK: scf.if [[COND2]] {
     if (is_excited) {
-        // CHECK:  [[THETA:%.*]] = oq3.variable_load @theta : !quir.angle<64>
+        // CHECK: [[THETA:%.*]] = qcs.parameter_load "theta" : !quir.angle<64> {initialValue = 3.141000e+00 : f64}
         // CHECK:  quir.call_circuit @circuit_2([[QUBIT]], [[THETA]]) : (!quir.qubit<1>, !quir.angle<64>) -> ()
         // CHECK: }
         h $0;

--- a/test/Frontend/OpenQASM3/input-parameters.qasm
+++ b/test/Frontend/OpenQASM3/input-parameters.qasm
@@ -1,5 +1,5 @@
 OPENQASM 3;
-// RUN: qss-compiler -X=qasm --emit=mlir --enable-parameters --enable-circuits-from-qasm %s | FileCheck %s --check-prefixes=CHECK,CHECK-XX
+// RUN: qss-compiler -X=qasm --emit=mlir --enable-parameters --enable-circuits-from-qasm %s | FileCheck %s --check-prefixes=CHECK
 
 //
 // This code is part of Qiskit.
@@ -66,16 +66,10 @@ c = measure $0;
 // CHECK: %1 = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
 
 // CHECK: %2 = qcs.parameter_load "theta" : !quir.angle<64> {initialValue = 3.141000e+00 : f64}
-// CHECK: oq3.variable_assign @theta : !quir.angle<64> = %2
-// CHECK: %3 = qcs.parameter_load "theta2" : f64 {initialValue = 1.560000e+00 : f64}
-// CHECK: oq3.variable_assign @theta2 : f64 = %3
-// CHECK-XX: quir.reset %0 : !quir.qubit<1>
-// CHECK-NOT: oq3.variable_assign @theta : !quir.angle<64> = %angle
 
-// CHECK: quir.call_circuit @circuit_0(%0, %4) : (!quir.qubit<1>, !quir.angle<64>) -> ()
-// CHECK: %6 = quir.call_circuit @circuit_1(%0) : (!quir.qubit<1>) -> i1
-// CHECK: oq3.cbit_assign_bit @b<1> [0] : i1 = %6
+// CHECK: quir.call_circuit @circuit_0(%0, %2) : (!quir.qubit<1>, !quir.angle<64>) -> ()
+// CHECK: %4 = quir.call_circuit @circuit_1(%0) : (!quir.qubit<1>) -> i1
+// CHECK: oq3.cbit_assign_bit @b<1> [0] : i1 = %4
 
-// CHECK: %7 = oq3.variable_load @theta2 : f64
-// CHECK: %8 = "oq3.cast"(%7) : (f64) -> !quir.angle<64>
-// CHECK: quir.call_circuit @circuit_2(%0, %8) : (!quir.qubit<1>, !quir.angle<64>) -> ()
+// CHECK: %5 = qcs.parameter_load "theta2" : !quir.angle<64> {initialValue = 1.560000e+00 : f64}
+// CHECK: quir.call_circuit @circuit_2(%0, %5) : (!quir.qubit<1>, !quir.angle<64>) -> ()

--- a/test/unittest/quir-dialect.cpp
+++ b/test/unittest/quir-dialect.cpp
@@ -36,13 +36,13 @@ namespace {
 class QUIRDialect : public ::testing::Test {
 protected:
   mlir::MLIRContext ctx;
-  mlir::UnknownLoc unkownLoc;
+  mlir::UnknownLoc unknownLoc;
   mlir::ModuleOp rootModule;
   mlir::OpBuilder builder;
 
   QUIRDialect()
-      : unkownLoc(mlir::UnknownLoc::get(&ctx)),
-        rootModule(mlir::ModuleOp::create(unkownLoc)), builder(rootModule) {
+      : unknownLoc(mlir::UnknownLoc::get(&ctx)),
+        rootModule(mlir::ModuleOp::create(unknownLoc)), builder(rootModule) {
     mlir::DialectRegistry registry;
     registry.insert<mlir::quir::QUIRDialect>();
     ctx.appendDialectRegistry(registry);
@@ -55,10 +55,10 @@ protected:
 TEST_F(QUIRDialect, CPTPOpTrait) {
 
   auto declareQubitOp = builder.create<mlir::quir::DeclareQubitOp>(
-      unkownLoc, builder.getType<mlir::quir::QubitType>(1),
+      unknownLoc, builder.getType<mlir::quir::QubitType>(1),
       builder.getIntegerAttr(builder.getI32Type(), 0));
   auto reset = builder.create<mlir::quir::ResetQubitOp>(
-      unkownLoc, mlir::ValueRange{declareQubitOp.getResult()});
+      unknownLoc, mlir::ValueRange{declareQubitOp.getResult()});
 
   EXPECT_FALSE(declareQubitOp->hasTrait<mlir::quir::UnitaryOp>());
   EXPECT_FALSE(declareQubitOp->hasTrait<mlir::quir::CPTPOp>());
@@ -73,10 +73,10 @@ TEST_F(QUIRDialect, CPTPOpTrait) {
 TEST_F(QUIRDialect, UnitaryOpTrait) {
 
   auto declareQubitOp = builder.create<mlir::quir::DeclareQubitOp>(
-      unkownLoc, builder.getType<mlir::quir::QubitType>(1),
+      unknownLoc, builder.getType<mlir::quir::QubitType>(1),
       builder.getIntegerAttr(builder.getI32Type(), 0));
   auto barrier = builder.create<mlir::quir::BarrierOp>(
-      unkownLoc, mlir::ValueRange{declareQubitOp.getResult()});
+      unknownLoc, mlir::ValueRange{declareQubitOp.getResult()});
 
   EXPECT_TRUE(barrier->hasTrait<mlir::quir::UnitaryOp>());
   EXPECT_FALSE(barrier->hasTrait<mlir::quir::CPTPOp>());
@@ -88,11 +88,11 @@ TEST_F(QUIRDialect, UnitaryOpTrait) {
 TEST_F(QUIRDialect, MeasureSideEffects) {
 
   auto qubitDecl = builder.create<mlir::quir::DeclareQubitOp>(
-      unkownLoc, builder.getType<mlir::quir::QubitType>(1),
+      unknownLoc, builder.getType<mlir::quir::QubitType>(1),
       builder.getIntegerAttr(builder.getI32Type(), 0));
 
   auto measureOp = builder.create<mlir::quir::MeasureOp>(
-      unkownLoc, builder.getI1Type(), qubitDecl.getRes());
+      unknownLoc, builder.getI1Type(), qubitDecl.getRes());
 
   EXPECT_TRUE(measureOp);
 


### PR DESCRIPTION
This PR updates how parameters are handled. They are now directly read from "parameter_load" ops which removes the need for QUIR variable analysis and casting which significantly improves performance of large parameter programs by reducing the total number of operations in the program. This also cuts down on the total number of arguments to each circuit/sequence by storing the parameter loads/constants directly in the sequence itself

For example before for the program below
```qasm
OPENQASM 3;

qubit $0;
qubit $1;
qubit $2;

gate sx q { }
gate rz(phi) q { }

input float[64] theta = 3.14159265358979;
input angle phi;

sx $0;
rz(theta) $0;

sx $0;

rz(phi) $1;
rz(3.141592) $1;

rz(theta) $2;
rz(phi) $2;


bit b;

b = measure $0;
```

The MLIR generated is now:
```mlir
module {
  func.func @sx(%arg0: !quir.qubit<1>) attributes {quir.classicalOnly = false} {
    return
  }
  func.func @rz(%arg0: !quir.qubit<1>, %arg1: !quir.angle<64>) attributes {quir.classicalOnly = false} {
    return
  }
  quir.circuit @circuit_0(%arg0: !quir.qubit<1> {quir.physicalId = 0 : i32}, %arg1: !quir.qubit<1> {quir.physicalId = 1 : i32}, %arg2: !quir.qubit<1> {quir.physicalId = 2 : i32}) -> i1 attributes {quir.classicalOnly = false, quir.physicalIds = [0 : i32, 1 : i32, 2 : i32]} {
    quir.call_gate @sx(%arg0) : (!quir.qubit<1>) -> ()
    %0 = qcs.parameter_load "theta" : !quir.angle<64> {initialValue = 3.14159265358979 : f64}
    quir.call_gate @rz(%arg0, %0) : (!quir.qubit<1>, !quir.angle<64>) -> ()
    quir.call_gate @sx(%arg0) : (!quir.qubit<1>) -> ()
    %1 = qcs.parameter_load "phi" : !quir.angle<64>
    quir.call_gate @rz(%arg1, %1) : (!quir.qubit<1>, !quir.angle<64>) -> ()
    %angle = quir.constant #quir.angle<3.1415920000000002> : !quir.angle<64>
    quir.call_gate @rz(%arg1, %angle) : (!quir.qubit<1>, !quir.angle<64>) -> ()
    %2 = qcs.parameter_load "theta" : !quir.angle<64> {initialValue = 3.14159265358979 : f64}
    quir.call_gate @rz(%arg2, %2) : (!quir.qubit<1>, !quir.angle<64>) -> ()
    %3 = qcs.parameter_load "phi" : !quir.angle<64>
    quir.call_gate @rz(%arg2, %3) : (!quir.qubit<1>, !quir.angle<64>) -> ()
    %4 = quir.measure(%arg0) {quir.noFastPathComm, quir.noJunoComm, quir.noJunoUse} : (!quir.qubit<1>) -> i1
    quir.return %4 : i1
  }
  func.func @main() -> i32 attributes {quir.classicalOnly = false} {
    %c0_i32 = arith.constant 0 : i32
    %dur = quir.constant #quir.duration<4.500000e+06> : !quir.duration<dt>
    %c1 = arith.constant 1 : index
    %c1000 = arith.constant 1000 : index
    %c0 = arith.constant 0 : index
    qcs.init
    scf.for %arg0 = %c0 to %c1000 step %c1 {
      quir.delay %dur, () : !quir.duration<dt>, () -> ()
      qcs.shot_init {qcs.num_shots = 1000 : i32}
      %0 = quir.declare_qubit {id = 0 : i32} : !quir.qubit<1>
      %1 = quir.declare_qubit {id = 1 : i32} : !quir.qubit<1>
      %2 = quir.declare_qubit {id = 2 : i32} : !quir.qubit<1>
      %3 = quir.call_circuit @circuit_0(%0, %1, %2) : (!quir.qubit<1>, !quir.qubit<1>, !quir.qubit<1>) -> i1
    } {qcs.shot_loop, quir.classicalOnly = false, quir.physicalIds = [0 : i32, 1 : i32, 2 : i32]}
    qcs.finalize
    return %c0_i32 : i32
  }
}
```