### PR TITLE
[Backport 3.10] Reduce memory usage in pulse sequencing  (#336)

### DIFF
--- a/include/Utils/SymbolCacheAnalysis.h
+++ b/include/Utils/SymbolCacheAnalysis.h
@@ -49,11 +49,11 @@ namespace qssc::utils {
 //                .addToCache<SequenceOp>();
 //
 // This analysis is intended to be used with MLIR's getAnalysis
-// framework. It has been designed to reused the chached value
+// framework. It has been designed to reuse the cached value
 // and will not be invalidated automatically with each pass.
 // If a pass manipulates the symbols that are cached with this
 // analysis then it should use the addCallee method to update the
-// map or call invalidate after appying updates.
+// map or call invalidate after applying updates.
 // Note this analysis should always be used by reference or
 // via a pointer to ensure that updates are applied to the maps
 // stored by the MLIR analysis framework.
@@ -95,6 +95,8 @@ public:
 
     op->walk([&](CalleeOp op) {
       symbolOpsMap[op.getSymName()] = op.getOperation();
+      // Don't recurse symbols
+      return mlir::WalkResult::skip();
     });
     cachedTypes.insert(typeName);
     invalid = false;
@@ -193,7 +195,7 @@ public:
 
 private:
   llvm::StringMap<mlir::Operation *> symbolOpsMap;
-  std::unordered_map<mlir::Operation *, mlir::Operation *> callMap;
+  llvm::DenseMap<mlir::Operation *, mlir::Operation *> callMap;
   std::unordered_set<std::string> cachedTypes;
   mlir::Operation *topOp{nullptr};
   bool invalid{true};

--- a/lib/Dialect/QUIR/Utils/Utils.cpp
+++ b/lib/Dialect/QUIR/Utils/Utils.cpp
@@ -97,7 +97,8 @@ auto getMainFunction(Operation *moduleOperation) -> Operation * {
       mainFunc = funcOp.getOperation();
       return WalkResult::interrupt();
     }
-    return WalkResult::advance();
+    // Don't process nested values
+    return WalkResult::skip();
   });
   if (!mainFunc)
     llvm::errs() << "Error: Main function not found!\n";

--- a/releasenotes/notes/symbol-cache-use-densemap-c178e05e59c41bbe.yaml
+++ b/releasenotes/notes/symbol-cache-use-densemap-c178e05e59c41bbe.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Symbol cache now uses llvm::DenseMap for performance reasons.


### PR DESCRIPTION
Builds on #335.